### PR TITLE
docs: clarify agent-reach has no read/search commands

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -57,7 +57,6 @@ def main():
     parser.add_argument("--version", action="version", version=f"Agent Reach v{__version__}")
     sub = parser.add_subparsers(dest="command", help="Available commands")
 
-    # ── read ──
     # ── setup ──
     sub.add_parser("setup", help="Interactive configuration wizard")
 

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -76,7 +76,9 @@ When a user asks to configure/enable any channel:
 
 ## Using Upstream Tools Directly
 
-After `agent-reach install`, call the upstream tools directly. No need for `agent-reach read` or `agent-reach search`.
+After `agent-reach install`, call the upstream tools directly.
+
+> **Note:** `agent-reach` is an installer and config tool — it does NOT have `read`, `search`, or content-fetching commands. Use the upstream tools below instead.
 
 ### Twitter/X (xreach CLI)
 


### PR DESCRIPTION
## Fixes #58

**Problem:** Users confuse `agent-reach` (installer/config tool) with a content-fetching CLI, expecting `agent-reach read <url>` to work.

**Root cause:**
1. `cli.py` had a dead placeholder comment `# ── read ──` (no implementation)
2. SKILL.md's wording "No need for `agent-reach read`" could be misread as implying the command exists but is optional

**Changes:**
- Remove dead `# ── read ──` comment from cli.py
- Reword SKILL.md to explicitly state agent-reach is an installer/config tool with **no** read/search/content-fetching commands
- Added a callout box directing users to the upstream tools section below

**2 files, 3 insertions, 2 deletions.**