### PR TITLE
feat: add Weibo (微博) channel

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,6 +20,7 @@ from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
 from .wechat import WeChatChannel
+from .weibo import WeiboChannel
 
 
 # Channel registry
@@ -34,6 +35,7 @@ ALL_CHANNELS: List[Channel] = [
     LinkedInChannel(),
     BossZhipinChannel(),
     WeChatChannel(),
+    WeiboChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/weibo.py
+++ b/agent_reach/channels/weibo.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Weibo (微博) — check if mcporter + weibo MCP server is available."""
+
+import shutil
+import subprocess
+from .base import Channel
+
+
+class WeiboChannel(Channel):
+    name = "weibo"
+    description = "微博动态和热搜"
+    backends = ["mcp-server-weibo"]
+    tier = 2
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "weibo.com" in d or "weibo.cn" in d
+
+    def check(self, config=None):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
+            return "off", (
+                "需要 mcporter + mcp-server-weibo。安装步骤：\n"
+                "  1. npm install -g mcporter\n"
+                "  2. docker run -d --name mcp-server-weibo -p 4200:4200 mcp-server-weibo\n"
+                "     或：uvx mcp-server-weibo（需要 uv）\n"
+                "  3. mcporter config add weibo http://localhost:4200/mcp\n"
+                "  详见 https://github.com/qinyuanpei/mcp-server-weibo"
+            )
+        try:
+            r = subprocess.run(
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
+            )
+            if "weibo" not in r.stdout:
+                return "off", (
+                    "mcporter 已装但微博 MCP 未配置。运行：\n"
+                    "  docker run -d --name mcp-server-weibo -p 4200:4200 mcp-server-weibo\n"
+                    "  mcporter config add weibo http://localhost:4200/mcp"
+                )
+        except Exception:
+            return "off", "mcporter 连接异常"
+        try:
+            r = subprocess.run(
+                [mcporter, "call", "weibo.get_hot_searches()"],
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10
+            )
+            if r.returncode == 0 and r.stdout.strip():
+                return "ok", "完整可用（热搜、搜索用户/内容、读动态）"
+            return "warn", "MCP 已连接但调用异常，检查 mcp-server-weibo 服务是否在运行"
+        except Exception:
+            return "warn", "MCP 连接异常，检查 mcp-server-weibo 服务是否在运行"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: agent-reach
 description: >
-  Use the internet: search, read, and interact with 13+ platforms including
+  Use the internet: search, read, and interact with 14+ platforms including
   Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu (小红书), Douyin (抖音),
-  WeChat Articles (微信公众号), LinkedIn, Boss直聘, RSS, Exa web search, and any web page.
+  WeChat Articles (微信公众号), Weibo (微博), LinkedIn, Boss直聘, RSS, Exa web search, and any web page.
   Use when: (1) user asks to search or read any of these platforms,
   (2) user shares a URL from any supported platform,
   (3) user asks to search the web, find information online, or research a topic,
@@ -13,13 +13,14 @@ description: >
   "search twitter", "read tweet", "youtube transcript", "search reddit",
   "read this link", "看这个链接", "B站", "bilibili", "抖音视频",
   "微信文章", "公众号", "LinkedIn", "GitHub issue", "RSS",
+  "微博", "Weibo", "热搜",
   "search online", "web search", "find information", "research",
   "帮我配", "configure twitter", "configure proxy", "帮我安装".
 ---
 
 # Agent Reach — Usage Guide
 
-Upstream tools for 13+ platforms. Call them directly.
+Upstream tools for 14+ platforms. Call them directly.
 
 Run `agent-reach doctor` to check which channels are available.
 
@@ -144,6 +145,31 @@ mcporter call 'bosszhipin.search_jobs_tool(keyword: "Python", city: "北京")'
 ```
 
 Fallback: `curl -s "https://r.jina.ai/https://www.zhipin.com/job_detail/xxx"`
+
+## 微博 / Weibo (mcporter)
+
+```bash
+# 热搜榜
+mcporter call 'weibo.get_hot_searches()'
+
+# 搜索用户
+mcporter call 'weibo.search_users(keyword: "AI agent", limit: 5)'
+
+# 获取用户信息
+mcporter call 'weibo.get_profile(uid: "1669879400")'
+
+# 获取用户动态
+mcporter call 'weibo.get_statuses(uid: "1669879400", limit: 10)'
+
+# 搜索微博内容
+mcporter call 'weibo.search_content(keyword: "人工智能", limit: 5)'
+
+# 获取粉丝/关注列表
+mcporter call 'weibo.get_followers(uid: "1669879400", limit: 10)'
+```
+
+> Requires mcp-server-weibo. Install: `docker run -d --name mcp-server-weibo -p 4200:4200 mcp-server-weibo`
+> Then: `mcporter config add weibo http://localhost:4200/mcp`
 
 ## RSS
 

--- a/tests/test_weibo_channel.py
+++ b/tests/test_weibo_channel.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Tests for Weibo channel."""
+
+import pytest
+from agent_reach.channels.weibo import WeiboChannel
+
+
+class TestWeiboChannel:
+    def setup_method(self):
+        self.ch = WeiboChannel()
+
+    def test_can_handle_weibo_com(self):
+        assert self.ch.can_handle("https://weibo.com/1669879400/LxS6o5yGQ")
+        assert self.ch.can_handle("https://www.weibo.com/u/1234567")
+        assert self.ch.can_handle("https://m.weibo.com/detail/5144480215658498")
+
+    def test_can_handle_weibo_cn(self):
+        assert self.ch.can_handle("https://weibo.cn/u/1234567")
+        assert self.ch.can_handle("https://m.weibo.cn/detail/5144480215658498")
+
+    def test_cannot_handle_other_url(self):
+        assert not self.ch.can_handle("https://twitter.com/test")
+        assert not self.ch.can_handle("https://github.com/test/repo")
+        assert not self.ch.can_handle("https://xiaohongshu.com/explore/123")
+
+    def test_check_returns_tuple(self):
+        result = self.ch.check()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert result[0] in ("ok", "warn", "off", "error")
+        assert isinstance(result[1], str)
+
+    def test_metadata(self):
+        assert self.ch.name == "weibo"
+        assert self.ch.tier == 2
+        assert "weibo" in self.ch.backends[0].lower()


### PR DESCRIPTION
## 🆕 新增微博渠道

加入了微博渠道，通过 [mcp-server-weibo](https://github.com/qinyuanpei/mcp-server-weibo) 实现热搜、用户搜索、内容搜索、用户动态读取等功能。

### 功能

| 功能 | 命令 |
|------|------|
| 热搜榜 | `mcporter call 'weibo.get_hot_searches()'` |
| 搜索用户 | `mcporter call 'weibo.search_users(keyword: "AI", limit: 5)'` |
| 搜索内容 | `mcporter call 'weibo.search_content(keyword: "AI", limit: 5)'` |
| 用户动态 | `mcporter call 'weibo.get_statuses(uid: "xxx", limit: 10)'` |
| 用户信息 | `mcporter call 'weibo.get_profile(uid: "xxx")'` |

### 改动

- 新增 `channels/weibo.py`（Tier 2，需要 MCP 服务）
- 注册到 `channels/__init__.py`
- 更新 `SKILL.md` 加入 mcporter 命令示例
- 新增 5 个测试，全部通过
- 渠道数量 +1

### 为什么用 MCP

微博目前反爬很严格，不登录连热搜 API 都返回 403。mcp-server-weibo（⭐34）通过 Cookie 认证解决了这个问题，和小红书、抖音的接入方式一致。