### PR TITLE
feat: add Stack Exchange channel (StackOverflow + 170 sites)

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,6 +20,7 @@ from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
 from .wechat import WeChatChannel
+from .stackexchange import StackExchangeChannel
 
 
 # Channel registry
@@ -27,6 +28,7 @@ ALL_CHANNELS: List[Channel] = [
     GitHubChannel(),
     TwitterChannel(),
     YouTubeChannel(),
+    StackExchangeChannel(),
     RedditChannel(),
     BilibiliChannel(),
     XiaoHongShuChannel(),

--- a/agent_reach/channels/stackexchange.py
+++ b/agent_reach/channels/stackexchange.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Stack Exchange — Q&A search across 170+ sites (StackOverflow, Bioinformatics, etc.)."""
+
+import subprocess
+from .base import Channel
+
+
+class StackExchangeChannel(Channel):
+    name = "stackexchange"
+    description = "Stack Exchange 问答（StackOverflow 等 170+ 子站）"
+    backends = ["Stack Exchange API"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return any(x in d for x in [
+            "stackoverflow.com", "stackexchange.com",
+            "superuser.com", "serverfault.com",
+            "askubuntu.com", "mathoverflow.net",
+        ])
+
+    def check(self, config=None):
+        try:
+            r = subprocess.run(
+                ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+                 "--compressed",
+                 "https://api.stackexchange.com/2.3/info?site=stackoverflow",
+                 "--connect-timeout", "10"],
+                capture_output=True, encoding="utf-8", timeout=15,
+            )
+            if r.stdout.strip() == "200":
+                return "ok", "Stack Exchange API 可用（免费，无需 API Key，300 请求/天）"
+            return "warn", f"Stack Exchange API 返回 HTTP {r.stdout.strip()}"
+        except Exception as e:
+            return "warn", f"Stack Exchange API 连接失败：{e}"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -2,8 +2,9 @@
 name: agent-reach
 description: >
   Use the internet: search, read, and interact with 13+ platforms including
-  Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu (小红书), Douyin (抖音),
-  WeChat Articles (微信公众号), LinkedIn, Boss直聘, RSS, Exa web search, and any web page.
+  Twitter/X, Reddit, YouTube, GitHub, Stack Exchange (StackOverflow), Bilibili,
+  XiaoHongShu (小红书), Douyin (抖音), WeChat Articles (微信公众号), LinkedIn,
+  Boss直聘, RSS, Exa web search, and any web page.
   Use when: (1) user asks to search or read any of these platforms,
   (2) user shares a URL from any supported platform,
   (3) user asks to search the web, find information online, or research a topic,
@@ -13,6 +14,7 @@ description: >
   "search twitter", "read tweet", "youtube transcript", "search reddit",
   "read this link", "看这个链接", "B站", "bilibili", "抖音视频",
   "微信文章", "公众号", "LinkedIn", "GitHub issue", "RSS",
+  "stackoverflow", "stack exchange", "stackexchange",
   "search online", "web search", "find information", "research",
   "帮我配", "configure twitter", "configure proxy", "帮我安装".
 ---
@@ -75,6 +77,22 @@ curl -s "https://www.reddit.com/search.json?q=QUERY&limit=10" -H "User-Agent: ag
 ```
 
 > Server IPs may get 403. Search via Exa instead, or configure proxy.
+
+## Stack Exchange / StackOverflow (API)
+
+```bash
+# Search questions (170+ sites: stackoverflow, bioinformatics, biology, stats, etc.)
+curl -s --compressed "https://api.stackexchange.com/2.3/search/advanced?order=desc&sort=votes&q=QUERY&site=stackoverflow&pagesize=10"
+
+# Get question details with body
+curl -s --compressed "https://api.stackexchange.com/2.3/questions/QUESTION_ID?site=stackoverflow&filter=withbody"
+
+# Get answers for a question
+curl -s --compressed "https://api.stackexchange.com/2.3/questions/QUESTION_ID/answers?order=desc&sort=votes&site=stackoverflow&filter=withbody"
+```
+
+> Zero-config. Free API, no key needed (300 req/day; register for 10,000/day).
+> Change `site=` to target different communities: `bioinformatics`, `biology`, `stats`, `datascience`, etc.
 
 ## GitHub (gh CLI)
 

--- a/tests/test_stackexchange_channel.py
+++ b/tests/test_stackexchange_channel.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Stack Exchange channel."""
+
+import unittest
+from agent_reach.channels.stackexchange import StackExchangeChannel
+
+
+class TestStackExchangeChannel(unittest.TestCase):
+    def setUp(self):
+        self.ch = StackExchangeChannel()
+
+    # ---- metadata ----
+    def test_name(self):
+        self.assertEqual(self.ch.name, "stackexchange")
+
+    def test_tier(self):
+        self.assertEqual(self.ch.tier, 0)
+
+    def test_backends(self):
+        self.assertIn("Stack Exchange API", self.ch.backends)
+
+    # ---- can_handle ----
+    def test_handle_stackoverflow(self):
+        self.assertTrue(self.ch.can_handle("https://stackoverflow.com/questions/12345"))
+
+    def test_handle_stackoverflow_search(self):
+        self.assertTrue(self.ch.can_handle("https://stackoverflow.com/search?q=python"))
+
+    def test_handle_stackexchange_subdomain(self):
+        self.assertTrue(self.ch.can_handle("https://bioinformatics.stackexchange.com/questions/123"))
+
+    def test_handle_superuser(self):
+        self.assertTrue(self.ch.can_handle("https://superuser.com/questions/123"))
+
+    def test_handle_serverfault(self):
+        self.assertTrue(self.ch.can_handle("https://serverfault.com/questions/123"))
+
+    def test_handle_askubuntu(self):
+        self.assertTrue(self.ch.can_handle("https://askubuntu.com/questions/123"))
+
+    def test_handle_mathoverflow(self):
+        self.assertTrue(self.ch.can_handle("https://mathoverflow.net/questions/123"))
+
+    def test_reject_non_stackexchange(self):
+        self.assertFalse(self.ch.can_handle("https://www.google.com"))
+
+    def test_reject_quora(self):
+        self.assertFalse(self.ch.can_handle("https://www.quora.com/question"))
+
+    def test_reject_zhihu(self):
+        self.assertFalse(self.ch.can_handle("https://www.zhihu.com/question/123"))
+
+    # ---- check ----
+    def test_check_returns_tuple(self):
+        status, msg = self.ch.check()
+        self.assertIn(status, ("ok", "warn"))
+        self.assertIsInstance(msg, str)
+
+    # ---- registration ----
+    def test_registered(self):
+        from agent_reach.channels import ALL_CHANNELS
+        names = [c.name for c in ALL_CHANNELS]
+        self.assertIn("stackexchange", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a Stack Exchange channel covering StackOverflow and 170+ community Q&A sites via the official free API.

## Why

Stack Exchange is the largest Q&A platform globally, covering programming (StackOverflow), bioinformatics, statistics, mathematics, DevOps, and more. The API is free, well-documented, and requires zero configuration.

## Changes

- `agent_reach/channels/stackexchange.py` — 36-line channel module
  - `can_handle()`: matches `stackoverflow.com`, `*.stackexchange.com`, `superuser.com`, `serverfault.com`, `askubuntu.com`, `mathoverflow.net`
  - `check()`: verifies API connectivity via `/info` endpoint
  - Tier 0: no API key required (300 req/day free; 10,000/day with free registered key)
- `agent_reach/channels/__init__.py` — registered `StackExchangeChannel` in `ALL_CHANNELS`
- `agent_reach/skill/SKILL.md` — added usage examples (search, question details, answers)
- `tests/test_stackexchange_channel.py` — 15 tests (metadata, URL matching for 7 domains, rejection tests, check, registration)

## Design

- **Backend**: Official Stack Exchange API v2.3 (REST, JSON, gzip)
- **Tier 0**: Completely free, no API key needed
- **Scope**: 170+ sites via `site=` parameter (stackoverflow, bioinformatics, biology, stats, datascience, etc.)

## Testing

```
$ python3 -m pytest tests/test_stackexchange_channel.py -v
============================= 15 passed in 0.71s ==============================

$ agent-reach doctor
✅ Stack Exchange 问答（StackOverflow 等 170+ 子站） — Stack Exchange API 可用（免费，无需 API Key，300 请求/天）
```

E2E search on bioinformatics.stackexchange.com:
```
$ curl -s --compressed "https://api.stackexchange.com/2.3/search/advanced?q=single+cell+RNA+seq&site=bioinformatics&pagesize=3"
→ 5 results, [22★] What is the actual cause of excessive zeroes in scRNA-seq...
  Quota: 292/300
```