### PR TITLE
fix: 刷新 Star History 图表缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,4 +357,4 @@ Yes! Agent Reach is an installer + configuration tool — any AI coding agent th
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date)](https://star-history.com/#Panniantong/Agent-Reach&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date&v=20260309)](https://star-history.com/#Panniantong/Agent-Reach&Date)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -321,4 +321,4 @@ Interested in collaboration, have feature ideas, or just want to chat about AI A
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date)](https://star-history.com/#Panniantong/Agent-Reach&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date&v=20260309)](https://star-history.com/#Panniantong/Agent-Reach&Date)


### PR DESCRIPTION
加 cache-busting 参数让 GitHub 重新拉取最新的 Star History 图（当前 7,549 ⭐）。