### PR TITLE
fix: set MCPORTER_CONFIG env for all mcporter subprocess calls

### DIFF
--- a/agent_reach/channels/base.py
+++ b/agent_reach/channels/base.py
@@ -10,6 +10,7 @@ and provides:
 After installation, agents call upstream tools directly.
 """
 
+import os
 import shutil
 from abc import ABC, abstractmethod
 from typing import List, Tuple
@@ -22,6 +23,13 @@ class Channel(ABC):
     description: str = ""             # e.g. "YouTube 视频和字幕"
     backends: List[str] = []          # e.g. ["yt-dlp"] — what upstream tool is used
     tier: int = 0                     # 0=zero-config, 1=needs free key, 2=needs setup
+
+    @staticmethod
+    def get_mcporter_env() -> dict:
+        """Get environment with MCPORTER_CONFIG set for all mcporter commands."""
+        env = os.environ.copy()
+        env["MCPORTER_CONFIG"] = os.path.expanduser("~/.mcporter/mcporter.json")
+        return env
 
     @abstractmethod
     def can_handle(self, url: str) -> bool:

--- a/agent_reach/channels/bosszhipin.py
+++ b/agent_reach/channels/bosszhipin.py
@@ -14,6 +14,7 @@ class BossZhipinChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         domain = urlparse(url).netloc.lower()
         return "zhipin.com" in domain or "boss.com" in domain
 
@@ -25,12 +26,17 @@ class BossZhipinChannel(Channel):
                 "  1. git clone https://github.com/mucsbr/mcp-bosszp.git\n"
                 "  2. cd mcp-bosszp && pip install -r requirements.txt && playwright install chromium\n"
                 "  3. python boss_zhipin_fastmcp_v2.py（启动后扫码登录）\n"
-                "  4. mcporter config add bosszhipin http://localhost:8000/mcp"
+                "  4. export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
+                "  5. mcporter config add bosszhipin http://localhost:8000/mcp"
             )
         try:
             r = subprocess.run(
-                [mcporter, "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=10
+                [mcporter, "list"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+                env=self.get_mcporter_env(),
             )
             out = r.stdout.lower()
             if "boss" in out or "zhipin" in out:
@@ -38,6 +44,7 @@ class BossZhipinChannel(Channel):
         except Exception:
             pass
         return "off", (
-            "mcporter 已装但 Boss直聘 MCP 未配置。\n"
+            "mcporter 已装但 Boss直聘 MCP 未配置。运行：\n"
+            "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
             "  详见 https://github.com/mucsbr/mcp-bosszp"
         )

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -14,6 +14,7 @@ class DouyinChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         d = urlparse(url).netloc.lower()
         return "douyin.com" in d or "iesdouyin.com" in d
 
@@ -25,17 +26,24 @@ class DouyinChannel(Channel):
                 "  1. npm install -g mcporter\n"
                 "  2. pip install douyin-mcp-server\n"
                 "  3. 启动服务（见下方说明）\n"
-                "  4. mcporter config add douyin http://localhost:18070/mcp\n"
+                "  4. export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
+                "  5. mcporter config add douyin http://localhost:18070/mcp\n"
                 "  详见 https://github.com/yzfly/douyin-mcp-server"
             )
         try:
+            env = self.get_mcporter_env()
             r = subprocess.run(
-                [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                [mcporter, "config", "list"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                env=env,
             )
             if "douyin" not in r.stdout:
                 return "off", (
                     "mcporter 已装但抖音 MCP 未配置。运行：\n"
+                    "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
                     "  pip install douyin-mcp-server\n"
                     "  # 启动服务后：\n"
                     "  mcporter config add douyin http://localhost:18070/mcp"
@@ -44,8 +52,16 @@ class DouyinChannel(Channel):
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
-                [mcporter, "call", "douyin.parse_douyin_video_info(share_link: \"https://www.douyin.com\")"],
-                capture_output=True, encoding="utf-8", errors="replace", timeout=15
+                [
+                    mcporter,
+                    "call",
+                    'douyin.parse_douyin_video_info(share_link: "https://www.douyin.com")',
+                ],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
+                env=env,
             )
             if r.returncode == 0:
                 return "ok", "完整可用（视频解析、下载链接获取）"

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -25,13 +25,18 @@ class ExaSearchChannel(Channel):
             )
         try:
             r = subprocess.run(
-                [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                [mcporter, "config", "list"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                env=self.get_mcporter_env(),
             )
             if "exa" in r.stdout.lower():
                 return "ok", "全网语义搜索可用（免费，无需 API Key）"
             return "off", (
                 "mcporter 已装但 Exa 未配置。运行：\n"
+                "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
                 "  mcporter config add exa https://mcp.exa.ai/mcp"
             )
         except Exception:

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -14,6 +14,7 @@ class LinkedInChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         return "linkedin.com" in urlparse(url).netloc.lower()
 
     def check(self, config=None):
@@ -22,13 +23,18 @@ class LinkedInChannel(Channel):
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
                 "  pip install linkedin-scraper-mcp\n"
+                "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
                 "  mcporter config add linkedin http://localhost:3000/mcp\n"
                 "  详见 https://github.com/stickerdaniel/linkedin-mcp-server"
             )
         try:
             r = subprocess.run(
-                [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                [mcporter, "config", "list"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                env=self.get_mcporter_env(),
             )
             if "linkedin" in r.stdout.lower():
                 return "ok", "完整可用（Profile、公司、职位搜索）"
@@ -36,6 +42,7 @@ class LinkedInChannel(Channel):
             pass
         return "off", (
             "mcporter 已装但 LinkedIn MCP 未配置。运行：\n"
+            "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
             "  pip install linkedin-scraper-mcp\n"
             "  mcporter config add linkedin http://localhost:3000/mcp"
         )

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -36,6 +36,7 @@ class XiaoHongShuChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         d = urlparse(url).netloc.lower()
         return "xiaohongshu.com" in d or "xhslink.com" in d
 
@@ -45,19 +46,27 @@ class XiaoHongShuChannel(Channel):
             return "off", (
                 "需要 mcporter + xiaohongshu-mcp。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
-                "  2. " + _docker_run_hint().strip() + "\n"
-                "  3. mcporter config add xiaohongshu http://localhost:18060/mcp\n"
+                "  2. export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
+                "  3. " + _docker_run_hint().strip() + "\n"
+                "  4. mcporter config add xiaohongshu http://localhost:18060/mcp\n"
                 "  详见 https://github.com/xpzouying/xiaohongshu-mcp"
             )
         try:
+            env = self.get_mcporter_env()
             r = subprocess.run(
-                [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                [mcporter, "config", "list"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                env=env,
             )
             if "xiaohongshu" not in r.stdout:
                 return "off", (
                     "mcporter 已装但小红书 MCP 未配置。运行：\n"
-                    + _docker_run_hint() + "\n"
+                    "  export MCPORTER_CONFIG=~/.mcporter/mcporter.json\n"
+                    + _docker_run_hint()
+                    + "\n"
                     "  mcporter config add xiaohongshu http://localhost:18060/mcp"
                 )
         except Exception:
@@ -65,7 +74,11 @@ class XiaoHongShuChannel(Channel):
         try:
             r = subprocess.run(
                 [mcporter, "call", "xiaohongshu.check_login_status()"],
-                capture_output=True, encoding="utf-8", errors="replace", timeout=10
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+                env=env,
             )
             if "已登录" in r.stdout or "logged" in r.stdout.lower():
                 return "ok", "完整可用（阅读、搜索、发帖、评论、点赞）"

--- a/agent_reach/guides/setup-exa.md
+++ b/agent_reach/guides/setup-exa.md
@@ -11,7 +11,12 @@ Exa 是一个 AI 语义搜索引擎。通过 MCP 接入，**免费、无需 API 
 `agent-reach install --env=auto` 会自动完成以下步骤，通常不需要手动操作。
 
 ### 1. 安装 mcporter
+
 ```bash
+# 添加到 ~/.zshrc 或 ~/.bashrc
+export MCPORTER_CONFIG=~/.mcporter/mcporter.json
+
+# 安装 mcporter
 npm install -g mcporter
 ```
 

--- a/agent_reach/guides/setup-xiaohongshu.md
+++ b/agent_reach/guides/setup-xiaohongshu.md
@@ -10,7 +10,12 @@
 ## Agent 可自动完成的步骤
 
 ### 1. 安装 mcporter
+
 ```bash
+# 添加到 ~/.zshrc 或 ~/.bashrc
+export MCPORTER_CONFIG=~/.mcporter/mcporter.json
+
+# 安装 mcporter
 npm install -g mcporter
 ```
 
@@ -57,10 +62,11 @@ agent-reach doctor
 **Q: Docker 容器重启后 cookie 丢了？**
 A: 挂载数据卷持久化：
 ```bash
+mkdir -p ~/.agent-reach/xhs-data
 docker run -d \
   --name xiaohongshu-mcp \
   -p 18060:18060 \
-  -v xhs-data:/app/data \
+  -v ~/.agent-reach/xhs-data:/app/data \
   xpzouying/xiaohongshu-mcp
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,6 +139,9 @@ agent-reach configure proxy http://user:pass@ip:port
 > "小红书需要一个 MCP 服务。需要你的机器上有 Docker。安装好 Docker 后我来搞定剩下的。"
 
 ```bash
+# 设置 mcporter 配置路径（推荐添加到 ~/.zshrc 或 ~/.bashrc）
+export MCPORTER_CONFIG=~/.mcporter/mcporter.json
+
 docker run -d --name xiaohongshu-mcp -p 18060:18060 xpzouying/xiaohongshu-mcp
 mcporter config add xiaohongshu http://localhost:18060/mcp
 ```
@@ -174,6 +177,9 @@ mcp.settings.host = '127.0.0.1'
 mcp.settings.port = 18070
 mcp.run(transport='streamable-http')
 "
+
+# 设置 mcporter 配置路径
+export MCPORTER_CONFIG=~/.mcporter/mcporter.json
 
 # 3. 注册到 mcporter
 mcporter config add douyin http://localhost:18070/mcp


### PR DESCRIPTION
## Summary
- Add `get_mcporter_env()` static method to base Channel class to set `MCPORTER_CONFIG` environment variable
- Update all mcporter subprocess calls to use this environment for consistent config path resolution
- Update documentation to include `export MCPORTER_CONFIG=~/.mcporter/mcporter.json` instruction

## Changes
- `base.py`: Add `get_mcporter_env()` method
- `bosszhipin.py`, `douyin.py`, `exa_search.py`, `linkedin.py`, `xiaohongshu.py`: Pass `env=self.get_mcporter_env()` to subprocess calls
- `setup-exa.md`, `setup-xiaohongshu.md`, `install.md`: Add MCPORTER_CONFIG export instruction

This ensures all mcporter commands use the correct config file location.