### PR TITLE
fix: sync xfetch session.json when using --from-browser (closes #109)

### DIFF
--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -112,6 +112,32 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
     return results
 
 
+def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
+    """Sync Twitter credentials to ~/.config/xfetch/session.json for xreach CLI."""
+    import json
+    import os
+
+    try:
+        xfetch_dir = os.path.join(os.path.expanduser("~"), ".config", "xfetch")
+        os.makedirs(xfetch_dir, exist_ok=True)
+        session_path = os.path.join(xfetch_dir, "session.json")
+        session_data: dict = {}
+        if os.path.exists(session_path):
+            try:
+                with open(session_path, "r", encoding="utf-8") as sf:
+                    session_data = json.load(sf)
+            except (json.JSONDecodeError, OSError):
+                session_data = {}
+        session_data["authToken"] = auth_token
+        session_data["ct0"] = ct0
+        with open(session_path, "w", encoding="utf-8") as sf:
+            json.dump(session_data, sf, indent=2)
+        os.chmod(session_path, 0o600)
+    except Exception:
+        # Non-fatal: agent-reach config is the source of truth, xfetch sync is best-effort
+        pass
+
+
 def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
     """
     Extract cookies and configure all found platforms.
@@ -136,6 +162,8 @@ def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
         if "auth_token" in tc and "ct0" in tc:
             config.set("twitter_auth_token", tc["auth_token"])
             config.set("twitter_ct0", tc["ct0"])
+            # Sync credentials to xreach's session.json so `xreach auth check` works
+            _sync_xfetch_session(tc["auth_token"], tc["ct0"])
             results_list.append(("Twitter/X", True, "auth_token + ct0"))
         else:
             found = ", ".join(tc.keys())


### PR DESCRIPTION
## 问题

`agent-reach configure --from-browser chrome` 执行后 Twitter cookie 只写入了 `~/.agent-reach/config.yaml`，**没有**同步到 `~/.config/xfetch/session.json`，导致 xreach CLI 依然报 `Not authenticated`。

Issue #109 的用户遇到的正是此问题——configure 显示「✅ Twitter/X: auth_token + ct0」，但 `xreach bookmarks` 仍报未认证，需要用户手动再跑 `xfetch auth extract --browser chrome`。

## 根因

xfetch 桥接逻辑（写 session.json）只存在于手动路径 `cli.py:829`（`agent-reach configure twitter-cookies "auth_token=xxx ct0=yyy"`），`--from-browser` 走的是 `cookie_extract.py::configure_from_browser()`，完全没有这段逻辑。

## 修复

将 xfetch 桥接提取为独立辅助函数 `_sync_xfetch_session()`，放在 `cookie_extract.py`，在 `configure_from_browser()` 成功提取 Twitter cookie 后调用。

- 非阻塞：如果写 session.json 失败（权限/路径问题），静默忽略——agent-reach config.yaml 是主要来源
- 保留已有 session.json 其他字段（merge，不覆盖）
- 权限 0o600，与手动路径一致

## 变更

1 文件，+28 行（`agent_reach/cookie_extract.py`）