### PR TITLE
fix(xiaoyuzhou): read Groq key from Config instead of legacy config.json

### DIFF
--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from agent_reach.config import Config
 from .base import Channel
 
 
@@ -35,18 +36,14 @@ class XiaoyuzhouChannel(Channel):
                 "  或手动复制 transcribe.sh 到 ~/.agent-reach/tools/xiaoyuzhou/"
             )
 
-        # Check GROQ_API_KEY — prefer env var, fall back to config file
+        # Check GROQ_API_KEY — prefer env var, fall back to Agent Reach config
         has_key = bool(os.environ.get("GROQ_API_KEY"))
         if not has_key:
-            config_path = os.path.expanduser("~/.agent-reach/config.json")
-            if os.path.isfile(config_path):
-                try:
-                    import json
-                    with open(config_path) as f:
-                        cfg = json.load(f)
-                    has_key = bool(cfg.get("groq_api_key"))
-                except Exception:
-                    pass
+            try:
+                cfg = config if config is not None else Config()
+                has_key = bool(cfg.get("groq_api_key"))
+            except Exception:
+                has_key = False
         if not has_key:
             return "warn", (
                 "需要配置 Groq API Key（免费）。步骤：\n"


### PR DESCRIPTION
# PR Draft: Fix Xiaoyuzhou Groq key detection to use Config/config.yaml

## Title
fix(xiaoyuzhou): read Groq key from Config instead of legacy config.json

## Summary
This fixes a configuration mismatch in the Xiaoyuzhou channel health check.

`agent-reach configure groq-key` / `groq-api-key` writes the Groq key through `Config`, which stores data in `~/.agent-reach/config.yaml`.
However, `agent_reach/channels/xiaoyuzhou.py` was still checking `~/.agent-reach/config.json` directly.

As a result, users could configure Groq successfully, but `agent-reach doctor` would still report the Xiaoyuzhou channel as not configured.

## Root cause
Configuration storage and configuration checking used different sources:

- `Config` -> `~/.agent-reach/config.yaml`
- `XiaoyuzhouChannel.check()` -> `~/.agent-reach/config.json`

This caused a false negative in `doctor`.

## Fix
Use the shared `Config` object in `XiaoyuzhouChannel.check()`.

New behavior:
1. Prefer environment variable `GROQ_API_KEY`
2. Fall back to `Config().get("groq_api_key")`

This aligns Xiaoyuzhou with the rest of the configuration system and removes the legacy hardcoded `config.json` dependency.

## User-visible impact
Before:
- user runs `agent-reach configure groq-key ...`
- key is saved successfully
- `agent-reach doctor` still says Groq key is missing

After:
- `doctor` correctly recognizes the configured key
- Xiaoyuzhou shows as available when ffmpeg + script + key are present

## Patch
See: `agent-reach-groq-fix.patch`

## Minimal test idea
- With `~/.agent-reach/config.yaml` containing `groq_api_key`, `XiaoyuzhouChannel.check()` should return `ok`
- Without env var and without config key, it should return `warn`
