### PR TITLE
fix: config.json → config.yaml，修复 groq_api_key 读取失败

### DIFF
--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -38,16 +38,8 @@ class XiaoyuzhouChannel(Channel):
         # Check GROQ_API_KEY
         if not os.environ.get("GROQ_API_KEY"):
             # Check if saved in config
-            config_path = os.path.expanduser("~/.agent-reach/config.json")
-            has_key = False
-            if os.path.isfile(config_path):
-                try:
-                    import json
-                    with open(config_path) as f:
-                        cfg = json.load(f)
-                    has_key = bool(cfg.get("groq_api_key"))
-                except Exception:
-                    pass
+            from ..config import Config
+            has_key = bool(Config().get("groq_api_key"))
             if not has_key:
                 return "warn", (
                     "需要配置 Groq API Key（免费）。步骤：\n"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -490,15 +490,8 @@ def _install_xiaoyuzhou_deps():
         print("  -- ffmpeg not found. Install: apt install -y ffmpeg (or brew install ffmpeg)")
 
     # Check GROQ_API_KEY
-    config_path = os.path.expanduser("~/.agent-reach/config.json")
-    has_key = bool(os.environ.get("GROQ_API_KEY"))
-    if not has_key and os.path.isfile(config_path):
-        try:
-            with open(config_path) as f:
-                cfg = json.load(f)
-            has_key = bool(cfg.get("groq_api_key"))
-        except Exception:
-            pass
+    from .config import Config
+    has_key = bool(Config().get("groq_api_key"))
     if has_key:
         print("  ✅ Groq API key configured")
     else:

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -11,9 +11,9 @@ TMPDIR="/tmp/xiaoyuzhou_$$"
 
 # Try env var first, then agent-reach config
 if [ -z "$GROQ_API_KEY" ]; then
-    CONFIG_FILE="$HOME/.agent-reach/config.json"
+    CONFIG_FILE="$HOME/.agent-reach/config.yaml"
     if [ -f "$CONFIG_FILE" ]; then
-        GROQ_API_KEY=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('groq_api_key',''))" 2>/dev/null || true)
+        GROQ_API_KEY=$(python3 -c "import yaml; print(yaml.safe_load(open('$CONFIG_FILE')).get('groq_api_key',''))" 2>/dev/null || true)
     fi
 fi
 GROQ_API_KEY="${GROQ_API_KEY:?请设置 GROQ_API_KEY 环境变量或运行 agent-reach configure groq-key}"

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,7 +39,7 @@ All Agent Reach files go in dedicated directories — **never in the agent works
 
 | Purpose | Directory | Example |
 |---------|-----------|---------|
-| Config & tokens | `~/.agent-reach/` | `~/.agent-reach/config.json` |
+| Config & tokens | `~/.agent-reach/` | `~/.agent-reach/config.yaml` |
 | Upstream tool repos | `~/.agent-reach/tools/` | `~/.agent-reach/tools/douyin-mcp-server/` |
 | Temporary files | `/tmp/` | `/tmp/yt-dlp-output/` |
 | Skills | `~/.openclaw/skills/agent-reach/` | SKILL.md |


### PR DESCRIPTION
## 背景

Config 类写入 `~/.agent-reach/config.yaml`（YAML 格式），但 xiaoyuzhou channel、CLI install、transcribe 脚本都读取 `config.json`（JSON 格式），导致通过 `agent-reach configure groq-key` 保存的 `groq_api_key` 永远读不到。

## 改动

- `agent_reach/channels/xiaoyuzhou.py`：删除手动 JSON 读取，改用 `Config().get("groq_api_key")`
- `agent_reach/cli.py`：同上
- `agent_reach/scripts/transcribe_xiaoyuzhou.sh`：`config.json` → `config.yaml`，`json` → `yaml.safe_load`
- `docs/install.md`：文档中 `config.json` → `config.yaml`

## 验证

- 全部 36 个测试通过（`python3 -m pytest tests/ -v`）
- diff 仅 4 文件 7+/22-，零副作用

## 回滚

单 commit，revert 即可还原。