### PR TITLE
fix: Windows encoding + .cmd subprocess resolution

### DIFF
--- a/agent_reach/channels/bosszhipin.py
+++ b/agent_reach/channels/bosszhipin.py
@@ -18,7 +18,8 @@ class BossZhipinChannel(Channel):
         return "zhipin.com" in domain or "boss.com" in domain
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
             return "off", (
                 "可通过 Jina Reader 读取职位页面。完整功能需要：\n"
                 "  1. git clone https://github.com/mucsbr/mcp-bosszp.git\n"
@@ -28,7 +29,8 @@ class BossZhipinChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                [mcporter, "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=10
             )
             out = r.stdout.lower()
             if "boss" in out or "zhipin" in out:

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -18,7 +18,8 @@ class DouyinChannel(Channel):
         return "douyin.com" in d or "iesdouyin.com" in d
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
             return "off", (
                 "需要 mcporter + douyin-mcp-server。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
@@ -29,7 +30,8 @@ class DouyinChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
             )
             if "douyin" not in r.stdout:
                 return "off", (
@@ -42,8 +44,8 @@ class DouyinChannel(Channel):
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
-                ["mcporter", "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
-                capture_output=True, text=True, timeout=15
+                [mcporter, "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
+                capture_output=True, encoding="utf-8", errors="replace", timeout=15
             )
             if r.returncode == 0:
                 return "ok", "完整可用（视频解析、下载链接获取）"

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -16,7 +16,8 @@ class ExaSearchChannel(Channel):
         return False  # Search-only channel
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
                 "  npm install -g mcporter\n"
@@ -24,7 +25,8 @@ class ExaSearchChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
             )
             if "exa" in r.stdout.lower():
                 return "ok", "全网语义搜索可用（免费，无需 API Key）"

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -17,12 +17,13 @@ class GitHubChannel(Channel):
         return "github.com" in urlparse(url).netloc.lower()
 
     def check(self, config=None):
-        if not shutil.which("gh"):
+        gh = shutil.which("gh")
+        if not gh:
             return "warn", "gh CLI 未安装。安装：https://cli.github.com"
         try:
             r = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True, text=True, timeout=5
+                [gh, "auth", "status"],
+                capture_output=True, encoding="utf-8", errors="replace", timeout=5
             )
             if r.returncode == 0:
                 return "ok", "完整可用（读取、搜索、Fork、Issue、PR 等）"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -17,7 +17,8 @@ class LinkedInChannel(Channel):
         return "linkedin.com" in urlparse(url).netloc.lower()
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
                 "  pip install linkedin-scraper-mcp\n"
@@ -26,7 +27,8 @@ class LinkedInChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
             )
             if "linkedin" in r.stdout.lower():
                 return "ok", "完整可用（Profile、公司、职位搜索）"

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -26,7 +26,8 @@ class TwitterChannel(Channel):
             )
         try:
             r = subprocess.run(
-                [xreach, "auth", "check"], capture_output=True, text=True, timeout=10
+                [xreach, "auth", "check"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=10
             )
             if r.returncode == 0:
                 return "ok", "完整可用（读取、搜索推文）"

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -40,7 +40,8 @@ class XiaoHongShuChannel(Channel):
         return "xiaohongshu.com" in d or "xhslink.com" in d
 
     def check(self, config=None):
-        if not shutil.which("mcporter"):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
             return "off", (
                 "需要 mcporter + xiaohongshu-mcp。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
@@ -50,7 +51,8 @@ class XiaoHongShuChannel(Channel):
             )
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
             )
             if "xiaohongshu" not in r.stdout:
                 return "off", (
@@ -62,8 +64,8 @@ class XiaoHongShuChannel(Channel):
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
-                ["mcporter", "call", "xiaohongshu.check_login_status()"],
-                capture_output=True, text=True, timeout=10
+                [mcporter, "call", "xiaohongshu.check_login_status()"],
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10
             )
             if "已登录" in r.stdout or "logged" in r.stdout.lower():
                 return "ok", "完整可用（阅读、搜索、发帖、评论、点赞）"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -319,7 +319,7 @@ def _install_system_deps():
                 list_path = "/etc/apt/sources.list.d/github-cli.list"
                 arch = subprocess.run(
                     ["dpkg", "--print-architecture"],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                 ).stdout.strip() or "amd64"
                 subprocess.run(
                     ["curl", "-fsSL", "https://cli.github.com/packages/githubcli-archive-keyring.gpg", "-o", keyring_path],
@@ -394,7 +394,7 @@ def _install_system_deps():
             try:
                 subprocess.run(
                     ["npm", "install", "-g", "xreach-cli"],
-                    capture_output=True, text=True, timeout=120,
+                    capture_output=True, encoding="utf-8", errors="replace", timeout=120,
                 )
                 if shutil.which("xreach"):
                     print("  ✅ xreach CLI installed (Twitter search + timeline)")
@@ -407,13 +407,13 @@ def _install_system_deps():
 
     # ── undici (proxy support for Node.js fetch) ──
     if shutil.which("npm"):
-        npm_root = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True, timeout=5).stdout.strip()
+        npm_root = subprocess.run(["npm", "root", "-g"], capture_output=True, encoding="utf-8", errors="replace", timeout=5).stdout.strip()
         undici_path = os.path.join(npm_root, "undici", "index.js") if npm_root else ""
         if os.path.exists(undici_path):
             print("  ✅ undici already installed (Node.js proxy support)")
         else:
             try:
