### PR TITLE
docs: Cookie-Editor 作为所有 cookie 平台的首选登录方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 
 > **不知道怎么配？不用查文档。** 直接告诉 Agent「帮我配 XXX」，它知道需要什么、会一步一步引导你。
 >
-> 🍪 需要 Cookie 的平台（Twitter、小红书等），建议使用 Chrome 插件 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 一键导出。**服务器用户**没有浏览器界面，请在自己的电脑上登录对应网站后导出 Cookie，再发给 Agent 配置。
+> 🍪 需要 Cookie 的平台（Twitter、小红书等），**优先使用** Chrome 插件 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 导出 Cookie，发给 Agent 即可配置。流程统一：浏览器登录 → Cookie-Editor 导出 → 发给 Agent。比扫码更简单可靠。
 >
 > 🔒 Cookie 只存在你本地，不上传不外传。代码完全开源，随时可审查。
 > 💻 本地电脑不需要代理。代理只有部署在服务器上才需要（~$1/月）。

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -48,15 +48,26 @@ When a user asks to configure/enable any channel:
 1. Run `agent-reach doctor`
 2. Find the channel — it shows status (✅/⚠️/⬜) and **what to do next**
 3. Execute what you can automatically (install packages, start services)
-4. For human-required steps (scan QR, paste cookies), tell the user what to do
+4. For human-required steps (paste cookies), tell the user what to do
 5. Run `agent-reach doctor` again to verify
 
 **Do NOT memorize per-channel steps.** Always rely on `doctor` output.
 
-### Common human actions
+### Cookie 导入（所有需要登录的平台通用）
 
-- **Paste cookies:** User installs [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) → goes to the website → exports Header String → sends it to you → you run `agent-reach configure <platform>-cookies "..."`
-- **Scan QR code:** User opens the URL on their phone/browser and scans with the platform's app
+所有需要 Cookie 的平台（Twitter、小红书等），**优先使用 Cookie-Editor 导入**：
+
+1. 用户在自己的浏览器登录对应平台
+2. 安装 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) Chrome 插件
+3. 点击插件 → Export → Header String
+4. 把导出的字符串发给 Agent
+
+本地电脑用户也可以用 `agent-reach configure --from-browser chrome` 一键自动提取。
+
+扫码登录是备选方案（仅限本地有浏览器的情况），Cookie-Editor 更简单可靠。
+
+### Other human actions
+
 - **Proxy:** Reddit/Bilibili/XiaoHongShu may block server IPs — suggest a residential proxy if on a server
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -82,9 +82,18 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 
 > 🔒 **Security tip:** For platforms that need cookies (Twitter, XiaoHongShu), we recommend using a **dedicated/secondary account** rather than your main account. Cookie-based auth grants full account access — using a separate account limits the blast radius if credentials are ever compromised.
 
-**Twitter search & posting (server users):**
+> 🍪 **Cookie 导入（所有需要登录的平台通用）：**
+>
+> 所有需要 Cookie 的平台（Twitter、小红书等），**优先使用 Cookie-Editor 导入**，这是最简单最可靠的方式：
+> 1. 用户在自己的浏览器上登录对应平台
+> 2. 安装 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) Chrome 插件
+> 3. 点击插件 → Export → Header String
+> 4. 把导出的字符串发给 Agent
+>
+> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书）。
+
+**Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
-> Extension: https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm
 
 ```bash
 agent-reach configure twitter-cookies "PASTED_STRING"
@@ -121,9 +130,13 @@ mcporter config add xiaohongshu http://localhost:18060/mcp
 > 如果在服务器上，建议加代理避免 IP 风控：
 > `docker run -d --name xiaohongshu-mcp -p 18060:18060 -e XHS_PROXY=http://user:pass@ip:port xpzouying/xiaohongshu-mcp`
 >
-> **登录方式：**
-> - **本地电脑（有浏览器）：** 打开 http://localhost:18060 扫码登录即可。
-> - **服务器（无 UI 界面）：** 服务器上通常没有浏览器，无法直接扫码。最方便的方式是在自己的电脑上用浏览器登录小红书，然后用 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 插件导出 Cookie（Header String 格式），发给 Agent 即可完成配置。详见 [Cookie 导出指南](cookie-export.md)。
+> **登录方式（优先用 Cookie-Editor，最简单）：**
+> 1. 用户在自己的浏览器登录小红书 (xiaohongshu.com)
+> 2. 用 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 插件导出 Cookie（Header String 格式）
+> 3. 把 Cookie 字符串发给 Agent
+> 4. Agent 将 Cookie 写入 MCP 服务的 cookie 文件完成登录
+>
+> **备选：** 本地电脑如果有浏览器，也可以打开 http://localhost:18060 扫码登录。
 
 **LinkedIn (可选 — linkedin-scraper-mcp):**
 > "LinkedIn 基本内容可通过 Jina Reader 读取。完整功能（Profile 详情、职位搜索）需要 linkedin-scraper-mcp。"


### PR DESCRIPTION
## 改了什么

统一所有需要 Cookie 的平台（Twitter、小红书等）的登录引导方式：

**Cookie-Editor 导入优先** → 扫码降级为备选

### 具体改动

- **install.md**: 新增通用 Cookie 导入说明段，统一话术：浏览器登录 → Cookie-Editor 导出 → 发给 Agent
- **install.md**: 小红书登录从"本地扫码、服务器用 Cookie"改为"Cookie-Editor 优先，扫码备选"
- **SKILL.md**: Cookie 导入独立成段，agent 知道所有平台都优先用 Cookie-Editor
- **README.md**: 更新 Cookie 说明

### 为什么

用户反馈：小红书扫码经常出问题（QR 码加载失败、服务器没浏览器等）。Cookie-Editor 是最简单最可靠的方式，不管本地还是服务器都通用。