### PR TITLE
fix(groq): unify config loading on config.yaml across xiaoyuzhou flows

### DIFF
--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from agent_reach.config import Config
 from .base import Channel
 
 
@@ -35,18 +36,14 @@ class XiaoyuzhouChannel(Channel):
                 "  或手动复制 transcribe.sh 到 ~/.agent-reach/tools/xiaoyuzhou/"
             )
 
-        # Check GROQ_API_KEY — prefer env var, fall back to config file
+        # Check GROQ_API_KEY — prefer env var, fall back to Agent Reach config
         has_key = bool(os.environ.get("GROQ_API_KEY"))
         if not has_key:
-            config_path = os.path.expanduser("~/.agent-reach/config.json")
-            if os.path.isfile(config_path):
-                try:
-                    import json
-                    with open(config_path) as f:
-                        cfg = json.load(f)
-                    has_key = bool(cfg.get("groq_api_key"))
-                except Exception:
-                    pass
+            try:
+                cfg = config if config is not None else Config()
+                has_key = bool(cfg.get("groq_api_key"))
+            except Exception:
+                has_key = False
         if not has_key:
             return "warn", (
                 "需要配置 Groq API Key（免费）。步骤：\n"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -490,15 +490,7 @@ def _install_xiaoyuzhou_deps():
         print("  -- ffmpeg not found. Install: apt install -y ffmpeg (or brew install ffmpeg)")
 
     # Check GROQ_API_KEY
-    config_path = os.path.expanduser("~/.agent-reach/config.json")
-    has_key = bool(os.environ.get("GROQ_API_KEY"))
-    if not has_key and os.path.isfile(config_path):
-        try:
-            with open(config_path) as f:
-                cfg = json.load(f)
-            has_key = bool(cfg.get("groq_api_key"))
-        except Exception:
-            pass
+    has_key = bool(os.environ.get("GROQ_API_KEY")) or bool(config.get("groq_api_key"))
     if has_key:
         print("  ✅ Groq API key configured")
     else:

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -9,11 +9,11 @@ URL="${1:?用法: bash transcribe.sh <小宇宙链接> [输出文件路径]}"
 OUTPUT="${2:-/tmp/podcast_transcript.txt}"
 TMPDIR="/tmp/xiaoyuzhou_$$"
 
-# Try env var first, then agent-reach config
+# Try env var first, then agent-reach config.yaml
 if [ -z "$GROQ_API_KEY" ]; then
-    CONFIG_FILE="$HOME/.agent-reach/config.json"
+    CONFIG_FILE="$HOME/.agent-reach/config.yaml"
     if [ -f "$CONFIG_FILE" ]; then
-        GROQ_API_KEY=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('groq_api_key',''))" 2>/dev/null || true)
+        GROQ_API_KEY=$(python3 -c "import yaml; print((yaml.safe_load(open('$CONFIG_FILE')) or {}).get('groq_api_key',''))" 2>/dev/null || true)
     fi
 fi
 GROQ_API_KEY="${GROQ_API_KEY:?请设置 GROQ_API_KEY 环境变量或运行 agent-reach configure groq-key}"


### PR DESCRIPTION
# PR Draft: Unify Groq config loading on config.yaml across Xiaoyuzhou flows

## Title
fix(groq): unify Groq key loading on Config/config.yaml across doctor, installer, and script

## Summary
This PR fixes multiple inconsistent Groq configuration lookup paths related to Xiaoyuzhou transcription.

Previously, different parts of the project used different config sources:

- `Config` writes to `~/.agent-reach/config.yaml`
- Some Xiaoyuzhou checks still read `~/.agent-reach/config.json`
- The transcription shell script also read `config.json`

As a result, users could successfully configure Groq, but some checks or runtime flows would still behave as if the key were missing.

## Root cause
Groq config lookup was duplicated in multiple places and not consistently routed through the shared `Config` abstraction.

Affected areas:
1. `agent_reach/channels/xiaoyuzhou.py`
2. `_install_xiaoyuzhou_deps()` in `agent_reach/cli.py`
3. `agent_reach/scripts/transcribe_xiaoyuzhou.sh`

## Fix
### Python code paths
Use the shared `Config` object instead of hardcoded `config.json` paths.

New behavior:
1. Prefer environment variable `GROQ_API_KEY`
2. Fall back to `Config().get("groq_api_key")`

### Shell script path
Change the fallback file from:
- `~/.agent-reach/config.json`

to:
- `~/.agent-reach/config.yaml`

and parse it with `yaml.safe_load(...)`.

## User-visible impact
Before:
- user runs `agent-reach configure groq-key ...`
- key is saved successfully
- `doctor`, install checks, or script execution may still say the key is missing

After:
- Groq configuration is recognized consistently
- Xiaoyuzhou doctor/install/runtime behavior is aligned

## Files changed
- `agent_reach/channels/xiaoyuzhou.py`
- `agent_reach/cli.py`
- `agent_reach/scripts/transcribe_xiaoyuzhou.sh`

## Minimal test ideas
1. With `~/.agent-reach/config.yaml` containing `groq_api_key`, Xiaoyuzhou checks should return `ok`
2. Without env var and without config key, checks should return `warn`
3. The transcription script should successfully read `groq_api_key` from `config.yaml`
