### PR TITLE
docs: add update one-liner to English README

### DIFF
--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -39,6 +39,12 @@ Install Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/m
 
 Copy that to your Agent. A few minutes later, it can read tweets, search Reddit, and watch Bilibili.
 
+**Already installed? Update in one command:**
+
+```
+Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
+```
+
 ### ✅ Before you start, you might want to know
 
 | | |
@@ -82,6 +88,11 @@ Install Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/m
 ```
 
 The Agent auto-installs, detects your environment, and tells you what's ready.
+
+> 🔄 **Already installed?** Update in one command:
+> ```
+> Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
+> ```
 
 <details>
 <summary>Manual install</summary>

--- a/docs/update.md
+++ b/docs/update.md
@@ -8,6 +8,12 @@ Copy this to your AI Agent:
 帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
 ```
 
+Or in English:
+
+```
+Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
+```
+
 ---
 
 ## For AI Agents


### PR DESCRIPTION
English README was missing the update one-liner. Now both READMEs have it:

```
Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
```

Also added English version to update.md's 'For Humans' section.