-                subprocess.run(["npm", "install", "-g", "undici"], capture_output=True, text=True, timeout=60)
+                subprocess.run(["npm", "install", "-g", "undici"], capture_output=True, encoding="utf-8", errors="replace", timeout=60)
                 print("  ✅ undici installed (Node.js proxy support)")
             except Exception:
                 print("  ⬜ undici install failed (optional — xreach may not work behind proxies)")
@@ -506,7 +506,7 @@ def _install_mcporter():
         try:
             subprocess.run(
                 ["npm", "install", "-g", "mcporter"],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=120,
             )
             if shutil.which("mcporter"):
                 print("  ✅ mcporter installed")
@@ -520,12 +520,12 @@ def _install_mcporter():
     # Configure Exa MCP (free, no key needed)
     try:
         r = subprocess.run(
-            ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+            ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
         )
         if "exa" not in r.stdout:
             subprocess.run(
                 ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             print("  ✅ Exa search configured (free, no API key needed)")
         else:
@@ -536,7 +536,7 @@ def _install_mcporter():
     # Check XiaoHongShu MCP (only if server is running)
     try:
         r = subprocess.run(
-            ["mcporter", "config", "list"], capture_output=True, text=True, timeout=5
+            ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
         )
         if "xiaohongshu" in r.stdout:
             print("  ✅ XiaoHongShu MCP already configured")
@@ -547,7 +547,7 @@ def _install_mcporter():
                 requests.get("http://localhost:18060/", timeout=3)
                 subprocess.run(
                     ["mcporter", "config", "add", "xiaohongshu", "http://localhost:18060/mcp"],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                 )
                 print("  ✅ XiaoHongShu MCP auto-detected and configured")
             except Exception:
@@ -606,7 +606,7 @@ def _detect_environment():
     # systemd-detect-virt
     try:
         import subprocess
-        result = subprocess.run(["systemd-detect-virt"], capture_output=True, text=True, timeout=3)
+        result = subprocess.run(["systemd-detect-virt"], capture_output=True, encoding="utf-8", errors="replace", timeout=3)
         if result.returncode == 0 and result.stdout.strip() != "none":
             indicators += 1
     except:
@@ -737,7 +737,7 @@ def _cmd_configure(args):
                     env["CT0"] = ct0
                     result = subprocess.run(
                         [xreach, "search", "test", "-n", "1"],
-                        capture_output=True, text=True, timeout=15,
+                        capture_output=True, encoding="utf-8", errors="replace", timeout=15,
                         env=env,
                     )
                     if result.returncode == 0 and result.stdout.strip():
@@ -828,7 +828,7 @@ def _cmd_uninstall(args):
         for mcp_name in ("exa", "xiaohongshu"):
             try:
                 r = subprocess.run(
-                    ["mcporter", "list"], capture_output=True, text=True, timeout=10
+                    ["mcporter", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=10
                 )
                 if mcp_name in r.stdout:
                     if dry_run:
@@ -836,7 +836,7 @@ def _cmd_uninstall(args):
                     else:
                         subprocess.run(
                             ["mcporter", "config", "remove", mcp_name],
-                            capture_output=True, text=True, timeout=10,
+                            capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                         )
                         print(f"  Removed mcporter entry: {mcp_name}")
                         removed_any = True
@@ -896,7 +896,7 @@ def _cmd_setup():
     else:
         try:
             r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, text=True, timeout=10
+                ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=10
             )
             if "exa" in r.stdout.lower():
                 print("  当前状态: ✅ 已配置")
@@ -906,7 +906,7 @@ def _cmd_setup():
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
                         ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
-                        capture_output=True, text=True, timeout=10,
+                        capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                     )
                     if add_r.returncode == 0:
                         print("  ✅ Exa 已配置")


### PR DESCRIPTION
Fixes #64

## Problem

On Chinese Windows systems, `agent-reach doctor` crashes or shows false errors because:

1. **Encoding**: `subprocess.run(text=True)` defaults to GBK on Chinese Windows, but upstream tools (mcporter, xreach) output UTF-8 → `UnicodeDecodeError` → silently caught → reports "连接异常"
2. **.CMD resolution**: npm global installs on Windows create `.cmd` wrapper files. `subprocess.run(["mcporter", ...])` can't find them without `shell=True` or full path resolution

## Fix

- Replace `text=True` with `encoding="utf-8", errors="replace"` in all subprocess calls (7 channel files + cli.py)
- Use `shutil.which()` resolved paths in channel `check()` methods — `shutil.which` returns the full `.cmd` path on Windows

## Changed files

- `agent_reach/channels/twitter.py` — encoding fix
- `agent_reach/channels/github.py` — encoding fix + shutil.which for gh
- `agent_reach/channels/xiaohongshu.py` — encoding fix + use resolved mcporter path
- `agent_reach/channels/bosszhipin.py` — same
- `agent_reach/channels/linkedin.py` — same
- `agent_reach/channels/douyin.py` — same
- `agent_reach/channels/exa_search.py` — same
- `agent_reach/cli.py` — encoding fix (all 15 subprocess calls)

## Testing

- All syntax checks pass
- `agent-reach doctor` runs correctly (9/12 channels OK)
- Existing tests pass (1 pre-existing environment-dependent failure unrelated to this change)