### PR TITLE
fix(twitter): doctor warns when xreach < 0.3.2 (longform tweet / X Article support)

### DIFF
--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -5,6 +5,19 @@ import shutil
 import subprocess
 from .base import Channel
 
+# Minimum xreach-cli version with longform tweet and X Article support.
+# v0.3.2 added: extractTweetText() preferring note_tweet for long tweets (#aad6a16)
+# and X Article URL support (/article/ path, #2e05825).
+_MIN_XREACH_VERSION = (0, 3, 2)
+
+
+def _parse_version(ver_str: str) -> tuple[int, ...]:
+    """Parse a semver string like '0.3.2' into a tuple (0, 3, 2)."""
+    try:
+        return tuple(int(x) for x in ver_str.strip().split(".")[:3])
+    except (ValueError, AttributeError):
+        return (0, 0, 0)
+
 
 class TwitterChannel(Channel):
     name = "twitter"
@@ -24,13 +37,31 @@ class TwitterChannel(Channel):
                 "xreach CLI 未安装。搜索可通过 Exa 替代。安装：\n"
                 "  npm install -g xreach-cli"
             )
+        # Check version — longform tweet support requires >= 0.3.2
+        try:
+            ver_result = subprocess.run(
+                [xreach, "--version"], capture_output=True,
+                encoding="utf-8", errors="replace", timeout=5
+            )
+            version_str = (ver_result.stdout or ver_result.stderr).strip()
+            version_tuple = _parse_version(version_str)
+            if version_tuple < _MIN_XREACH_VERSION:
+                min_str = ".".join(str(x) for x in _MIN_XREACH_VERSION)
+                return "warn", (
+                    f"xreach CLI 版本过旧（当前 {version_str}，需 >= {min_str}）。"
+                    f"旧版本无法读取长文推文（note_tweet）和 X Article。升级：\n"
+                    f"  npm install -g xreach-cli@latest"
+                )
+        except Exception:
+            pass  # version check failure is non-fatal; proceed to auth check
+
         try:
             r = subprocess.run(
                 [xreach, "auth", "check"], capture_output=True,
                 encoding="utf-8", errors="replace", timeout=10
             )
             if r.returncode == 0:
-                return "ok", "完整可用（读取、搜索推文）"
+                return "ok", "完整可用（读取、搜索推文，含长文/X Article）"
             return "warn", (
                 "xreach CLI 已安装但未配置 Cookie。运行：\n"
                 "  agent-reach configure twitter-cookies \"auth_token=xxx; ct0=yyy\""


### PR DESCRIPTION
## 背景

Fixes #126

用户报告「普通推文能读，长文读不了」。根因：**xreach-cli 需 >= 0.3.2** 才能完整支持长文推文和 X Article，但旧版本用户 doctor 结果仍显示 `ok`，导致静默失败。

## xreach 版本历史

| 版本 | 关键改动 |
|------|---------|
| 0.3.0 | 初始 xreach-cli rebrand |
| 0.3.1 | 修复 note_tweet 长文截断（preferring `note_tweet.text` over `legacy.full_text`） |
| 0.3.2 | 修复 X Article URL 支持（`/article/` 路径） |

## 改动

`agent_reach/channels/twitter.py`：
- 在 `check()` 中新增 `xreach --version` 检测
- 版本 < 0.3.2 时返回 `warn` 并给出升级命令
- 版本检测失败（老版本不支持 --version 等情况）不影响后续 auth 检查
- `ok` 消息更新为「含长文/X Article」

## 验证

- 全部 36 个测试通过（`python3 -m pytest tests/ -v`）
- 手动验证：`xreach --version` 返回 `0.3.0` 时 check() 返回 warn；返回 `0.3.2` 时走 auth 检查
- 版本解析对格式错误输入安全降级（返回 (0,0,0)，触发升级提示）

## 回滚

单文件改动，revert 一个 commit 即可还原。