### PR TITLE
docs: 补充服务器用户小红书 Cookie 登录方式说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 
 > **不知道怎么配？不用查文档。** 直接告诉 Agent「帮我配 XXX」，它知道需要什么、会一步一步引导你。
 >
-> 🍪 需要 Cookie 的平台（Twitter、小红书等），建议使用 Chrome 插件 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 一键导出。
+> 🍪 需要 Cookie 的平台（Twitter、小红书等），建议使用 Chrome 插件 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 一键导出。**服务器用户**没有浏览器界面，请在自己的电脑上登录对应网站后导出 Cookie，再发给 Agent 配置。
 >
 > 🔒 Cookie 只存在你本地，不上传不外传。代码完全开源，随时可审查。
 > 💻 本地电脑不需要代理。代理只有部署在服务器上才需要（~$1/月）。

--- a/docs/install.md
+++ b/docs/install.md
@@ -69,7 +69,9 @@ mcporter config add xiaohongshu http://localhost:18060/mcp
 > 如果在服务器上，建议加代理避免 IP 风控：
 > `docker run -d --name xiaohongshu-mcp -p 18060:18060 -e XHS_PROXY=http://user:pass@ip:port xpzouying/xiaohongshu-mcp`
 >
-> 首次使用需要扫码登录，打开 http://localhost:18060 操作。
+> **登录方式：**
+> - **本地电脑（有浏览器）：** 打开 http://localhost:18060 扫码登录即可。
+> - **服务器（无 UI 界面）：** 服务器上通常没有浏览器，无法直接扫码。最方便的方式是在自己的电脑上用浏览器登录小红书，然后用 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 插件导出 Cookie（Header String 格式），发给 Agent 即可完成配置。详见 [Cookie 导出指南](cookie-export.md)。
 
 ### Step 4: Final check
 


### PR DESCRIPTION
## 问题

服务器用户（Linux 无 UI 界面）在配置小红书时，现有文档只提到「首次使用需要扫码登录，打开 http://localhost:18060 操作」。但服务器上通常没有浏览器，用户不知道怎么扫码。

## 改动

**`docs/install.md`**（Agent 读取的指令文件）：
- 小红书登录方式分两种场景说明：
  - 本地电脑 → 扫码登录
  - 服务器（无 UI）→ 在自己电脑浏览器登录小红书 → Cookie-Editor 导出 Cookie → 发给 Agent

**`README.md`**：
- Cookie 提示后补充一句服务器用户指引

改动很小，不影响现有结构。