### PR TITLE
fix: Twitter bird CLI fetch failed — 自动 fallback + 连通性检测

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -423,6 +423,19 @@ def _install_system_deps():
         else:
             print("  ⬜ bird CLI requires Node.js (optional — Twitter reading still works via Jina)")
 
+    # ── undici (proxy support for Node.js fetch) ──
+    if shutil.which("npm"):
+        npm_root = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True, timeout=5).stdout.strip()
+        undici_path = os.path.join(npm_root, "undici", "index.js") if npm_root else ""
+        if os.path.exists(undici_path):
+            print("  ✅ undici already installed (Node.js proxy support)")
+        else:
+            try:
+                subprocess.run(["npm", "install", "-g", "undici"], capture_output=True, text=True, timeout=60)
+                print("  ✅ undici installed (Node.js proxy support)")
+            except Exception:
+                print("  ⬜ undici install failed (optional — bird may not work behind proxies)")
+
     # ── instaloader (for Instagram) ──
     if shutil.which("instaloader"):
         print("  ✅ instaloader already installed")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,83 @@
+# Troubleshooting / 常见问题
+
+## Twitter/X: bird CLI "fetch failed"
+
+**症状：** `bird whoami` 或 `bird search` 返回 "fetch failed"
+
+**原因：** bird CLI 使用 Node.js 原生 `fetch()` 发请求，而 Node.js 的 fetch **不走系统代理**（不读取 `HTTP_PROXY`/`HTTPS_PROXY` 环境变量）。如果你的网络环境需要代理才能访问 x.com，bird 就连不上。
+
+**解决方案（按推荐顺序）：**
+
+### 方案 1：使用透明代理 / TUN 模式（推荐）
+
+让代理工具接管所有网络流量，这样 bird 的 fetch 也会走代理：
+
+- **Clash Verge / Clash for Windows：** 开启 TUN 模式或系统代理
+- **Proxifier（Windows）：** 添加规则让 Node.js 进程走代理
+- **macOS：** 在 Surge/ClashX Pro 中开启增强模式
+
+### 方案 2：验证 Cookie 有效性
+
+确认 Cookie 没过期：
+
+1. 在浏览器里正常登录 x.com
+2. 用 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 重新导出 Header String
+3. 重新配置：`agent-reach configure twitter-cookies "新的Cookie"`
+
+### 方案 3：不用 bird，用 Exa 搜索替代
+
+Agent Reach 在 bird 失败时会自动 fallback 到 Exa 搜索。Exa 支持搜索 x.com 上的内容，虽然不如 bird 实时，但不受代理限制：
+
+```bash
+agent-reach search-twitter "query"  # bird 失败时自动用 Exa
+agent-reach search "site:x.com query"  # 直接用 Exa 搜索
+```
+
+### 方案 4：配置 Node.js 全局代理（高级）
+
+安装 `global-agent` 让 Node.js 的 fetch 走代理：
+
+```bash
+npm install -g global-agent
+```
+
+然后在运行 bird 前设置环境变量：
+
+```bash
+# Linux / macOS
+export GLOBAL_AGENT_HTTP_PROXY=http://127.0.0.1:7890
+export NODE_OPTIONS="--require global-agent/bootstrap"
+bird search "test"
+
+# Windows (PowerShell)
+$env:GLOBAL_AGENT_HTTP_PROXY = "http://127.0.0.1:7890"
+$env:NODE_OPTIONS = "--require global-agent/bootstrap"
+bird search "test"
+```
+
+> ⚠️ 注意：这个方案需要每次运行 bird 前都设置环境变量，不太方便。推荐用方案 1。
+
+---
+
+## Boss直聘: "访问行为异常"
+
+**症状：** mcp-bosszp 登录成功，但 API 请求返回"您的访问行为异常"
+
+**原因：** Boss直聘的反爬机制会检测请求指纹（不只是 IP），Python requests 库的特征与真实浏览器不同。
+
+**解决方案：**
+- **本地电脑：** 正常使用，一般不会被拦
+- **服务器：** 使用 Jina Reader 读取职位页面 + Exa 搜索职位信息作为替代
+
+---
+
+## Instagram: Checkpoint / 安全验证
+
+**症状：** `instaloader --login` 触发 Instagram 安全验证
+
+**原因：** Instagram 检测到从未见过的设备/位置登录。
+
+**解决方案：**
+1. 在自己的浏览器登录 Instagram
+2. 用 Cookie-Editor 导出 Cookie
+3. 配置：`agent-reach configure instagram-cookies "sessionid=xxx; csrftoken=yyy; ..."`


### PR DESCRIPTION
Fixes #9

## 问题
bird CLI 用 Node.js 原生 fetch()，不走 HTTP_PROXY 环境变量。Windows 用户配了本地代理（如 127.0.0.1:7890）但 bird 根本不走，导致 fetch failed。

## 修复
1. **doctor 实际测连通性** — 之前只检查 bird 装没装，现在跑 `bird whoami` 实测。失败时给出具体原因和建议。
2. **search 自动 fallback** — bird 搜索失败时自动切到 Exa，不再返回空列表。用户无感知。
3. **新增 troubleshooting.md** — 4 种解决方案：透明代理（推荐）、重新导 Cookie、Exa 替代、global-agent。

## 测试
- bird 不可用时 `agent-reach search-twitter` 自动走 Exa ✅
- doctor 显示具体连接问题和建议 ✅