### PR TITLE
docs(weibo): add comprehensive usage examples

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -126,6 +126,42 @@ cd ~/.agent-reach/tools/wechat-article-for-ai && python3 main.py "https://mp.wei
 
 > WeChat articles cannot be read with Jina Reader or curl. Must use Camoufox.
 
+## 微博 / Weibo (mcporter)
+
+```bash
+# 热搜榜
+mcporter call 'weibo.get_trendings(limit: 20)'
+
+# 搜索用户
+mcporter call 'weibo.search_users(keyword: "雷军", limit: 10)'
+
+# 获取用户资料
+mcporter call 'weibo.get_profile(uid: "1195230310")'
+
+# 获取用户微博动态
+mcporter call 'weibo.get_feeds(uid: "1195230310", limit: 20)'
+
+# 获取用户热门微博
+mcporter call 'weibo.get_hot_feeds(uid: "1195230310", limit: 10)'
+
+# 搜索微博内容
+mcporter call 'weibo.search_content(keyword: "人工智能", limit: 20)'
+
+# 搜索话题
+mcporter call 'weibo.search_topics(keyword: "AI", limit: 10)'
+
+# 获取微博评论
+mcporter call 'weibo.get_comments(mid: "5099916367123456", limit: 50)'
+
+# 获取粉丝列表
+mcporter call 'weibo.get_fans(uid: "1195230310", limit: 20)'
+
+# 获取关注列表
+mcporter call 'weibo.get_followers(uid: "1195230310", limit: 20)'
+```
+
+> Zero config. No login needed. Uses mobile API with auto visitor cookies.
+
 ## 小宇宙播客 / Xiaoyuzhou Podcast (groq-whisper + ffmpeg)
 
 ```bash


### PR DESCRIPTION
## 变更内容

在 SKILL.md 中添加微博渠道的完整使用示例。

## 功能覆盖

- ✅ 热搜榜 (get_trendings)
- ✅ 搜索用户 (search_users)
- ✅ 用户资料 (get_profile)
- ✅ 用户动态 (get_feeds / get_hot_feeds)
- ✅ 内容搜索 (search_content)
- ✅ 话题搜索 (search_topics)
- ✅ 评论列表 (get_comments)
- ✅ 粉丝/关注列表 (get_fans / get_followers)

## 技术细节

- 使用 mcp-server-weibo (Panniantong/mcp-server-weibo)
- 通过 mcporter 调用
- 零配置，不需要登录
- 自动获取访客 cookie

## 测试

- ✅ 所有测试通过 (15/15)
- ✅ 功能已在本地验证

Closes #179 (Bilibili 搜索问题已在 #182 修复)
Closes #180 (Bilibili doctor 检查已在 #182 修复)