### PR TITLE
fix(reddit): add User-Agent to doctor health check to avoid false 403

### DIFF
--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -1,8 +1,23 @@
 # -*- coding: utf-8 -*-
-"""Reddit — check if proxy and credentials are configured."""
+"""Reddit — check connectivity and proxy configuration."""
 
 import os
+import urllib.request
 from .base import Channel
+
+_UA = "agent-reach/1.0"
+_TIMEOUT = 10
+
+
+def _reddit_reachable() -> bool:
+    """Return True if Reddit JSON API responds with 200 (带 User-Agent)."""
+    url = "https://www.reddit.com/r/linux.json?limit=1"
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 class RedditChannel(Channel):
@@ -20,7 +35,10 @@ class RedditChannel(Channel):
         proxy = (config.get("reddit_proxy") if config else None) or os.environ.get("REDDIT_PROXY")
         if proxy:
             return "ok", "代理已配置，可读取帖子。搜索走 Exa"
+        # 实际探测连通性（带 User-Agent，符合 Reddit API 要求）
+        if _reddit_reachable():
+            return "ok", "直连可用（JSON API 响应正常）。搜索走 Exa"
         return "warn", (
-            "无代理。服务器 IP 可能被 Reddit 封锁。配置代理：\n"
+            "无代理且 Reddit JSON API 无响应。服务器 IP 可能被封锁。配置代理：\n"
             "  agent-reach configure proxy http://user:pass@ip:port"
         )


### PR DESCRIPTION
## 问题

fixes #168

Reddit JSON API 要求请求必须携带非空 `User-Agent` 请求头（[官方 API 规则](https://github.com/reddit-archive/reddit/wiki/API#rules)）。原来的 `check()` 只检查是否有代理配置，没有实际发 HTTP 请求，导致：

- 家庭宽带用户（Reddit 可正常访问）→ doctor 误报「服务器 IP 可能被封锁」
- 根本原因：缺少 User-Agent，导致 403，但代码没有实际探测——所以只要无代理就一律告警

## 修复

参考 `v2ex.py` 的四信号模式，增加实际连通性探测：

```python
def _reddit_reachable() -> bool:
    """Return True if Reddit JSON API responds with 200 (带 User-Agent)."""    url = "https://www.reddit.com/r/linux.json?limit=1"
    req = urllib.request.Request(url, headers={"User-Agent": "agent-reach/1.0"})
    try:
        with urllib.request.urlopen(req, timeout=10) as resp:
            return resp.status == 200
    except Exception:
        return False
```

**check() 逻辑**：
1. 有代理配置 → ok
2. 无代理但 Reddit API 实际可达 → ok（家庭宽带正常情况）
3. 无代理且 API 不可达 → warn（真实被封的情况）

## 验证

```bash
# 带 User-Agent → 200 ✅
curl -s -o /dev/null -w "%{http_code}" -A "agent-reach/1.0" https://www.reddit.com/r/linux.json?limit=1

# 不带 User-Agent → 403 ❌（原来的 bug 根因）
curl -s -o /dev/null -w "%{http_code}" https://www.reddit.com/r/linux.json?limit=1
```

所有现有测试通过：`21 passed in 1.30s`