### PR TITLE
fix: remove emojis from CLI output + fix Windows GBK crash (#95)

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -25,8 +25,6 @@ def _ensure_utf8_console():
     # Avoid interfering with pytest/captured streams.
     if os.environ.get("PYTEST_CURRENT_TEST"):
         return
-    if not getattr(sys.stdout, "isatty", lambda: False)():
-        return
     try:
         import io
         if hasattr(sys.stdout, "buffer"):


### PR DESCRIPTION
**两个改动：**

1. **删除所有装饰性 emoji** — install/doctor/config 输出里的 📦🔧📥🤖👁️🔍 等全部替换为纯文本。只保留 ✅（成功勾）和最后的 ⭐🙏（star 提示）。减少 Windows 编码问题，输出更稳定。

2. **修复 Windows GBK 崩溃 (#95)** — `_ensure_utf8_console()` 里的 `isatty()` 守卫导致 AI agent 以 subprocess 调用时跳过 UTF-8 包装，emoji 字符在 GBK 编码下触发 `UnicodeEncodeError`。删除该守卫，始终应用 UTF-8 wrapping。

改动文件：`cli.py` (164行变动) + `doctor.py` (18行变动)
测试：31 passed

Closes #95