### PR TITLE
feat: Support OPENCLAW_HOME environment variable

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -271,11 +271,20 @@ def _install_skill():
     import importlib.resources
 
     # Determine skill install path
+    # Priority 1: OPENCLAW_HOME environment variable (if set)
+    # Priority 2: ~/.openclaw/skills (default)
+    # Priority 3: ~/.claude/skills (Claude Code)
+    # Priority 4: ~/.agents/skills (Generic agents)
     skill_dirs = [
         os.path.expanduser("~/.openclaw/skills"),   # OpenClaw
         os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
         os.path.expanduser("~/.agents/skills"),      # Generic agents
     ]
+
+    # Insert OPENCLAW_HOME path at the beginning if environment variable is set
+    openclaw_home = os.environ.get("OPENCLAW_HOME")
+    if openclaw_home:
+        skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
 
     installed = False
     for skill_dir in skill_dirs:


### PR DESCRIPTION
# PR: 支持 OPENCLAW_HOME 环境变量

## 问题描述

当前 `_install_skill()` 函数硬编码了 OpenClaw skills 目录为 `~/.openclaw/skills`，没有读取 `OPENCLAW_HOME` 环境变量。

当用户设置 `OPENCLAW_HOME=/data/openclaw` 时，Agent Reach 仍然会安装到 `~/.openclaw/skills/`，而不是 `$OPENCLAW_HOME/.openclaw/skills/`。

## 修复内容

在 `_install_skill()` 函数中，优先读取 `OPENCLAW_HOME` 环境变量，如果设置则将其对应的 skills 目录放在搜索列表的最前面。

### 修改前
```python
skill_dirs = [
    os.path.expanduser("~/.openclaw/skills"),   # OpenClaw
    os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
    os.path.expanduser("~/.agents/skills"),      # Generic agents
]
```

### 修改后
```python
skill_dirs = [
    os.path.expanduser("~/.openclaw/skills"),   # OpenClaw
    os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
    os.path.expanduser("~/.agents/skills"),      # Generic agents
]

# Insert OPENCLAW_HOME path at the beginning if environment variable is set
openclaw_home = os.environ.get("OPENCLAW_HOME")
if openclaw_home:
    skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
```

## 优先级

修复后的目录搜索优先级：
1. `$OPENCLAW_HOME/.openclaw/skills/` (如果设置了 OPENCLAW_HOME)
2. `~/.openclaw/skills/` (默认)
3. `~/.claude/skills/` (Claude Code)
4. `~/.agents/skills/` (Generic agents)

## 测试

设置 `OPENCLAW_HOME=/data/openclaw` 后运行 `agent-reach install`，skill 应安装到 `/data/openclaw/.openclaw/skills/agent-reach/`。

## 影响范围

- 仅影响新安装的用户
- 已安装的用户不受影响
- 向后兼容：未设置 OPENCLAW_HOME 时行为不变