### PR TITLE
fix: sync __version__ with pyproject.toml (1.0.0 → 1.2.0)

### DIFF
--- a/agent_reach/__init__.py
+++ b/agent_reach/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Agent Reach — Give your AI Agent eyes to see the entire internet."""
 
-__version__ = "1.0.0"
+__version__ = "1.2.0"
 __author__ = "Neo Reid"
 
 from agent_reach.core import AgentReach


### PR DESCRIPTION
## 问题

`__init__.py` 中的 `__version__` 还是 `"1.0.0"`，但 `pyproject.toml` 已经是 `"1.2.0"`。

导致 `agent-reach --version` 和 `agent-reach doctor` 显示错误版本号。

**Fixes #29**

## 改动

- `agent_reach/__init__.py`: `__version__ = "1.0.0"" → "1.2.0"`

一行改动，简单同步。