### PR TITLE
fix(xhs): use absolute path fallback and restart container after cookie import

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1106,9 +1106,9 @@ def _configure_xhs_cookies(value):
         )
         cookie_path_in_container = result.stdout.strip()
         if not cookie_path_in_container:
-            cookie_path_in_container = "cookies.json"  # fallback to workdir
+            cookie_path_in_container = "/app/cookies.json"  # fallback: absolute path in workdir
     except Exception:
-        cookie_path_in_container = "cookies.json"
+        cookie_path_in_container = "/app/cookies.json"
 
     # Write cookies into the container
     try:
@@ -1129,6 +1129,17 @@ def _configure_xhs_cookies(value):
             return
 
         print(f"✅ Cookies written to {container_name}:{cookie_path_in_container}")
+        # Restart container so it reloads cookies from disk
+        print("  Restarting container to reload cookies...", end=" ", flush=True)
+        try:
+            subprocess.run(
+                [docker, "restart", container_name],
+                capture_output=True, encoding="utf-8", timeout=30,
+            )
+            print("done")
+        except Exception as e:
+            print(f"\n  [!] Could not restart container: {e}")
+            print(f"  Restart manually: docker restart {container_name}")
     except Exception as e:
         print(f"[X] Failed to write cookies: {e}")
         return


### PR DESCRIPTION
## 问题

Issue #175：用户配置小红书 cookies 后容器仍显示未登录。

## 根因

`_configure_xhs_cookies` 通过 `printenv COOKIES_PATH` 获取容器内 cookie 路径。当该环境变量为空（旧版镜像）时，fallback 是裸的相对路径 `cookies.json`，导致 `docker cp container:cookies.json` 写到错误位置或失败。

另外，写入 cookies 后没有重启容器，上游 MCP 不会自动重新加载。

## 修复

1. 将两处 fallback（正常分支 + except 分支）从 `"cookies.json"` 改为 `"/app/cookies.json"`（绝对路径）
2. 写入成功后自动 `docker restart` 容器，让上游 MCP 重新加载 cookies

## 验证

- 49 existing tests pass
- 本机容器验证：`COOKIES_PATH=/app/data/cookies.json`，`workdir=/app`，逻辑正确

Fixes #175