### PR TITLE
fix: CI 测试修复 — gh CLI 在 CI 环境不存在

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -15,7 +15,7 @@ class TestDoctor:
     def test_zero_config_channels_ok(self, tmp_config):
         results = check_all(tmp_config)
         assert results["web"]["status"] == "ok"
-        assert results["github"]["status"] == "ok"
+        assert results["github"]["status"] in ("ok", "warn")  # warn if gh CLI not installed
         assert results["bilibili"]["status"] in ("ok", "warn")  # warn on servers
         assert results["rss"]["status"] == "ok"
 


### PR DESCRIPTION
CI 的 test_doctor 断言 github channel 应该返回 ok，但 GitHub Actions runner 没装 gh CLI，所以返回 warn。改成允许两种状态。