### PR TITLE
feat: add WeChat Official Account channel

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -19,6 +19,7 @@ from .xiaohongshu import XiaoHongShuChannel
 from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
+from .wechat import WeChatChannel
 
 
 # Channel registry
@@ -32,6 +33,7 @@ ALL_CHANNELS: List[Channel] = [
     DouyinChannel(),
     LinkedInChannel(),
     BossZhipinChannel(),
+    WeChatChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/wechat.py
+++ b/agent_reach/channels/wechat.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""WeChat Official Account articles — check if wechat-article-for-ai is available."""
+
+import shutil
+import subprocess
+from .base import Channel
+
+
+class WeChatChannel(Channel):
+    name = "wechat"
+    description = "微信公众号文章"
+    backends = ["wechat-article-for-ai (Camoufox)"]
+    tier = 2
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "mp.weixin.qq.com" in d or "weixin.qq.com" in d
+
+    def check(self, config=None):
+        try:
+            import camoufox  # noqa: F401
+        except ImportError:
+            return "off", (
+                "需要 wechat-article-for-ai。安装：\n"
+                "  pip install camoufox[geoip] markdownify beautifulsoup4 httpx mcp\n"
+                "  # 或完整安装：\n"
+                "  git clone https://github.com/bzd6661/wechat-article-for-ai.git\n"
+                "  cd wechat-article-for-ai && pip install -r requirements.txt\n"
+                "  详见 https://github.com/bzd6661/wechat-article-for-ai"
+            )
+        return "ok", "可读取微信公众号文章（URL → Markdown）"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -3,7 +3,7 @@ name: agent-reach
 description: >
   Give your AI agent eyes to see the entire internet. Install and configure
   upstream tools for Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu,
-  Douyin, LinkedIn, Boss直聘, RSS, and any web page — then call them directly.
+  Douyin, LinkedIn, Boss直聘, WeChat (微信公众号), RSS, and any web page — then call them directly.
   Use when: (1) setting up platform access tools for the first time,
   (2) checking which platforms are available,
   (3) user asks to configure/enable a platform channel.
@@ -252,6 +252,23 @@ mcporter call 'bosszhipin.get_job_detail_tool(job_url: "https://www.zhipin.com/j
 ```
 
 Fallback: `curl -s "https://r.jina.ai/https://www.zhipin.com/job_detail/xxx"`
+
+### 微信公众号 (wechat-article-for-ai)
+
+Uses Camoufox (stealth Firefox) to bypass WeChat's anti-bot detection and extract full article content.
+
+```bash
+# Read a WeChat article (returns Markdown with images)
+cd /path/to/wechat-article-for-ai && python3 main.py "https://mp.weixin.qq.com/s/ARTICLE_ID"
+
+# Batch convert multiple articles
+python3 main.py "URL1" "URL2" "URL3" -o ./output
+
+# Run as MCP server (for AI agent integration)
+python3 mcp_server.py
+```
+
+Note: WeChat articles require a real browser to render. Jina Reader and curl cannot read them.
 
 ### RSS (feedparser)
 


### PR DESCRIPTION
Closes #54

## What

New channel: `wechat` (微信公众号文章) — Agent Reach's 13th channel.

## Backend

[`bzd6661/wechat-article-for-ai`](https://github.com/bzd6661/wechat-article-for-ai) — uses Camoufox (stealth Firefox) to bypass WeChat's anti-bot detection and extract full article content as clean Markdown.

**Tested on this server:**
- ✅ `OpenAI自建代码平台：一场价值130亿美元的"分手"预谋` — title, author, full text, images all extracted
- ✅ `美军，突然引爆！OpenAI，利空突袭！` — same, 3256 chars + 2 images

## Why Camoufox instead of Jina Reader / curl

WeChat articles use dynamic JS rendering + anti-bot detection. Jina Reader returns `System error`, curl gets empty HTML. A stealth browser is the only reliable approach (same principle Kimi uses internally with their \$web_search tool).

## Changes

- `agent_reach/channels/wechat.py` — new channel, checks for `camoufox` package
- `agent_reach/channels/__init__.py` — register channel
- `agent_reach/skill/SKILL.md` — usage docs

## Tests

All 6 tests pass. Doctor shows 10/13 channels available.