### PR TITLE
feat: 新增抖音（Douyin）渠道

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📺 **B站** | 本地：字幕提取 + 搜索 | 服务器也能用 | 告诉 Agent「帮我配代理」 |
 | 📖 **Reddit** | 搜索（通过 Exa 免费） | 读帖子和评论 | 告诉 Agent「帮我配代理」 |
 | 📕 **小红书** | — | 阅读、搜索、发帖、评论、点赞 | 告诉 Agent「帮我配小红书」 |
+| 🎵 **抖音** | — | 视频解析、无水印下载链接获取 | 告诉 Agent「帮我配抖音」 |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
 | 🏢 **Boss直聘** | Jina Reader 读职位页 | 搜索职位、向 HR 打招呼 | 告诉 Agent「帮我配 Boss直聘」 |
 
@@ -149,6 +150,7 @@ channels/
 ├── bilibili.py     → yt-dlp          ← 可以换成 bilibili-api……
 ├── reddit.py       → JSON API + Exa  ← 可以换成 PRAW、Pushshift……
 ├── xiaohongshu.py  → mcporter MCP    ← 可以换成其他 XHS 工具……
+├── douyin.py       → mcporter MCP    ← 可以换成其他抖音工具……
 ├── linkedin.py     → linkedin-mcp    ← 可以换成 LinkedIn API……
 ├── bosszhipin.py   → mcp-bosszp      ← 可以换成其他招聘工具……
 ├── rss.py          → feedparser      ← 可以换成 atoma……
@@ -169,6 +171,7 @@ channels/
 | GitHub | [gh CLI](https://cli.github.com) | 官方工具，认证后完整 API 能力 |
 | 读 RSS | [feedparser](https://github.com/kurtmckee/feedparser) | Python 生态标准选择，2.3K Star |
 | 小红书 | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) | ⭐9K+，Go 语言，Docker 一键部署 |
+| 抖音 | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) | MCP 服务，无需登录，视频解析 + 无水印下载 |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | ⭐900+，MCP 服务，浏览器自动化 |
 | Boss直聘 | [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp) | MCP 服务，支持职位搜索和打招呼 |
 
@@ -261,6 +264,12 @@ Reddit 封锁数据中心 IP。配置一个住宅代理即可解决：`agent-rea
 </details>
 
 <details>
+<summary><strong>怎么让 AI Agent 解析抖音视频？</strong></summary>
+
+安装 douyin-mcp-server 后，Agent 就能用 `mcporter call 'douyin.parse_douyin_video_info(share_link: "分享链接")'` 解析视频信息、获取无水印下载链接。不需要登录，把抖音分享链接发给 Agent 就行。详见 https://github.com/yzfly/douyin-mcp-server
+</details>
+
+<details>
 <summary><strong>Compatible with Claude Code / Cursor / OpenClaw / Windsurf?</strong></summary>
 
 Yes! Agent Reach is an installer + configuration tool — any AI coding agent that can run shell commands can use it. Works with Claude Code, Cursor, OpenClaw, Windsurf, Codex, and more. Just `pip install agent-reach`, run `agent-reach install`, and the agent can start using the upstream tools immediately.
@@ -276,7 +285,7 @@ Yes! Agent Reach is an installer + configuration tool — any AI coding agent th
 
 ## 致谢
 
-[Jina Reader](https://github.com/jina-ai/reader) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [bird](https://www.npmjs.com/package/@steipete/bird) · [Exa](https://exa.ai) · [mcporter](https://github.com/steipete/mcporter) · [feedparser](https://github.com/kurtmckee/feedparser) · [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) · [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp)
+[Jina Reader](https://github.com/jina-ai/reader) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [bird](https://www.npmjs.com/package/@steipete/bird) · [Exa](https://exa.ai) · [mcporter](https://github.com/steipete/mcporter) · [feedparser](https://github.com/kurtmckee/feedparser) · [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) · [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) · [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp)
 
 ## License
 

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -16,6 +16,7 @@ from .rss import RSSChannel
 from .bilibili import BilibiliChannel
 from .exa_search import ExaSearchChannel
 from .xiaohongshu import XiaoHongShuChannel
+from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
 
@@ -28,6 +29,7 @@ ALL_CHANNELS: List[Channel] = [
     RedditChannel(),
     BilibiliChannel(),
     XiaoHongShuChannel(),
+    DouyinChannel(),
     LinkedInChannel(),
     BossZhipinChannel(),
     RSSChannel(),

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Douyin (抖音) — check if mcporter + douyin-mcp-server is available."""
+
+import shutil
+import subprocess
+from .base import Channel
+
+
+class DouyinChannel(Channel):
+    name = "douyin"
+    description = "抖音短视频"
+    backends = ["douyin-mcp-server"]
+    tier = 2
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "douyin.com" in d or "iesdouyin.com" in d
+
+    def check(self, config=None):
+        if not shutil.which("mcporter"):
+            return "off", (
+                "需要 mcporter + douyin-mcp-server。安装步骤：\n"
+                "  1. npm install -g mcporter\n"
+                "  2. pip install douyin-mcp-server\n"
+                "  3. 启动服务（见下方说明）\n"
+                "  4. mcporter config add douyin http://localhost:18070/mcp\n"
+                "  详见 https://github.com/yzfly/douyin-mcp-server"
+            )
+        try:
+            r = subprocess.run(
+                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+            )
+            if "douyin" not in r.stdout:
+                return "off", (
+                    "mcporter 已装但抖音 MCP 未配置。运行：\n"
+                    "  pip install douyin-mcp-server\n"
+                    "  # 启动服务后：\n"
+                    "  mcporter config add douyin http://localhost:18070/mcp"
+                )
+        except Exception:
+            return "off", "mcporter 连接异常"
+        try:
+            r = subprocess.run(
+                ["mcporter", "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
+                capture_output=True, text=True, timeout=15
+            )
+            if r.returncode == 0:
+                return "ok", "完整可用（视频解析、下载链接获取）"
+            return "warn", "MCP 已连接但调用异常，检查 douyin-mcp-server 服务是否在运行"
+        except Exception:
+            return "warn", "MCP 连接异常，检查 douyin-mcp-server 服务是否在运行"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -3,7 +3,7 @@ name: agent-reach
 description: >
   Give your AI agent eyes to see the entire internet. Install and configure
   upstream tools for Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu,
-  LinkedIn, Boss直聘, RSS, and any web page — then call them directly.
+  Douyin, LinkedIn, Boss直聘, RSS, and any web page — then call them directly.
   Use when: (1) setting up platform access tools for the first time,
   (2) checking which platforms are available,
   (3) user asks to configure/enable a platform channel.
@@ -143,6 +143,21 @@ mcporter call 'xiaohongshu.get_feed_comments(feed_id: "xxx", xsec_token: "yyy")'
 # Post a note
 mcporter call 'xiaohongshu.create_image_feed(title: "标题", desc: "内容", image_paths: ["/path/to/img.jpg"])'
 ```
