### PR TITLE
feat: add uninstall command; fix utf-8 encoding and minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,24 @@ Agent Reach 在设计上重视安全：
 | 安全模式 | `agent-reach install --env=auto --safe` | 生产服务器、多人共用机器 |
 | 仅预览 | `agent-reach install --env=auto --dry-run` | 先看看会做什么 |
 
+### 🗑️ 卸载
+
+```bash
+agent-reach uninstall
+```
+
+会清除：`~/.agent-reach/`（含所有 token/cookie）、各 Agent 的 skill 文件、mcporter 中的 MCP 配置。
+
+```bash
+# 只预览，不实际删除
+agent-reach uninstall --dry-run
+
+# 只删 skill 文件，保留 token 配置（重装时用）
+agent-reach uninstall --keep-config
+```
+
+卸载 Python 包本身：`pip uninstall agent-reach`
+
 ---
 
 ## 贡献

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -41,7 +41,7 @@ class Config:
     def load(self):
         """Load config from YAML file."""
         if self.config_path.exists():
-            with open(self.config_path, "r") as f:
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 self.data = yaml.safe_load(f) or {}
         else:
             self.data = {}
@@ -49,7 +49,7 @@ class Config:
     def save(self):
         """Save config to YAML file."""
         self._ensure_dir()
-        with open(self.config_path, "w") as f:
+        with open(self.config_path, "w", encoding="utf-8") as f:
             yaml.dump(self.data, f, default_flow_style=False, allow_unicode=True)
         # Restrict permissions — config may contain credentials
         try:

--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -74,11 +74,12 @@ def format_report(results: Dict[str, dict]) -> str:
     if ok_count < total:
         lines.append("运行 `agent-reach setup` 解锁更多渠道")
 
-    # Security check: config file permissions
+    # Security check: config file permissions (Unix only)
     import os
     import stat
+    import sys
     config_path = Config.CONFIG_DIR / "config.yaml"
-    if config_path.exists():
+    if config_path.exists() and sys.platform != "win32":
         try:
             mode = config_path.stat().st_mode
             if mode & (stat.S_IRGRP | stat.S_IROTH):


### PR DESCRIPTION
- Add `agent-reach uninstall` with --dry-run / --keep-config flags
- config.py: enforce utf-8 encoding on file IO
- doctor.py: skip Unix permission check on Windows
- cli.py: remove unused _parse_cookie_header function
- README: document uninstall usage

Hello, I am here to contribute code again. This update has added uninstallation instructions and fixed some minor issues. Additionally, there are still some issues in the/tests directory 
1.Serious disconnect between testing and code - a large number of tests called non-existent functions/classes/methods (get_channel_for_url, ReadResult, SearchResult, Channel.sea)
rch()、AgentReach.detect_platform()）， Cannot run at all
2. Mock target error - patched requests.get, but the actual code used subprocess
3. Hard coded/tmp/path - will fail on Windows
4. Test coverage is extremely low - there are only 3 tests in line 1000+of cli. py, which only appear in pytest and do not participate in the actual installation and usage process