### PR TITLE
fix(windows): use shutil.which() for npm subprocess calls

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -410,14 +410,15 @@ def _install_system_deps():
             print("  ⬜ xreach CLI requires Node.js (optional — Twitter reading still works via Jina)")
 
     # ── undici (proxy support for Node.js fetch) ──
-    if shutil.which("npm"):
-        npm_root = subprocess.run(["npm", "root", "-g"], capture_output=True, encoding="utf-8", errors="replace", timeout=5).stdout.strip()
+    npm_cmd = shutil.which("npm")
+    if npm_cmd:
+        npm_root = subprocess.run([npm_cmd, "root", "-g"], capture_output=True, encoding="utf-8", errors="replace", timeout=5).stdout.strip()
         undici_path = os.path.join(npm_root, "undici", "index.js") if npm_root else ""
         if os.path.exists(undici_path):
             print("  ✅ undici already installed (Node.js proxy support)")
         else:
             try:
-                subprocess.run(["npm", "install", "-g", "undici"], capture_output=True, encoding="utf-8", errors="replace", timeout=60)
+                subprocess.run([npm_cmd, "install", "-g", "undici"], capture_output=True, encoding="utf-8", errors="replace", timeout=60)
                 print("  ✅ undici installed (Node.js proxy support)")
             except Exception:
                 print("  ⬜ undici install failed (optional — xreach may not work behind proxies)")


### PR DESCRIPTION
Two `subprocess.run(["npm", ...])` calls in undici installation were using bare command name → fails on Windows where npm is `npm.cmd`. Now resolves full path via `shutil.which()`, consistent with all other subprocess calls.