### PR TITLE
docs(wechat): use agent-reach interpreter for miku_ai search example

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -108,13 +108,16 @@ mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com
 ## 微信公众号 / WeChat Articles
 
 **Search** (miku_ai):
-```python
-python3 -c "
+```bash
+# miku_ai is installed inside the agent-reach Python environment.
+# Use the same interpreter that runs agent-reach (handles pipx / venv installs):
+AGENT_REACH_PYTHON=$(python3 -c "import agent_reach, sys; print(sys.executable)" 2>/dev/null || echo python3)
+$AGENT_REACH_PYTHON -c "
 import asyncio
 from miku_ai import get_wexin_article
 async def s():
-    for a in await get_wexin_article('query', 5):
-        print(f'{a[\"title\"]} | {a[\"url\"]}')
+    for a in await get_wexin_article(\'query\', 5):
+        print(f\'{a[\"title\"]} | {a[\"url\"]}\')
 asyncio.run(s())
 "
 ```


### PR DESCRIPTION
## Problem

Fixes #187

`miku_ai` is installed **inside the agent-reach Python environment** (via `pipx inject` or `pip install` into the same venv). When users install agent-reach via pipx (the recommended method in `docs/install.md`), the system `python3` is a different interpreter — it cannot import `miku_ai`, causing `ModuleNotFoundError`.

The SKILL.md search example used bare `python3 -c ...`, which silently breaks for pipx users.

## Fix

Detect the correct interpreter at runtime:
```bash
AGENT_REACH_PYTHON=$(python3 -c "import agent_reach, sys; print(sys.executable)" 2>/dev/null || echo python3)
```

This resolves correctly for all install methods:
- **pipx**: resolves to `~/.local/share/pipx/venvs/agent-reach/bin/python`
- **venv**: resolves to the venv's python
- **plain pip / system install**: falls back to `python3` (same as before)

No hardcoded paths; no new dependencies.

## Verification

- `python3 -m pytest tests/ -x -q` → **49 passed**
- Diff: 1 file, 7 lines changed (SKILL.md only)