### PR TITLE
fix(groq): use Config class instead of hardcoded config.json

### DIFF
--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from agent_reach.config import Config
 from .base import Channel
 
 
@@ -35,18 +36,14 @@ class XiaoyuzhouChannel(Channel):
                 "  或手动复制 transcribe.sh 到 ~/.agent-reach/tools/xiaoyuzhou/"
             )
 
-        # Check GROQ_API_KEY — prefer env var, fall back to config file
+        # Check GROQ_API_KEY — prefer env var, fall back to Agent Reach config
         has_key = bool(os.environ.get("GROQ_API_KEY"))
         if not has_key:
-            config_path = os.path.expanduser("~/.agent-reach/config.json")
-            if os.path.isfile(config_path):
-                try:
-                    import json
-                    with open(config_path) as f:
-                        cfg = json.load(f)
-                    has_key = bool(cfg.get("groq_api_key"))
-                except Exception:
-                    pass
+            try:
+                cfg = config if config is not None else Config()
+                has_key = bool(cfg.get("groq_api_key"))
+            except Exception:
+                has_key = False
         if not has_key:
             return "warn", (
                 "需要配置 Groq API Key（免费）。步骤：\n"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -490,15 +490,7 @@ def _install_xiaoyuzhou_deps():
         print("  -- ffmpeg not found. Install: apt install -y ffmpeg (or brew install ffmpeg)")
 
     # Check GROQ_API_KEY
-    config_path = os.path.expanduser("~/.agent-reach/config.json")
-    has_key = bool(os.environ.get("GROQ_API_KEY"))
-    if not has_key and os.path.isfile(config_path):
-        try:
-            with open(config_path) as f:
-                cfg = json.load(f)
-            has_key = bool(cfg.get("groq_api_key"))
-        except Exception:
-            pass
+    has_key = bool(os.environ.get("GROQ_API_KEY")) or bool(config.get("groq_api_key"))
     if has_key:
         print("  ✅ Groq API key configured")
     else:

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -9,11 +9,11 @@ URL="${1:?用法: bash transcribe.sh <小宇宙链接> [输出文件路径]}"
 OUTPUT="${2:-/tmp/podcast_transcript.txt}"
 TMPDIR="/tmp/xiaoyuzhou_$$"
 
-# Try env var first, then agent-reach config
+# Try env var first, then agent-reach config.yaml
 if [ -z "$GROQ_API_KEY" ]; then
-    CONFIG_FILE="$HOME/.agent-reach/config.json"
+    CONFIG_FILE="$HOME/.agent-reach/config.yaml"
     if [ -f "$CONFIG_FILE" ]; then
-        GROQ_API_KEY=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('groq_api_key',''))" 2>/dev/null || true)
+        GROQ_API_KEY=$(python3 -c "import yaml; print((yaml.safe_load(open('$CONFIG_FILE')) or {}).get('groq_api_key',''))" 2>/dev/null || true)
     fi
 fi
 GROQ_API_KEY="${GROQ_API_KEY:?请设置 GROQ_API_KEY 环境变量或运行 agent-reach configure groq-key}"


### PR DESCRIPTION
Config 类写 YAML（config.yaml），但 xiaoyuzhou.py、cli.py、transcribe.sh 都硬编码读 config.json。用户通过 `agent-reach configure groq-key` 配置的 key 因此读不到。

**改动：**
- `xiaoyuzhou.py`：用 `Config()` 替代手动读 JSON
- `cli.py`：同上
- `transcribe.sh`：改读 config.yaml + 用 yaml.safe_load

3 文件，+11/-22，35 测试全过。

Closes #128
Supersedes #130 #133