### PR TITLE
fix(twitter): extract cookie parsing into helper function

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -913,21 +913,7 @@ def _cmd_configure(args):
         # Accept two formats:
         # 1. auth_token ct0 (two separate values)
         # 2. Full cookie header string: "auth_token=xxx; ct0=yyy; ..."
-        auth_token = None
-        ct0 = None
-
-        if "auth_token=" in value and "ct0=" in value:
-            # Full cookie string — parse it
-            for part in value.replace(";", " ").split():
-                if part.startswith("auth_token="):
-                    auth_token = part.split("=", 1)[1]
-                elif part.startswith("ct0="):
-                    ct0 = part.split("=", 1)[1]
-        elif len(value.split()) == 2 and "=" not in value:
-            # Two separate values: AUTH_TOKEN CT0
-            parts = value.split()
-            auth_token = parts[0]
-            ct0 = parts[1]
+        auth_token, ct0 = _parse_twitter_cookie_input(value)
 
         if auth_token and ct0:
             config.set("twitter_auth_token", auth_token)
@@ -1007,6 +993,27 @@ def _cmd_configure(args):
     elif args.key == "groq-key":
         config.set("groq_api_key", value)
         print(f"✅ Groq key configured!")
+
+
+def _parse_twitter_cookie_input(value: str):
+    """Parse Twitter cookie input from either separate values or a cookie header."""
+    auth_token = None
+    ct0 = None
+
+    if "auth_token=" in value and "ct0=" in value:
+        # Full cookie string — parse it.
+        for part in value.replace(";", " ").split():
+            if part.startswith("auth_token="):
+                auth_token = part.split("=", 1)[1]
+            elif part.startswith("ct0="):
+                ct0 = part.split("=", 1)[1]
+    elif len(value.split()) == 2 and "=" not in value:
+        # Two separate values: AUTH_TOKEN CT0.
+        parts = value.split()
+        auth_token = parts[0]
+        ct0 = parts[1]
+
+    return auth_token, ct0
 
 
 def _configure_xhs_cookies(value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,18 @@ class TestCLI:
         assert "Agent Reach" in captured.out
         assert "✅" in captured.out
 
+    def test_parse_twitter_cookie_input_separate_values(self):
+        auth_token, ct0 = cli._parse_twitter_cookie_input("token123 ct0abc")
+        assert auth_token == "token123"
+        assert ct0 == "ct0abc"
+
+    def test_parse_twitter_cookie_input_cookie_header(self):
+        auth_token, ct0 = cli._parse_twitter_cookie_input(
+            "auth_token=token123; ct0=ct0abc; other=value"
+        )
+        assert auth_token == "token123"
+        assert ct0 == "ct0abc"
+
 
 class TestCheckUpdateRetry:
     def test_retry_timeout_classification(self):


### PR DESCRIPTION
## Summary

Rebased version of PR #190 by @srxly888-creator — thank you for the contribution! 🎉

Extracts the Twitter cookie parsing logic from `_cmd_configure()` into a standalone `_parse_twitter_cookie_input()` function, improving maintainability and testability.

## Changes

- **`agent_reach/cli.py`**: Extract cookie parsing into `_parse_twitter_cookie_input()`
- **`tests/test_cli.py`**: Add 2 test cases for cookie parsing (separate values + header string)

## Tests

✅ All 10 CLI tests pass after rebase onto latest main (post bird migration).

Closes #191
Supersedes #190

Co-authored-by: srxly888-creator