### PR TITLE
feat(channels): add Discord and Slack support

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -23,6 +23,8 @@ from .weibo import WeiboChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .v2ex import V2EXChannel
 from .xueqiu import XueqiuChannel
+from .discord import DiscordChannel
+from .slack import SlackChannel
 
 
 
@@ -40,6 +42,8 @@ ALL_CHANNELS: List[Channel] = [
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),
+    DiscordChannel(),
+    SlackChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/discord.py
+++ b/agent_reach/channels/discord.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Discord — check connectivity and configuration."""
+
+import os
+import urllib.request
+from .base import Channel
+
+_TIMEOUT = 10
+
+
+def _discord_reachable() -> bool:
+    """Return True if Discord API is reachable."""
+    url = "https://discord.com/api/v10/gateway"
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+class DiscordChannel(Channel):
+    name = "discord"
+    description = "Discord 服务器消息和频道"
+    backends = ["Discord API"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "discord.com" in d or "discord.gg" in d
+
+    def check(self, config=None):
+        token = (config.get("discord_token") if config else None) or os.environ.get("DISCORD_TOKEN")
+        if not token:
+            return "warn", (
+                "未配置 Discord Bot Token。请设置环境变量：\n"
+                "  export DISCORD_TOKEN=your_bot_token"
+            )
+        if _discord_reachable():
+            return "ok", "Discord API 可达，Token 已配置"
+        return "warn", "Discord API 无法连接，请检查网络或代理配置"

--- a/agent_reach/channels/slack.py
+++ b/agent_reach/channels/slack.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Slack — check connectivity and configuration."""
+
+import os
+import urllib.request
+from .base import Channel
+
+_TIMEOUT = 10
+
+
+def _slack_reachable() -> bool:
+    """Return True if Slack API is reachable."""
+    url = "https://slack.com/api/api.test"
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+class SlackChannel(Channel):
+    name = "slack"
+    description = "Slack 工作区消息和频道"
+    backends = ["Slack API"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "slack.com" in d
+
+    def check(self, config=None):
+        token = (config.get("slack_token") if config else None) or os.environ.get("SLACK_TOKEN")
+        if not token:
+            return "warn", (
+                "未配置 Slack Token。请设置环境变量：\n"
+                "  export SLACK_TOKEN=xoxb-your-token"
+            )
+        if _slack_reachable():
+            return "ok", "Slack API 可达，Token 已配置"
+        return "warn", "Slack API 无法连接，请检查网络或代理配置"


### PR DESCRIPTION
## Summary

Add Discord and Slack as new channel platforms.

## Changes

- `discord.py`: Discord channel with URL recognition (`discord.com`, `discord.gg`), API connectivity check, and `DISCORD_TOKEN` configuration
- `slack.py`: Slack channel with URL recognition (`slack.com`), API connectivity check, and `SLACK_TOKEN` configuration
- `__init__.py`: Register both new channels

## Usage

Set environment variables to enable:
```bash
export DISCORD_TOKEN=your_bot_token
export SLACK_TOKEN=xoxb-your-token
```

Closes #189