+
+### 抖音 / Douyin (mcporter + douyin-mcp-server)
+
+```bash
+# 解析抖音视频信息（分享链接 → 标题、作者、无水印视频URL等）
+mcporter call 'douyin.parse_douyin_video_info(share_link: "https://v.douyin.com/xxx/")'
+
+# 获取无水印视频下载链接
+mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com/xxx/")'
+
+# AI 提取视频语音文案（需要配置硅基流动 API Key）
+mcporter call 'douyin.extract_douyin_text(share_link: "https://v.douyin.com/xxx/")'
+```
+
+> 无需登录即可解析视频。支持抖音分享链接和直接链接。
 
 ### GitHub (gh CLI)
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -58,6 +58,7 @@ Copy that to your Agent. A few minutes later, it can read tweets, search Reddit,
 | 🌐 **Web** | Read | Zero config | Any URL → clean Markdown ([Jina Reader](https://github.com/jina-ai/reader) ⭐9.8K) |
 | 🐦 **Twitter/X** | Read · Search | Zero config / Cookie | Single tweets readable out of the box. Cookie unlocks search, timeline, posting ([bird](https://github.com/steipete/bird)) |
 | 📕 **XiaoHongShu** | Read · Search · **Post · Comment · Like** | mcporter | Via [xiaohongshu-mcp](https://github.com/user/xiaohongshu-mcp) internal API, install and go |
+| 🎵 **Douyin** | Video parsing · Watermark-free download | mcporter | Via [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server), no login needed |
 | 💼 **LinkedIn** | Jina Reader (public pages) | Full profiles, companies, job search | Tell your Agent "help me set up LinkedIn" |
 | 🏢 **Boss直聘** | Jina Reader (job pages) | Job search, greet recruiters | Tell your Agent "help me set up Boss直聘" |
 | 🔍 **Web Search** | Search | Auto-configured | Auto-configured during install, free, no API key ([Exa](https://exa.ai) via [mcporter](https://github.com/nicepkg/mcporter)) |
@@ -186,6 +187,7 @@ channels/
 ├── bilibili.py     → yt-dlp          ← swap to bilibili-api…
 ├── reddit.py       → JSON API + Exa  ← swap to PRAW, Pushshift…
 ├── xiaohongshu.py  → mcporter MCP    ← swap to other XHS tools…
+├── douyin.py       → mcporter MCP    ← swap to other Douyin tools…
 ├── linkedin.py     → linkedin-mcp    ← swap to LinkedIn API…
 ├── bosszhipin.py   → mcp-bosszp      ← swap to other job tools…
 ├── rss.py          → feedparser      ← swap to atoma…
@@ -206,6 +208,7 @@ Each channel file only checks whether its upstream tool is installed and working
 | GitHub | [gh CLI](https://cli.github.com) | Official tool, full API after auth |
 | Read RSS | [feedparser](https://github.com/kurtmckee/feedparser) | Python ecosystem standard, 2.3K stars |
 | XiaoHongShu | [xiaohongshu-mcp](https://github.com/user/xiaohongshu-mcp) | Internal API, bypasses anti-bot |
+| Douyin | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) | MCP server, no login needed, video parsing + watermark-free download |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | 900+ stars, MCP server, browser automation |
 | Boss直聘 | [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp) | MCP server, job search + recruiter greeting |
 
@@ -269,11 +272,17 @@ Agent Reach uses bird CLI which accesses Twitter via cookie auth — same as you
 Agent Reach integrates with xiaohongshu-mcp (runs in Docker). After setup, use `mcporter call 'xiaohongshu.get_feed_detail(...)'` to read notes or `mcporter call 'xiaohongshu.search_feeds(keyword: "query")'` to search.
 </details>
 
+<details>
+<summary><strong>How to parse Douyin / 抖音 videos with AI agent?</strong></summary>
+
+Install douyin-mcp-server, then your agent can use `mcporter call 'douyin.parse_douyin_video_info(share_link: "share_url")'` to parse video info and get watermark-free download links. No login required — just share the Douyin link. See https://github.com/yzfly/douyin-mcp-server
+</details>
+
 ---
 
 ## Credits
 
-[Jina Reader](https://github.com/jina-ai/reader) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [bird](https://github.com/steipete/bird) · [Exa](https://exa.ai) · [feedparser](https://github.com/kurtmckee/feedparser) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) · [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp)
+[Jina Reader](https://github.com/jina-ai/reader) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [bird](https://github.com/steipete/bird) · [Exa](https://exa.ai) · [feedparser](https://github.com/kurtmckee/feedparser) · [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) · [mcp-bosszp](https://github.com/mucsbr/mcp-bosszp)
 
 ## License
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -138,6 +138,35 @@ mcporter config add xiaohongshu http://localhost:18060/mcp
 >
 > **备选：** 本地电脑如果有浏览器，也可以打开 http://localhost:18060 扫码登录。
 
+**抖音 / Douyin (douyin-mcp-server):**
+> "抖音视频解析需要一个 MCP 服务。安装 douyin-mcp-server 后即可解析视频、获取无水印下载链接。"
+
+```bash
+# 1. 安装
+pip install douyin-mcp-server
+
+# 2. 启动 HTTP 服务（端口 18070）
+# 方式一：用 uv（推荐）
+git clone https://github.com/yzfly/douyin-mcp-server.git && cd douyin-mcp-server
+uv sync && uv run python run_http.py
+
+# 方式二：直接用 Python 启动
+python -c "
+from douyin_mcp_server.server import mcp
+mcp.settings.host = '127.0.0.1'
+mcp.settings.port = 18070
+mcp.run(transport='streamable-http')
+"
+
+# 3. 注册到 mcporter
+mcporter config add douyin http://localhost:18070/mcp
+```
+
+> 无需认证即可解析视频信息和获取下载链接。
+> 如需 AI 语音识别提取文案功能，需要配置硅基流动 API Key（`export API_KEY="sk-xxx"`）。
+>
+> 详见 https://github.com/yzfly/douyin-mcp-server
+
 **LinkedIn (可选 — linkedin-scraper-mcp):**
 > "LinkedIn 基本内容可通过 Jina Reader 读取。完整功能（Profile 详情、职位搜索）需要 linkedin-scraper-mcp。"
 
@@ -254,6 +283,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | Web | `curl` + Jina | `curl -s "https://r.jina.ai/URL"` |
 | Exa Search | `mcporter` | `mcporter call 'exa.web_search_exa(...)'` |
 | 小红书 | `mcporter` | `mcporter call 'xiaohongshu.search_feeds(...)'` |
+| 抖音 | `mcporter` | `mcporter call 'douyin.parse_douyin_video_info(...)'` |
 | LinkedIn | `mcporter` | `mcporter call 'linkedin.get_person_profile(...)'` |
 | Boss直聘 | `mcporter` | `mcporter call 'bosszhipin.search_jobs_tool(...)'` |
 | RSS | `feedparser` | `python3 -c "import feedparser; ..."` |


### PR DESCRIPTION
## 新增抖音渠道

基于 [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server)，通过 mcporter 调用 MCP 服务。

### 变更内容

- **新增** `agent_reach/channels/douyin.py` — 抖音渠道 channel 文件
  - doctor 检查：mcporter 是否装了 → douyin MCP 是否配了 → 服务是否可调用
  - 安装指引：pip install → 启动服务 → mcporter config add
- **更新** `agent_reach/channels/__init__.py` — 注册 douyin 渠道
- **更新** `docs/install.md` — 新增抖音配置段落和 Quick Reference 表
- **更新** `agent_reach/skill/SKILL.md` — 新增抖音使用说明和 mcporter 调用示例
- **更新** `README.md` — 平台列表、架构图、选型表、致谢、FAQ
- **更新** `docs/README_en.md` — 英文版同步更新

### 功能

- 🎬 解析抖音视频信息（标题、作者、统计数据等）
- 📥 获取无水印视频下载链接
- 🎙️ AI 语音识别提取视频文案（需配置 API Key）
- 🔓 无需登录即可使用基础功能

### 测试

```
agent-reach doctor 输出：
✅ 抖音短视频 — 完整可用（视频解析、下载链接获取）
状态：11/12 个渠道可用
```