### PR TITLE
docs: add pipx/venv guidance for Homebrew Python installs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -51,11 +51,23 @@ All Agent Reach files go in dedicated directories — **never in the agent works
 **Default (fully automatic):**
 
 ```bash
+# 推荐：pipx（最省心）
+pipx install https://github.com/Panniantong/agent-reach/archive/main.zip
+agent-reach install --env=auto
+
+# 如果你的 Python 来自 Homebrew / 遇到 PEP 668（externally-managed-environment）
+# 用虚拟环境安装：
+python3 -m venv ~/.agent-reach-venv
+source ~/.agent-reach-venv/bin/activate
 pip install https://github.com/Panniantong/agent-reach/archive/main.zip
 agent-reach install --env=auto
 ```
 
 This auto-installs system dependencies (gh CLI, Node.js, mcporter, xreach), configures Exa search, detects environment, and tests all channels.
+
+> 💡 **macOS / Homebrew Python 提示 `externally-managed-environment`？**
+> 这是 PEP 668 保护，不是 Agent Reach 本身的问题。优先用 `pipx install ...`，或先创建 `venv` 再安装。
+
 
 **Safe mode (no automatic system changes):**
 


### PR DESCRIPTION
## Summary\n- document a safer install path for macOS/Homebrew Python users\n- recommend  first, and  as fallback\n- explain that  is PEP 668 protection rather than an Agent Reach bug\n\n## Why\nCurrent docs lead with plain , which can fail on Homebrew Python with:\n\n\n\nWe hit this during real installation on macOS, then had to switch to a venv manually. This PR makes the official install path match that reality.\n