### PR TITLE
fix: ARM64/Apple Silicon support for xiaohongshu-mcp Docker setup

### DIFF
--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -1,9 +1,31 @@
 # -*- coding: utf-8 -*-
-"""XiaoHongShu — check if mcporter + xiaohongshu MCP is available."""
+"""XiaoHongShu -- check if mcporter + xiaohongshu MCP is available."""
 
+import platform
 import shutil
 import subprocess
 from .base import Channel
+
+
+def _is_arm64() -> bool:
+    """Detect ARM64 architecture (e.g. Apple Silicon)."""
+    machine = platform.machine().lower()
+    return machine in ("arm64", "aarch64")
+
+
+def _docker_run_hint() -> str:
+    """Return the docker run command, with --platform flag for ARM64."""
+    if _is_arm64():
+        return (
+            "  docker run -d --name xiaohongshu-mcp -p 18060:18060 "
+            "--platform linux/amd64 xpzouying/xiaohongshu-mcp\n"
+            "  # ARM64 also: build from source: "
+            "https://github.com/xpzouying/xiaohongshu-mcp"
+        )
+    return (
+        "  docker run -d --name xiaohongshu-mcp -p 18060:18060 "
+        "xpzouying/xiaohongshu-mcp"
+    )
 
 
 class XiaoHongShuChannel(Channel):
@@ -22,7 +44,7 @@ class XiaoHongShuChannel(Channel):
             return "off", (
                 "需要 mcporter + xiaohongshu-mcp。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
-                "  2. docker run -d --name xiaohongshu-mcp -p 18060:18060 xpzouying/xiaohongshu-mcp\n"
+                "  2. " + _docker_run_hint().strip() + "\n"
                 "  3. mcporter config add xiaohongshu http://localhost:18060/mcp\n"
                 "  详见 https://github.com/xpzouying/xiaohongshu-mcp"
             )
@@ -33,7 +55,7 @@ class XiaoHongShuChannel(Channel):
             if "xiaohongshu" not in r.stdout:
                 return "off", (
                     "mcporter 已装但小红书 MCP 未配置。运行：\n"
-                    "  docker run -d --name xiaohongshu-mcp -p 18060:18060 xpzouying/xiaohongshu-mcp\n"
+                    + _docker_run_hint() + "\n"
                     "  mcporter config add xiaohongshu http://localhost:18060/mcp"
                 )
         except Exception:

--- a/agent_reach/guides/setup-xiaohongshu.md
+++ b/agent_reach/guides/setup-xiaohongshu.md
@@ -67,5 +67,25 @@ docker run -d \
 **Q: 服务器上小红书提示 IP 风险？**
 A: 加代理参数 `-e XHS_PROXY=http://user:pass@ip:port`，推荐住宅代理。
 
+**Q: Docker 镜像不支持 ARM64 / Apple Silicon？**
+A: 上游镜像暂无 ARM64 版本，两种解决办法：
+
+方法一：使用 Rosetta 模拟运行（推荐，最简单）
+```bash
+docker run -d \
+  --name xiaohongshu-mcp \
+  -p 18060:18060 \
+  --platform linux/amd64 \
+  xpzouying/xiaohongshu-mcp
+```
+
+方法二：从源码编译原生 ARM64 版本
+```bash
+git clone https://github.com/xpzouying/xiaohongshu-mcp
+cd xiaohongshu-mcp
+docker build -t xiaohongshu-mcp .
+docker run -d --name xiaohongshu-mcp -p 18060:18060 xiaohongshu-mcp
+```
+
 **Q: 我不想用 Docker？**
 A: 可以从源码编译：https://github.com/xpzouying/xiaohongshu-mcp


### PR DESCRIPTION
## Problem
Issue #44: `xpzouying/xiaohongshu-mcp` Docker image has no ARM64 manifest, causing `docker: no matching manifest for linux/arm64/v8` on Apple Silicon devices.

## Fix
Since this is an upstream image issue (not something Agent-Reach controls), we improve the **guidance** Agent-Reach gives:

### 1. Architecture detection in `xiaohongshu.py`
- New `_is_arm64()` helper detects ARM64/aarch64 architecture
- `_docker_run_hint()` automatically includes `--platform linux/amd64` on ARM64
- Doctor/check output now shows the correct command for the user's architecture

### 2. Setup guide update
- Added FAQ entry with two solutions:
  - **Rosetta emulation**: `--platform linux/amd64` (simplest, recommended)
  - **Build from source**: clone + `docker build` for native ARM64

## Scope
- 2 files changed, no new dependencies
- No behavior change on x86_64 systems

Closes #44