### PR TITLE
fix: replace 'mcporter list' with 'mcporter config list' to prevent hangs

### DIFF
--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -29,7 +29,7 @@ class DouyinChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "douyin" not in r.stdout:
                 return "off", (

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -24,7 +24,7 @@ class ExaSearchChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "exa" in r.stdout.lower():
                 return "ok", "全网语义搜索可用（免费，无需 API Key）"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -26,7 +26,7 @@ class LinkedInChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "linkedin" in r.stdout.lower():
                 return "ok", "完整可用（Profile、公司、职位搜索）"

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -28,7 +28,7 @@ class XiaoHongShuChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "xiaohongshu" not in r.stdout:
                 return "off", (

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -453,7 +453,7 @@ def _install_mcporter():
     # Configure Exa MCP (free, no key needed)
     try:
         r = subprocess.run(
-            ["mcporter", "list"], capture_output=True, text=True, timeout=10
+            ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
         )
         if "exa" not in r.stdout:
             subprocess.run(
@@ -469,7 +469,7 @@ def _install_mcporter():
     # Check XiaoHongShu MCP (only if server is running)
     try:
         r = subprocess.run(
-            ["mcporter", "list"], capture_output=True, text=True, timeout=10
+            ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
         )
         if "xiaohongshu" in r.stdout:
             print("  ✅ XiaoHongShu MCP already configured")


### PR DESCRIPTION
## Problem

`agent-reach doctor` and `agent-reach install` hang when mcporter has slow or offline MCP servers configured.

**Root cause:** 4 channel checks + 2 install checks all call `mcporter list`, which probes every configured server sequentially. If servers are offline, each call blocks up to the timeout — totaling 60+ seconds of hanging with no output.

## Fix

Replace `mcporter list` with `mcporter config list` in all 6 call sites.

`mcporter config list` reads configuration without probing servers — it returns instantly. This is sufficient because these checks only need to know **if a server is configured**, not whether it's reachable. Channels that need deeper probing (xiaohongshu, douyin) already do targeted `mcporter call` afterward.

Also reduced subprocess timeout from 10s to 5s since config reads should be near-instant.

### Files changed

| File | Change |
|------|--------|
| `channels/exa_search.py` | `mcporter list` → `mcporter config list` |
| `channels/xiaohongshu.py` | same |
| `channels/douyin.py` | same |
| `channels/linkedin.py` | same |
| `cli.py` (`_install_mcporter`) | same (2 calls) |

Fixes #34