### PR TITLE
fix(twitter): remove redundant inner 'import os' causing UnboundLocalError on configure

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -951,7 +951,6 @@ def _cmd_configure(args):
                 if not xreach:
                     print("[!] xreach CLI not installed. Run: npm install -g xreach-cli")
                 else:
-                    import os
                     env = os.environ.copy()
                     env["AUTH_TOKEN"] = auth_token
                     env["CT0"] = ct0


### PR DESCRIPTION
## Problem

Fixes #183

`agent-reach configure twitter-cookies "auth_token=...; ct0=..."` prints:

```
✅ Twitter cookies configured!
[!] Could not sync to xreach session.json: cannot access local variable 'os' where it is not associated with a value
```

## Root Cause

Inside `_cmd_configure()`, the `twitter-cookies` branch has a nested `import os` (line 954, inside a try block for the xreach test step):

```python
else:
    import os          # ← the problem
    env = os.environ.copy()
```

Python's scoping rules treat **any** name binding (including `import`) as local to the **entire** function. So the module-level `import os` at line 15 was shadowed, making every `os.xxx` call *before* the inner import (line 927–941: `os.path.join`, `os.makedirs`, `os.path.exists`, `os.chmod`) raise:

> UnboundLocalError: cannot access local variable 'os' where it is not associated with a value

## Fix

Remove the redundant `import os` line — `os` is already imported at module level.

## Verification

- `python3 -c "import agent_reach.cli"` → OK  
- `python3 -m pytest tests/ -x -q` → **49 passed**