### PR TITLE
fix: resolve mcporter executable path for Windows subprocess

### DIFF
--- a/agent_reach/channels/bosszhipin.py
+++ b/agent_reach/channels/bosszhipin.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Boss直聘 — check if mcp-bosszp is available."""
 
-import shutil
 import subprocess
+
+from agent_reach.mcporter import find_mcporter
 from .base import Channel
 
 
@@ -18,7 +19,8 @@ class BossZhipinChannel(Channel):
         return "zhipin.com" in domain or "boss.com" in domain
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = find_mcporter()
+        if not mcporter:
             return "off", (
                 "可通过 Jina Reader 读取职位页面。完整功能需要：\n"
                 "  1. git clone https://github.com/mucsbr/mcp-bosszp.git\n"
@@ -28,7 +30,7 @@ class BossZhipinChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                [mcporter, "list"], capture_output=True, text=True, timeout=10
             )
             out = r.stdout.lower()
             if "boss" in out or "zhipin" in out:

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Douyin (抖音) — check if mcporter + douyin-mcp-server is available."""
 
-import shutil
 import subprocess
+
+from agent_reach.mcporter import find_mcporter
 from .base import Channel
 
 
@@ -18,7 +19,8 @@ class DouyinChannel(Channel):
         return "douyin.com" in d or "iesdouyin.com" in d
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = find_mcporter()
+        if not mcporter:
             return "off", (
                 "需要 mcporter + douyin-mcp-server。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
@@ -29,7 +31,7 @@ class DouyinChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "douyin" not in r.stdout:
                 return "off", (
@@ -42,7 +44,7 @@ class DouyinChannel(Channel):
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
-                ["mcporter", "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
+                [mcporter, "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
                 capture_output=True, text=True, timeout=15
             )
             if r.returncode == 0:

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Exa Search — check if mcporter + Exa MCP is available."""
 
-import shutil
 import subprocess
+
+from agent_reach.mcporter import find_mcporter
 from .base import Channel
 
 
@@ -16,7 +17,8 @@ class ExaSearchChannel(Channel):
         return False  # Search-only channel
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = find_mcporter()
+        if not mcporter:
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
                 "  npm install -g mcporter\n"
@@ -24,7 +26,7 @@ class ExaSearchChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "exa" in r.stdout.lower():
                 return "ok", "全网语义搜索可用（免费，无需 API Key）"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """LinkedIn — check if linkedin-scraper-mcp is available."""
 
-import shutil
 import subprocess
+
+from agent_reach.mcporter import find_mcporter
 from .base import Channel
 
 
@@ -17,7 +18,8 @@ class LinkedInChannel(Channel):
         return "linkedin.com" in urlparse(url).netloc.lower()
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = find_mcporter()
+        if not mcporter:
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
                 "  pip install linkedin-scraper-mcp\n"
@@ -26,7 +28,7 @@ class LinkedInChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "linkedin" in r.stdout.lower():
                 return "ok", "完整可用（Profile、公司、职位搜索）"

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """XiaoHongShu — check if mcporter + xiaohongshu MCP is available."""
 
-import shutil
 import subprocess
+
+from agent_reach.mcporter import find_mcporter
 from .base import Channel
 
 
@@ -18,7 +19,8 @@ class XiaoHongShuChannel(Channel):
         return "xiaohongshu.com" in d or "xhslink.com" in d
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = find_mcporter()
+        if not mcporter:
             return "off", (
                 "需要 mcporter + xiaohongshu-mcp。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
@@ -28,7 +30,7 @@ class XiaoHongShuChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True, text=True, timeout=5
             )
             if "xiaohongshu" not in r.stdout:
                 return "off", (
@@ -40,7 +42,7 @@ class XiaoHongShuChannel(Channel):
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
-                ["mcporter", "call", "xiaohongshu.check_login_status()"],
+                [mcporter, "call", "xiaohongshu.check_login_status()"],
                 capture_output=True, text=True, timeout=10
             )
             if "已登录" in r.stdout or "logged" in r.stdout.lower():

--- a/agent_reach/mcporter.py
+++ b/agent_reach/mcporter.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Helpers for locating mcporter executable reliably across platforms."""
+
+import shutil
+from typing import Optional
+
+
+def find_mcporter() -> Optional[str]:
+    """Return absolute mcporter executable path if available."""
+    return shutil.which("mcporter")
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 
 import pytest
 import requests
+from types import SimpleNamespace
 from unittest.mock import patch
 import agent_reach.cli as cli
 from agent_reach.cli import main
@@ -112,3 +113,25 @@ class TestCheckUpdateRetry:
         assert result == "error"
         assert "网络超时" in captured.out
         assert "已重试 3 次" in captured.out
+
+
+class TestMcporterExecutableResolution:
+    def test_uninstall_uses_resolved_mcporter_path(self, capsys):
+        calls = []
+
+        class Result:
+            def __init__(self, stdout=""):
+                self.stdout = stdout
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return Result(stdout="exa\nxiaohongshu\n")
+
+        args = SimpleNamespace(dry_run=True, keep_config=False)
+
+        with patch("agent_reach.cli.find_mcporter", return_value=r"C:\Tools\mcporter.CMD"):
+            with patch("subprocess.run", side_effect=fake_run):
+                cli._cmd_uninstall(args)
+
+        assert calls, "expected subprocess.run to be called"
+        assert calls[0][0] == r"C:\Tools\mcporter.CMD"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,6 +2,7 @@
 """Tests for doctor module."""
 
 import pytest
+from agent_reach.channels.exa_search import ExaSearchChannel
 from agent_reach.config import Config
 from agent_reach.doctor import check_all, format_report
 
@@ -28,6 +29,24 @@ class TestDoctor:
         tmp_config.set("exa_api_key", "test-key")
         results = check_all(tmp_config)
         assert results["exa_search"]["status"] in ("off", "ok")
+
+    def test_exa_channel_uses_resolved_mcporter_path(self, monkeypatch):
+        import agent_reach.channels.exa_search as exa_mod
+
+        monkeypatch.setattr(exa_mod, "find_mcporter", lambda: r"C:\Tools\mcporter.CMD")
+        seen = {}
+
+        class Result:
+            stdout = "exa"
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return Result()
+
+        monkeypatch.setattr(exa_mod.subprocess, "run", fake_run)
+        status, _msg = ExaSearchChannel().check()
+        assert status == "ok"
+        assert seen["cmd"][0] == r"C:\Tools\mcporter.CMD"
 
     def test_format_report(self, tmp_config):
         results = check_all(tmp_config)


### PR DESCRIPTION
## Summary
- fix Windows subprocess compatibility by resolving `mcporter` executable path once via `shutil.which`
- replace hardcoded `"mcporter"` invocations in CLI and channel integrations with resolved executable path
- add focused tests for doctor and uninstall flows to guard regression

## Why
On some Windows environments, Python subprocess calls can fail to resolve bare `mcporter` command names reliably. Using the resolved executable path improves robustness without changing product behavior.

## Scope
- no telemetry/features
- no changelog rewrite
- no unrelated infra/doc changes

## Validation
- `python -m pytest -q -s tests/test_doctor.py::TestDoctor::test_exa_channel_uses_resolved_mcporter_path`
- `python -m pytest -q -s tests/test_cli.py::TestMcporterExecutableResolution::test_uninstall_uses_resolved_mcporter_path`
- `python -m pytest -q -s tests/test_cli.py::TestCLI::test_doctor_runs`

## Risk
Low. This is a path-resolution hardening change plus targeted regression tests.
