### PR TITLE
feat: add Hacker News channel (Tier 0) — Firebase API + Algolia Search

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,6 +20,7 @@ from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
 from .wechat import WeChatChannel
+from .hackernews import HackerNewsChannel
 
 
 # Channel registry
@@ -33,6 +34,7 @@ ALL_CHANNELS: List[Channel] = [
     DouyinChannel(),
     LinkedInChannel(),
     BossZhipinChannel(),
+    HackerNewsChannel(),
     WeChatChannel(),
     RSSChannel(),
     ExaSearchChannel(),

--- a/agent_reach/channels/hackernews.py
+++ b/agent_reach/channels/hackernews.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Hacker News — tech community via official Firebase API + Algolia search."""
+
+from .base import Channel
+
+
+class HackerNewsChannel(Channel):
+    name = "hackernews"
+    description = "Hacker News 技术社区"
+    backends = ["Firebase API", "Algolia Search"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        host = urlparse(url).netloc.lower()
+        return "news.ycombinator.com" in host or "hn.algolia.com" in host
+
+    def check(self, config=None):
+        import json
+        import urllib.request
+        try:
+            req = urllib.request.Request(
+                "https://hacker-news.firebaseio.com/v0/topstories.json",
+                headers={"User-Agent": "Mozilla/5.0"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as r:
+                if r.status == 200:
+                    ids = json.loads(r.read())
+                    if ids:
+                        return "ok", f"Firebase API 可用，{len(ids)} top stories"
+        except Exception:
+            pass
+        return "warn", "API 暂不可达，可能需要代理"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -3,7 +3,8 @@ name: agent-reach
 description: >
   Use the internet: search, read, and interact with 13+ platforms including
   Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu (小红书), Douyin (抖音),
-  WeChat Articles (微信公众号), LinkedIn, Boss直聘, RSS, Exa web search, and any web page.
+  WeChat Articles (微信公众号), LinkedIn, Boss直聘, Hacker News,
+  RSS, Exa web search, and any web page.
   Use when: (1) user asks to search or read any of these platforms,
   (2) user shares a URL from any supported platform,
   (3) user asks to search the web, find information online, or research a topic,
@@ -14,7 +15,8 @@ description: >
   "read this link", "看这个链接", "B站", "bilibili", "抖音视频",
   "微信文章", "公众号", "LinkedIn", "GitHub issue", "RSS",
   "search online", "web search", "find information", "research",
-  "帮我配", "configure twitter", "configure proxy", "帮我安装".
+  "帮我配", "configure twitter", "configure proxy", "帮我安装",
+  "hacker news", "HN", "ycombinator".
 ---
 
 # Agent Reach — Usage Guide
@@ -144,6 +146,41 @@ mcporter call 'bosszhipin.search_jobs_tool(keyword: "Python", city: "北京")'
 ```
 
 Fallback: `curl -s "https://r.jina.ai/https://www.zhipin.com/job_detail/xxx"`
+
+## Hacker News (Official Firebase API + Algolia Search)
+
+**Top/New/Best stories:**
+```bash
+# Get story IDs (top/new/best/ask/show/jobs)
+curl -s "https://hacker-news.firebaseio.com/v0/topstories.json"
+
+# Get item details (story, comment, poll, job)
+curl -s "https://hacker-news.firebaseio.com/v0/item/<ID>.json"
+```
+
+> Returns JSON with `title`, `url`, `score`, `by`, `descendants` (comment count), `kids` (child comment IDs).
+
+**Read comments:**
+```bash
+# Get comment IDs from story's "kids" field, then fetch each
+curl -s "https://hacker-news.firebaseio.com/v0/item/<COMMENT_ID>.json"
+```
+
+> Returns `text` (HTML), `by`, `time`, `kids` (replies). Walk the tree for full thread.
+
+**Search (Algolia — full-text, free, no API key):**
+```bash
+# Search stories
+curl -s "https://hn.algolia.com/api/v1/search?query=QUERY&tags=story&hitsPerPage=10"
+
+# Search comments
+curl -s "https://hn.algolia.com/api/v1/search?query=QUERY&tags=comment&hitsPerPage=10"
+
+# Filter by date
+curl -s "https://hn.algolia.com/api/v1/search_by_date?query=QUERY&tags=story&hitsPerPage=10"
+```
+
+> Returns `hits[]` with `title`, `url`, `points`, `num_comments`, `author`, `story_text`. Supports `numericFilters` for score/date filtering.
 
 ## RSS
 

--- a/tests/test_hackernews_channel.py
+++ b/tests/test_hackernews_channel.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Tests for Hacker News channel."""
+
+import pytest
+from agent_reach.channels.hackernews import HackerNewsChannel
+
+
+@pytest.fixture
+def ch():
+    return HackerNewsChannel()
+
+
+# ── metadata ──
+
+def test_metadata(ch):
+    assert ch.name == "hackernews"
+    assert ch.tier == 0
+    assert "Firebase API" in ch.backends
+    assert "Algolia Search" in ch.backends
+
+
+# ── can_handle: positive ──
+
+@pytest.mark.parametrize("url", [
+    "https://news.ycombinator.com/",
+    "https://news.ycombinator.com/item?id=47282736",
+    "https://news.ycombinator.com/newest",
+    "https://news.ycombinator.com/ask",
+    "https://news.ycombinator.com/show",
+    "https://news.ycombinator.com/jobs",
+    "https://news.ycombinator.com/user?id=dang",
+    "https://news.ycombinator.com/from?site=github.com",
+    "https://hn.algolia.com/?query=AI+agent",
+])
+def test_can_handle_positive(ch, url):
+    assert ch.can_handle(url)
+
+
+# ── can_handle: negative ──
+
+@pytest.mark.parametrize("url", [
+    "https://www.reddit.com/r/programming/",
+    "https://www.ycombinator.com/apply/",
+    "https://medium.com/@user/article",
+    "https://dev.to/user/article",
+    "https://lobste.rs/",
+    "https://news.google.com/",
+    "https://example.com/news.ycombinator.com",
+])
+def test_can_handle_negative(ch, url):
+    assert not ch.can_handle(url)
+
+
+# ── check ──
+
+def test_check_returns_tuple(ch):
+    status, msg = ch.check()
+    assert status in ("ok", "warn")
+    assert isinstance(msg, str)
+
+
+# ── registration ──
+
+def test_registered():
+    from agent_reach.channels import ALL_CHANNELS
+    names = [c.name for c in ALL_CHANNELS]
+    assert "hackernews" in names
+
+
+# ── Firebase API live tests ──
+
+class TestFirebaseAPI:
+    """Live API tests — skipped if network unavailable."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_offline(self):
+        import urllib.request
+        try:
+            urllib.request.urlopen(
+                "https://hacker-news.firebaseio.com/v0/topstories.json",
+                timeout=5,
+            )
+        except Exception:
+            pytest.skip("HN API unreachable")
+
+    def test_topstories(self):
+        import json
+        import urllib.request
+        with urllib.request.urlopen(
+            "https://hacker-news.firebaseio.com/v0/topstories.json",
+            timeout=10,
+        ) as r:
+            ids = json.loads(r.read())
+            assert isinstance(ids, list)
+            assert len(ids) > 0
+
+    def test_item(self):
+        import json
+        import urllib.request
+        with urllib.request.urlopen(
+            "https://hacker-news.firebaseio.com/v0/item/1.json",
+            timeout=10,
+        ) as r:
+            item = json.loads(r.read())
+            assert item["id"] == 1
+            assert "by" in item
+
+    def test_all_story_endpoints(self):
+        import json
+        import urllib.request
+        for ep in ["topstories", "newstories", "beststories",
+                    "askstories", "showstories", "jobstories"]:
+            url = f"https://hacker-news.firebaseio.com/v0/{ep}.json"
+            with urllib.request.urlopen(url, timeout=10) as r:
+                ids = json.loads(r.read())
+                assert isinstance(ids, list), f"{ep} returned non-list"
+
+
+# ── Algolia Search live tests ──
+
+class TestAlgoliaSearch:
+    """Live Algolia HN Search tests."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_offline(self):
+        import urllib.request
+        try:
+            urllib.request.urlopen(
+                "https://hn.algolia.com/api/v1/search?query=test&hitsPerPage=1",
+                timeout=5,
+            )
+        except Exception:
+            pytest.skip("Algolia HN API unreachable")
+
+    def test_search_stories(self):
+        import json
+        import urllib.request
+        url = ("https://hn.algolia.com/api/v1/search"
+               "?query=python&tags=story&hitsPerPage=3")
+        with urllib.request.urlopen(url, timeout=10) as r:
+            data = json.loads(r.read())
+            assert data["nbHits"] > 0
+            assert len(data["hits"]) > 0
+            hit = data["hits"][0]
+            assert "title" in hit
+            assert "points" in hit
+
+    def test_search_comments(self):
+        import json
+        import urllib.request
+        url = ("https://hn.algolia.com/api/v1/search"
+               "?query=machine+learning&tags=comment&hitsPerPage=3")
+        with urllib.request.urlopen(url, timeout=10) as r:
+            data = json.loads(r.read())
+            assert data["nbHits"] > 0


### PR DESCRIPTION
## Summary

Adds **Hacker News** as a Tier 0 channel — zero-config, no API key, fully free.

HN is the largest tech community (news.ycombinator.com), and has one of the best free APIs available: an official Firebase real-time API + Algolia full-text search.

## Evaluation (why add this?)

### Overlap with existing channels

- **WebChannel (Jina Reader):** Can render HN pages (16KB frontpage, 55KB comment threads), but provides raw text — no structured data (score, comment count, author), no search, no comment tree traversal
- **RSSChannel:** HN RSS exists but only has title + link — no scores, no comments, no author
- **Exa Search:** Can find HN content, but can't browse HN-specific feeds (top/new/best/ask/show/jobs) or read comment trees
- **Conclusion:** Existing channels provide significantly degraded experience compared to a dedicated channel with proper API access

### Why Hacker News specifically?

- Official Firebase API: completely free, no auth, no rate limits documented
- Algolia HN Search: free full-text search (11K+ results for "AI agent"), no API key needed
- 6 story feeds: top, new, best, ask, show, jobs (1,452 items total)
- Full comment tree traversal via item API
- THE tech community for developers and researchers

### Platforms evaluated but rejected

- **Medium:** ❌ Paywall blocks content extraction; RSS already covers browsing; no free API
- **Hashnode:** ❌ Feed quality poor (57% SEO spam); API unstable; Jina returns empty; small user base

## Backends

| Backend | Endpoint | Auth | Capabilities |
|---------|----------|------|------|
| Firebase API | `hacker-news.firebaseio.com/v0/` | None | Stories, items, comments, user profiles |
| Algolia Search | `hn.algolia.com/api/v1/` | None | Full-text search for stories and comments |

## Reliability testing (3 rounds)

```
Firebase topstories: 500 IDs (3/3 stable)
Firebase item: title + score + comments + URL (3/3 stable)
Algolia search "AI agent": 11,282 results (3/3 stable)
```

## End-to-end scenario testing

| Scenario | Method | Result |
|----------|--------|--------|
| Browse top stories | Firebase `topstories.json` → item details | ✅ `[212⬆ 69💬] Plasma Bigscreen...` |
| Search topic | Algolia `search?query=virtual+cell` | ✅ 2 results with title + points |
| Read comments | Firebase `item/<id>.json` → kids → recurse | ✅ Full comment text extracted |
| All 6 feeds | top/new/best/ask/show/jobs | ✅ All return valid ID lists |

## What's changed

- `agent_reach/channels/hackernews.py` — Channel (32 lines)
- `tests/test_hackernews_channel.py` — 24 tests (URL matching, metadata, check, registration, live API)
- `agent_reach/channels/__init__.py` — Register HackerNewsChannel
- `agent_reach/skill/SKILL.md` — Usage docs for Firebase browsing + Algolia searching

## Test results

```
tests/test_hackernews_channel.py — 24 passed in 13.17s
```

Includes **live API tests** (auto-skipped if network unavailable):
- Firebase: topstories, single item, all 6 story endpoints
- Algolia: story search, comment search

## SKILL.md examples

```bash
# Top stories
curl -s "https://hacker-news.firebaseio.com/v0/topstories.json"
curl -s "https://hacker-news.firebaseio.com/v0/item/<ID>.json"

# Search
curl -s "https://hn.algolia.com/api/v1/search?query=QUERY&tags=story&hitsPerPage=10"
```