### PR TITLE
feat: add Weibo channel via mcp-server-weibo (addresses #75)

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,6 +20,7 @@ from .douyin import DouyinChannel
 from .linkedin import LinkedInChannel
 from .bosszhipin import BossZhipinChannel
 from .wechat import WeChatChannel
+from .weibo import WeiboChannel
 
 
 # Channel registry
@@ -34,6 +35,7 @@ ALL_CHANNELS: List[Channel] = [
     LinkedInChannel(),
     BossZhipinChannel(),
     WeChatChannel(),
+    WeiboChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/weibo.py
+++ b/agent_reach/channels/weibo.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Weibo (微博) — check if mcporter + mcp-server-weibo is available."""
+
+import shutil
+import subprocess
+from .base import Channel
+
+
+class WeiboChannel(Channel):
+    name = "weibo"
+    description = "微博动态与热搜"
+    backends = ["mcp-server-weibo"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "weibo.com" in d or "weibo.cn" in d
+
+    def check(self, config=None):
+        mcporter = shutil.which("mcporter")
+        if not mcporter:
+            return "off", (
+                "需要 mcporter + mcp-server-weibo。安装步骤：\n"
+                "  1. npm install -g mcporter\n"
+                "  2. uvx mcp-server-weibo（或 pip install mcp-server-weibo）\n"
+                "  3. mcporter config add weibo --command 'uvx mcp-server-weibo'\n"
+                "  详见 https://github.com/qinyuanpei/mcp-server-weibo"
+            )
+        try:
+            r = subprocess.run(
+                [mcporter, "config", "list"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
+            )
+            if "weibo" not in r.stdout:
+                return "off", (
+                    "mcporter 已装但微博 MCP 未配置。运行：\n"
+                    "  uvx mcp-server-weibo  # 或 pip install mcp-server-weibo\n"
+                    "  mcporter config add weibo --command 'uvx mcp-server-weibo'\n"
+                    "  # 海外服务器需配置 WEIBO_COOKIE 环境变量，\n"
+                    "  # 详见 SKILL.md 微博章节"
+                )
+        except Exception:
+            return "off", "mcporter 连接异常"
+        try:
+            r = subprocess.run(
+                [mcporter, "list", "weibo"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=15
+            )
+            if r.returncode == 0 and "search_users" in r.stdout:
+                return "ok", "完整可用（热搜、搜索、用户动态、评论）"
+            return "warn", "MCP 已配置但工具加载失败，检查 mcp-server-weibo 版本"
+        except Exception:
+            return "warn", "MCP 连接异常，检查 mcp-server-weibo 是否可用"

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -40,6 +40,7 @@ def test_channel_can_handle_contract():
         "douyin": "https://www.douyin.com/video/123",
         "linkedin": "https://www.linkedin.com/in/test",
         "bosszhipin": "https://www.zhipin.com/web/geek/job?query=python",
+        "weibo": "https://weibo.com/u/1749127163",
         "rss": "https://example.com/feed.xml",
         "exa_search": "https://example.com",
         "web": "https://example.com",


### PR DESCRIPTION
## Summary

Adds a Weibo (微博) channel that integrates [qinyuanpei/mcp-server-weibo](https://github.com/qinyuanpei/mcp-server-weibo) (34+ ⭐, MIT license, 10 tools) via mcporter.

This addresses **#75** — a user requested Weibo support for monitoring bloggers' new posts.

## Why a dedicated channel?

Weibo's mobile API (`m.weibo.cn`) is **not accessible via curl or Jina Reader**:

- Without cookies: returns **HTTP 302** (redirect to visitor passport) from foreign IPs, or **HTTP 432** from datacenter IPs
- The visitor passport flow involves a multi-step JavaScript-based cookie acquisition process (`genvisitor2` → `crossdomain` → set 9 cookies)
- The `SUB` cookie obtained through this flow is valid for **1 year**
- Once cookies are obtained, all API endpoints work reliably without proxy

The upstream MCP server (`mcp-server-weibo`) wraps this complexity and provides 10 structured tools.

## Changes

3 files, +57 lines:

| File | Change |
|------|--------|
| `agent_reach/channels/weibo.py` | New WeiboChannel (54 lines) |
| `agent_reach/channels/__init__.py` | Register WeiboChannel |
| `tests/test_channel_contracts.py` | Add weibo URL sample |

### Channel design

- **`can_handle()`**: matches `weibo.com` and `weibo.cn` (including subdomains like `m.weibo.cn`, `s.weibo.com`)
- **`check()`**: two-layer detection:
  1. `mcporter config list` — verify MCP server is configured
  2. `mcporter list weibo` — verify tools load correctly (lightweight, no live API call)
- **`tier=1`**: requires installing `mcp-server-weibo` but no paid API key
- **Style**: follows existing patterns (same `"domain" in d` matching as other channels, same `subprocess.run` + `mcporter` pattern as XiaoHongShu/Douyin/BossZhipin)

## Upstream MCP server capabilities

`mcp-server-weibo` v1.0.7 provides 10 tools:

| Tool | Description |
|------|-------------|
| `search_users` | Search users by keyword |
| `get_profile` | Get user profile (name, bio, follower count, verification) |
| `get_feeds` | Get user's posts with pagination |
| `get_hot_feeds` | Get user's popular posts |
| `get_trendings` | Get real-time trending topics (热搜) |
| `search_content` | Search posts by keyword |
| `search_topics` | Search hashtag topics with read/discussion counts |
| `get_comments` | Get comments for a specific post |
| `get_followers` | Get user's following list |
| `get_fans` | Get user's fan list |

Install: `uvx mcp-server-weibo` or `pip install mcp-server-weibo`

## Test results

### Unit tests: 9/9 passed

```
tests/test_channel_contracts.py::test_channel_registry_contract PASSED
tests/test_channel_contracts.py::test_channel_check_contract_with_minimal_runtime PASSED
tests/test_channel_contracts.py::test_channel_can_handle_contract PASSED
tests/test_channels.py (3 tests) PASSED
tests/test_core.py (3 tests) PASSED
```

### E2E tool tests: 10/10 passed

All 10 MCP tools verified with live Weibo API:
- search_users: ✅ (found @雷军, @人民日报)
- get_profile: ✅ (11 fields complete)
- get_feeds: ✅ (with engagement metrics, location, media)
- get_hot_feeds: ✅
- get_trendings: ✅ (returns up to 53 items)
- search_content: ✅ (includes pic thumbnails + video stream URLs)
- search_topics: ✅ (includes read count + discussion count)
- get_comments: ✅
- get_followers/get_fans: ✅

### Stability test: 8/8 consecutive calls, avg 1.9s/call

### Edge cases tested

| Case | Result |
|------|--------|
| Non-existent uid | MCP returns error (upstream issue) |
| uid=0 | MCP returns error (upstream issue) |
| Empty search | Returns empty array ✅ |
| Emoji search (🐻) | Works ✅ |
| Japanese text search | Works ✅ |
| Deactivated account | Returns empty array ✅ |
| limit=100 (over max) | Returns 53 (actual max) ✅ |

### User flow verified

```
agent-reach doctor  →  "-- 微博: mcporter 已装但微博 MCP 未配置"
    ↓ mcporter config add weibo --command 'uvx mcp-server-weibo'
agent-reach doctor  →  "-- 微博: MCP 已配置但工具加载失败" (if no cookie)
    ↓ configure WEIBO_COOKIE env
agent-reach doctor  →  "✅ 微博: 完整可用（热搜、搜索、用户动态、评论）"
```

## Known issues in upstream MCP server

These are bugs in `mcp-server-weibo`, not in this PR:

1. **`search_users()` has debug `print(result)` on line 156** that corrupts MCP stdio transport — causes mcporter to hang. Workaround: remove the print statement. (Will file upstream issue.)
2. **`get_comments()` omits `like_count` field** — the raw API returns it but the data mapping drops it. Hot comments require the `hotflow` endpoint which isn't exposed.
3. **No error handling for invalid uid** — throws `KeyError: 'userInfo'` instead of returning empty.

## Cookie notes for overseas users

The MCP server supports `WEIBO_COOKIE` env var. For servers outside mainland China:
- Weibo's mobile API requires a visitor cookie obtained via the `visitor.passport.weibo.cn` flow
- The `SUB` cookie alone is sufficient and valid for 1 year
- Chinese users likely won't need this step (direct access works from domestic IPs)