### PR TITLE
fix: sync Twitter cookies to xreach session.json on configure

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -719,6 +719,7 @@ def _cmd_configure(args):
                 session_data["ct0"] = ct0
                 with open(session_path, "w", encoding="utf-8") as sf:
                     json.dump(session_data, sf, indent=2)
+                os.chmod(session_path, 0o600)
                 print("✅ Twitter cookies configured (synced to xreach)!")
             except Exception as e:
                 print("✅ Twitter cookies configured!")


### PR DESCRIPTION
## Problem

When running `agent-reach configure twitter-cookies`, credentials are saved to `~/.agent-reach/config.yaml` but **not** to `~/.config/xfetch/session.json` where `xreach` reads them. This means `xreach auth check` reports "Not authenticated" even after a successful configure.

## Fix

After saving to agent-reach's config, automatically write `authToken` and `ct0` to `~/.config/xfetch/session.json`:

- Creates `~/.config/xfetch/` directory if it doesn't exist
- Preserves existing fields in `session.json` if the file already exists
- Falls back gracefully if the sync fails (credentials are still saved to agent-reach config)
- Success message now says "synced to xreach" to confirm the bridge worked

## Testing

- All 8 CLI tests pass
- 1 pre-existing failure in `test_doctor.py::test_exa_off_without_key` (unrelated)

## Note on xreach auth set bug

The issue also reports that `xreach auth set --auth-token="xxx" --ct0="yyy"` fails with equals-sign format. That's an upstream xreach-cli bug — per project philosophy, we don't modify upstream. The session.json sync approach bypasses this entirely.

Fixes #50