### PR TITLE
fix(instagram): 改善错误提示 + 自动提取浏览器 cookies

### DIFF
--- a/agent_reach/channels/instagram.py
+++ b/agent_reach/channels/instagram.py
@@ -3,8 +3,16 @@
 
 Backend: instaloader (9.8K stars, Python CLI + library)
 Swap to: any Instagram access tool
+
+Known limitations (as of 2026-02):
+  Instagram has increasingly aggressive anti-bot measures. Even with valid
+  cookies/sessions, instaloader may return 401 or "Something went wrong".
+  See: https://github.com/instaloader/instaloader/issues/2585
+       https://github.com/instaloader/instaloader/issues/2648
+  When instaloader fails, we fall back to Jina Reader for public content.
 """
 
+import logging
 import re
 import shutil
 import subprocess
@@ -12,6 +20,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 from .base import Channel, ReadResult, SearchResult
 from typing import List
+
+logger = logging.getLogger(__name__)
 
 
 class InstagramChannel(Channel):
@@ -43,9 +53,47 @@ class InstagramChannel(Channel):
 
         # Check if cookies are configured
         cookie_file = Path.home() / ".agent-reach" / "instagram-cookies.txt"
+        session_ok = self._check_session_file(cookie_file)
+
         if cookie_file.exists():
-            return "ok", "已登录，可读取 Instagram 帖子和 Profile"
-        return "ok", "可读取公开帖子和 Profile。登录可访问更多内容:\n  agent-reach configure instagram-cookies \"sessionid=xxx; csrftoken=yyy; ...\""
+            if session_ok:
+                return "ok", (
+                    "已配置 cookies，可读取 Instagram 帖子和 Profile\n"
+                    "  ⚠️ 注意：Instagram 反爬较严，如遇 401/\"Something went wrong\"，\n"
+                    "  请尝试用 instaloader --login USERNAME 方式登录"
+                )
+            else:
+                return "warn", (
+                    "cookies 文件存在但格式可能有问题（缺少 sessionid 或 csrftoken）\n"
+                    '  重新配置: agent-reach configure instagram-cookies "sessionid=xxx; csrftoken=yyy; ..."'
+                )
+        return "ok", (
+            "可读取公开帖子和 Profile。登录可访问更多内容：\n"
+            '  agent-reach configure instagram-cookies "sessionid=xxx; csrftoken=yyy; ..."\n'
+            "  或: agent-reach configure --from-browser chrome（自动提取）"
+        )
+
+    def _check_session_file(self, cookie_file: Path) -> bool:
+        """Validate cookie file has required fields."""
+        if not cookie_file.exists():
+            return False
+        try:
+            cookie_str = cookie_file.read_text().strip()
+            cookies = self._parse_cookies(cookie_str)
+            return "sessionid" in cookies and "csrftoken" in cookies
+        except Exception:
+            return False
+
+    @staticmethod
+    def _parse_cookies(cookie_str: str) -> dict:
+        """Parse cookie header string into dict."""
+        cookies = {}
+        for part in cookie_str.split(";"):
+            part = part.strip()
+            if "=" in part:
+                k, v = part.split("=", 1)
+                cookies[k.strip()] = v.strip()
+        return cookies
 
     async def read(self, url: str, config=None) -> ReadResult:
         # Try instaloader (module or CLI)
@@ -62,7 +110,10 @@ class InstagramChannel(Channel):
         import asyncio
         import concurrent.futures
 
+        instaloader_error = None
+
         def _sync_read():
+            nonlocal instaloader_error
             import instaloader
             L = instaloader.Instaloader(
                 download_pictures=False,
@@ -76,27 +127,29 @@ class InstagramChannel(Channel):
             )
 
             # Try to load session: cookie file > saved session
+            session_loaded = False
             cookie_file = Path.home() / ".agent-reach" / "instagram-cookies.txt"
             if cookie_file.exists():
                 try:
                     cookie_str = cookie_file.read_text().strip()
-                    cookies = {}
-                    for part in cookie_str.split(";"):
-                        part = part.strip()
-                        if "=" in part:
-                            k, v = part.split("=", 1)
-                            cookies[k.strip()] = v.strip()
+                    cookies = self._parse_cookies(cookie_str)
                     if "sessionid" in cookies and "csrftoken" in cookies:
-                        # Extract username from ds_user_id or use generic
+                        # ds_user_id is numeric; instaloader stores username
+                        # for session management but it doesn't affect API calls
                         username = cookies.get("ds_user_id", "user")
                         L.context.load_session(username, cookies)
-                except Exception:
-                    pass
-            elif config and config.get("instagram_username"):
+                        session_loaded = True
+                        logger.debug("Instagram session loaded from cookie file")
+                except Exception as e:
+                    logger.warning("Failed to load Instagram cookies: %s", e)
+
+            if not session_loaded and config and config.get("instagram_username"):
                 try:
                     L.load_session_from_file(config.get("instagram_username"))
-                except Exception:
-                    pass
+                    session_loaded = True
+                    logger.debug("Instagram session loaded from session file")
+                except Exception as e:
+                    logger.warning("Failed to load Instagram session file: %s", e)
 
             path = urlparse(url).path.strip("/")
 
@@ -114,9 +167,35 @@ class InstagramChannel(Channel):
                     timeout=15,
                 )
                 return result
-        except (asyncio.TimeoutError, Exception):
-            # Any error or timeout → Jina fallback
-            return await self._read_jina(url)
+        except asyncio.TimeoutError:
+            logger.warning("Instaloader timed out for %s, falling back to Jina", url)
+            return await self._read_jina(url, hint="instaloader 请求超时")
+        except Exception as e:
+            error_msg = str(e)
+            logger.warning("Instaloader failed for %s: %s", url, error_msg)
+
+            # Provide specific hints based on error type
+            hint = "instaloader 出错"
+            if "401" in error_msg or "Unauthorized" in error_msg:
+                hint = (
+                    "Instagram 返回 401 Unauthorized。这是 Instagram 反爬机制导致的已知问题。\n"
+                    "建议：1) 用 instaloader --login USERNAME 交互式登录\n"
+                    "      2) 或在浏览器中重新获取 cookies"
+                )
+            elif "redirected to login" in error_msg.lower() or "login" in error_msg.lower():
+                hint = (
+                    "被重定向到登录页面。cookies 可能已过期或被 Instagram 标记。\n"
+                    "建议：在浏览器中重新登录 Instagram，然后重新配置 cookies"
+                )
+            elif "something went wrong" in error_msg.lower():
+                hint = (
+                    "Instagram 返回 \"Something went wrong\"。这是 Instagram 的通用反爬响应。\n"
+                    "参考: https://github.com/instaloader/instaloader/issues/2648"
+                )
+            elif "rate" in error_msg.lower() or "wait" in error_msg.lower():
+                hint = "Instagram 速率限制，请稍后再试"
+
+            return await self._read_jina(url, hint=hint)
 
     def _read_post_sync(self, L, url: str, path: str) -> ReadResult:
         """Read a single Instagram post (sync, runs in executor)."""
@@ -128,34 +207,31 @@ class InstagramChannel(Channel):
             raise ValueError("Cannot extract shortcode from URL")
 
         shortcode = match.group(1)
-        try:
-            post = instaloader.Post.from_shortcode(L.context, shortcode)
+        post = instaloader.Post.from_shortcode(L.context, shortcode)
 
-            lines = []
-            if post.caption:
-                lines.append(post.caption)
-            lines.append("")
-            lines.append(f"👤 @{post.owner_username}")
-            lines.append(f"❤️ {post.likes} likes")
-            if post.comments:
-                lines.append(f"💬 {post.comments} comments")
-            lines.append(f"📅 {post.date_utc.strftime('%Y-%m-%d %H:%M')}")
-            if post.location:
-                lines.append(f"📍 {post.location}")
-            if post.hashtags:
-                lines.append(f"#️⃣ {' '.join('#' + h for h in post.hashtags)}")
+        lines = []
+        if post.caption:
+            lines.append(post.caption)
+        lines.append("")
+        lines.append(f"👤 @{post.owner_username}")
+        lines.append(f"❤️ {post.likes} likes")
+        if post.comments:
+            lines.append(f"💬 {post.comments} comments")
+        lines.append(f"📅 {post.date_utc.strftime('%Y-%m-%d %H:%M')}")
+        if post.location:
+            lines.append(f"📍 {post.location}")
+        if post.hashtags:
+            lines.append(f"#️⃣ {' '.join('#' + h for h in post.hashtags)}")
 
-            return ReadResult(
-                title=f"@{post.owner_username}: {(post.caption or '')[:80]}",
-                content="\n".join(lines),
-                url=url,
-                author=f"@{post.owner_username}",
-                date=post.date_utc.strftime("%Y-%m-%d"),
-                platform="instagram",
-                extra={"likes": post.likes, "comments": post.comments},
-            )
-        except Exception:
-            raise  # Let executor timeout handle fallback
+        return ReadResult(
+            title=f"@{post.owner_username}: {(post.caption or '')[:80]}",
+            content="\n".join(lines),
+            url=url,
+            author=f"@{post.owner_username}",
+            date=post.date_utc.strftime("%Y-%m-%d"),
+            platform="instagram",
+            extra={"likes": post.likes, "comments": post.comments},
+        )
 
     def _read_profile_sync(self, L, url: str, path: str) -> ReadResult:
         """Read an Instagram profile (sync, runs in executor)."""
@@ -166,60 +242,68 @@ class InstagramChannel(Channel):
         if not username or username in ("p", "reel", "stories", "explore"):
             raise ValueError("Cannot extract username from URL")
 
+        profile = instaloader.Profile.from_username(L.context, username)
+
+        lines = []
+        lines.append(f"👤 {profile.full_name} (@{profile.username})")
+        if profile.biography:
+            lines.append(f"📝 {profile.biography}")
+        if profile.external_url:
+            lines.append(f"🔗 {profile.external_url}")
+        lines.append("")
+        lines.append(f"📊 {profile.mediacount} posts · "
+                     f"{profile.followers} followers · "
+                     f"{profile.followees} following")
+        if profile.is_verified:
+            lines.append("✅ Verified")
+        if profile.is_business_account and profile.business_category_name:
+            lines.append(f"🏢 {profile.business_category_name}")
+
+        # Get recent posts (up to 5)
+        lines.append("")
+        lines.append("📸 Recent posts:")
+        count = 0
         try:
-            profile = instaloader.Profile.from_username(L.context, username)
-
-            lines = []
-            lines.append(f"👤 {profile.full_name} (@{profile.username})")
-            if profile.biography:
-                lines.append(f"📝 {profile.biography}")
-            if profile.external_url:
-                lines.append(f"🔗 {profile.external_url}")
-            lines.append("")
-            lines.append(f"📊 {profile.mediacount} posts · "
-                         f"{profile.followers} followers · "
-                         f"{profile.followees} following")
-            if profile.is_verified:
-                lines.append("✅ Verified")
-            if profile.is_business_account and profile.business_category_name:
-                lines.append(f"🏢 {profile.business_category_name}")
-
-            # Get recent posts (up to 5)
-            lines.append("")
-            lines.append("📸 Recent posts:")
-            count = 0
             for post in profile.get_posts():
                 if count >= 5:
                     break
                 caption = (post.caption or "")[:100].replace("\n", " ")
                 lines.append(f"  • ❤️{post.likes} | {post.date_utc.strftime('%m-%d')} | {caption}")
                 count += 1
+        except Exception as e:
+            # Posts listing may fail even if profile loads fine
+            logger.debug("Failed to list posts for %s: %s", username, e)
+            if count == 0:
+                lines.append("  （获取帖子列表失败，可能是 Instagram 限制）")
 
-            return ReadResult(
-                title=f"{profile.full_name} (@{profile.username}) - Instagram",
-                content="\n".join(lines),
-                url=url,
-                author=f"@{profile.username}",
-                platform="instagram",
-                extra={
-                    "followers": profile.followers,
-                    "posts": profile.mediacount,
-                },
-            )
-        except Exception:
-            raise  # Let executor timeout handle fallback
+        return ReadResult(
+            title=f"{profile.full_name} (@{profile.username}) - Instagram",
+            content="\n".join(lines),
+            url=url,
+            author=f"@{profile.username}",
+            platform="instagram",
+            extra={
+                "followers": profile.followers,
+                "posts": profile.mediacount,
+            },
+        )
 
-    async def _read_jina(self, url: str) -> ReadResult:
+    async def _read_jina(self, url: str, hint: str = "") -> ReadResult:
         """Fallback: use Jina Reader."""
-        import requests
+        import httpx
         try:
-            resp = requests.get(
-                f"https://r.jina.ai/{url}",
-                headers={"Accept": "text/markdown"},
-                timeout=15,
-            )
-            resp.raise_for_status()
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.get(
+                    f"https://r.jina.ai/{url}",
+                    headers={"Accept": "text/markdown"},
+                )
+                resp.raise_for_status()
             text = resp.text
+
+            # Prepend hint if instaloader failed with a specific reason
+            if hint:
+                text = f"⚠️ {hint}\n（以下为 Jina Reader 抓取的公开内容）\n\n{text}"
+
             return ReadResult(
                 title=text[:100] if text else url,
                 content=text,
@@ -227,15 +311,23 @@ class InstagramChannel(Channel):
                 platform="instagram",
             )
         except Exception:
+            content_parts = [f"⚠️ 无法读取此 Instagram 内容: {url}"]
+            if hint:
+                content_parts.append(f"\n原因: {hint}")
+            content_parts.append(
+                "\n\n提示：\n"
+                "- 确保 URL 正确\n"
+                "- 安装 instaloader: pip install instaloader\n"
+                "- 登录方式 1: instaloader --login YOUR_USERNAME（推荐，交互式登录）\n"
+                '- 登录方式 2: agent-reach configure instagram-cookies "sessionid=xxx; csrftoken=yyy; ..."\n'
+                "- 登录方式 3: agent-reach configure --from-browser chrome（自动从浏览器提取）\n"
+                "\n"
+                "⚠️ 注意：Instagram 反爬机制较严，即使配置了 cookies 也可能无法访问。\n"
+                "这是 instaloader 上游的已知问题: https://github.com/instaloader/instaloader/issues/2585"
+            )
             return ReadResult(
                 title="Instagram",
-                content=(
-                    f"⚠️ 无法读取此 Instagram 内容: {url}\n\n"
-                    "提示：\n"
-                    "- 确保 URL 正确\n"
-                    "- 安装 instaloader: pip install instaloader\n"
-                    "- 登录以访问更多内容: instaloader --login YOUR_USERNAME"
-                ),
+                content="".join(content_parts),
                 url=url,
                 platform="instagram",
             )

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -21,6 +21,12 @@ PLATFORM_SPECS = [
         "config_key": "twitter",
     },
     {
+        "name": "Instagram",
+        "domains": [".instagram.com"],
+        "cookies": None,  # None = grab all cookies as header string
+        "config_key": "instagram",
+    },
+    {
         "name": "XiaoHongShu",
         "domains": [".xiaohongshu.com"],
         "cookies": None,  # None = grab all cookies as header string
@@ -143,6 +149,32 @@ def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
             results_list.append(("Twitter/X", False,
                                  f"Found {found}, but missing: {', '.join(missing)}. "
                                  f"Make sure you're logged into x.com in {browser}."))
+
+    if "instagram" in extracted:
+        cookie_str = extracted["instagram"].get("cookie_string", "")
+        if cookie_str:
+            # Validate essential cookies exist
+            cookies = {}
+            for part in cookie_str.split(";"):
+                part = part.strip()
+                if "=" in part:
+                    k, v = part.split("=", 1)
+                    cookies[k.strip()] = v.strip()
+            if "sessionid" in cookies:
+                # Save as cookie file (same format as manual configure)
+                from pathlib import Path
+                cookie_dir = Path.home() / ".agent-reach"
+                cookie_dir.mkdir(parents=True, exist_ok=True)
+                cookie_file = cookie_dir / "instagram-cookies.txt"
+                cookie_file.write_text(cookie_str)
+                cookie_file.chmod(0o600)
+                n_cookies = len(cookies)
+                results_list.append(("Instagram", True,
+                                     f"{n_cookies} cookies (sessionid ✅)"))
+            else:
+                results_list.append(("Instagram", False,
+                                     f"Cookies found but missing sessionid. "
+                                     f"Make sure you're logged into instagram.com in {browser}."))
 
     if "xhs" in extracted:
         cookie_str = extracted["xhs"].get("cookie_string", "")


### PR DESCRIPTION
Fixes #13

## 问题
用户配置 Instagram cookies 后仍然被重定向到登录页面 / 看到 "Something went wrong"。

## 调研发现
这是 **instaloader 上游的已知问题**。Instagram 近期大幅加强了反爬措施：
- [instaloader#2585](https://github.com/instaloader/instaloader/issues/2585) — 登录后下载任何内容都返回 401
- [instaloader#2648](https://github.com/instaloader/instaloader/issues/2648) — 即使加载浏览器 session 也返回 "Something went wrong"

即使 cookies 配置完全正确，Instagram 也可能拒绝非浏览器的 API 请求。

## 改动

### 1. 错误提示大幅改善 (`instagram.py`)
- **之前**：instaloader 失败后静默 fallback 到 Jina Reader，用户完全不知道发生了什么
- **之后**：根据具体错误类型（401 / 重定向 / "Something went wrong" / 速率限制）给出针对性的提示和建议
- 使用 logging 记录详细错误信息
- `check()` 方法验证 cookie 文件格式，并提醒 Instagram 反爬风险

### 2. 支持从浏览器自动提取 Instagram cookies (`cookie_extract.py`)
- Instagram 加入 `PLATFORM_SPECS`
- `agent-reach configure --from-browser chrome` 现在也会提取 Instagram cookies
- 自动保存到 `~/.agent-reach/instagram-cookies.txt`

### 3. Jina 回退改为异步
- `_read_jina()` 从 `requests.get` 改为 `httpx` 异步客户端

### 4. Profile 帖子列表容错
- 获取 profile 的 recent posts 失败时不再整个请求失败，而是返回已获取的 profile 信息
