### PR TITLE
Fix missing shutil import in Weibo installer

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -456,6 +456,7 @@ def _install_system_deps():
 
 def _install_weibo_deps():
     """Install Weibo MCP server (Panniantong fork with visitor passport auth)."""
+    import shutil
     import subprocess
 
     print("Setting up Weibo MCP server...")


### PR DESCRIPTION
﻿## Summary
- add the missing `shutil` import in `_install_weibo_deps()`
- prevent `agent-reach install --env=auto` from crashing before Weibo setup completes

## Problem
On Windows, `agent-reach install --env=auto` can fail with:

```text
NameError: name 'shutil' is not defined
```

This happens because `_install_weibo_deps()` calls `shutil.which("mcporter")` without importing `shutil`.

## Validation
- imported `agent_reach.cli` successfully after the change
- reproduced the install flow locally and confirmed it proceeds past the Weibo setup step
