### PR TITLE
fix: 修复微博和小宇宙安装函数缺少 shutil import

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -459,6 +459,8 @@ def _install_system_deps():
 
 def _install_xiaoyuzhou_deps():
     """Install Xiaoyuzhou podcast transcription script."""
+    import shutil
+
     print("Setting up Xiaoyuzhou podcast transcription...")
 
     tools_dir = os.path.expanduser("~/.agent-reach/tools/xiaoyuzhou")
@@ -506,6 +508,7 @@ def _install_xiaoyuzhou_deps():
 
 def _install_weibo_deps():
     """Install Weibo MCP server (Panniantong fork with visitor passport auth)."""
+    import shutil
     import subprocess
 
     print("Setting up Weibo MCP server...")


### PR DESCRIPTION
修复 _install_weibo_deps() 和 _install_xiaoyuzhou_deps() 都用了 shutil.which() 但没 import shutil，会导致 NameError。

PR #123 只修了 weibo 一处，这个 PR 两处一起修。建议关掉 #123。