### PR TITLE
docs: add alternative unified Douyin/XiaoHongShu MCP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,32 @@ channels/
 
 > 📌 这些都是「当前选型」。不满意？换掉对应文件就行。这正是脚手架的意义。
 
+### 抖音 / 小红书脚本提取的可选实现
+
+如果你不只是想“解析抖音视频信息”，还想统一处理：
+
+- 抖音视频脚本提取
+- 小红书视频笔记脚本提取
+- 小红书图文笔记正文 + 图片文字提取
+- 固定输出 `script.md` 和 `info.json`
+
+可以把 `douyin` 这个 mcporter alias 指向另一个兼容实现：
+
+- [social-post-extractor-mcp](https://github.com/JNHFlow21/social-post-extractor-mcp)
+
+这个实现保留了旧工具名兼容性：
+
+- `parse_douyin_video_info`
+- `get_douyin_download_link`
+- `extract_douyin_text`
+
+同时新增统一工具：
+
+- `parse_social_post_info`
+- `extract_social_post_script`
+
+所以从 Agent Reach 的视角看，它依然只是一个 `mcporter` 里的 `douyin` server，只是能力更完整。
+
 ---
 
 ## 安全性

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -294,6 +294,33 @@ Agent Reach integrates with xiaohongshu-mcp (runs in Docker). After setup, use `
 Install douyin-mcp-server, then your agent can use `mcporter call 'douyin.parse_douyin_video_info(share_link: "share_url")'` to parse video info and get watermark-free download links. No login required — just share the Douyin link. See https://github.com/yzfly/douyin-mcp-server
 </details>
 
+<details>
+<summary><strong>How to extract scripts from both Douyin and XiaoHongShu with one MCP?</strong></summary>
+
+If you want one MCP server that can handle:
+
+- Douyin videos
+- XiaoHongShu video notes
+- XiaoHongShu image notes
+
+and directly write `script.md` + `info.json`, you can point the existing `douyin` mcporter alias at:
+
+- https://github.com/JNHFlow21/social-post-extractor-mcp
+
+It keeps backward compatibility with:
+
+- `parse_douyin_video_info`
+- `get_douyin_download_link`
+- `extract_douyin_text`
+
+and adds unified tools:
+
+- `parse_social_post_info`
+- `extract_social_post_script`
+
+This is useful when your agent workflow is “paste a link, get a script file”.
+</details>
+
 ---
 
 ## Credits

--- a/docs/install.md
+++ b/docs/install.md
@@ -244,6 +244,45 @@ mcporter config add douyin http://localhost:18070/mcp
 >
 > 详见 https://github.com/yzfly/douyin-mcp-server
 
+**可选实现：Douyin + XiaoHongShu unified extractor**
+> "如果你想把抖音和小红书统一成一个 MCP，并直接输出 `script.md` 和 `info.json`，可以改用 social-post-extractor-mcp。"
+
+适用场景：
+
+- 抖音视频转文字稿
+- 小红书视频笔记转文字稿
+- 小红书图文笔记正文 + 图片文字提取
+
+兼容性：
+
+- 仍然可以注册成 `douyin` 这个 mcporter server 名称
+- 兼容旧工具名 `parse_douyin_video_info` / `get_douyin_download_link` / `extract_douyin_text`
+- 同时新增 `parse_social_post_info` / `extract_social_post_script`
+
+示例配置：
+
+```bash
+git clone https://github.com/JNHFlow21/social-post-extractor-mcp.git
+cd social-post-extractor-mcp
+uv sync
+
+mcporter config add douyin \
+  --command /bin/zsh \
+  --arg -lc \
+  --arg "cd '$PWD' && exec '.venv/bin/python' -m social_post_extractor_mcp" \
+  --env ASR_PROVIDER=bailian \
+  --env ASR_MODEL=paraformer-v2 \
+  --env VISION_PROVIDER=bailian \
+  --env VISION_MODEL=qwen3-vl-flash \
+  --env CLEAN_PROVIDER=bailian \
+  --env CLEAN_MODEL=qwen-flash \
+  --env BAILIAN_API_KEY=YOUR_BAILIAN_API_KEY
+```
+
+> 这个实现更适合“把链接直接交给 Agent，然后拿到脚本文件”的工作流。
+>
+> 详见 https://github.com/JNHFlow21/social-post-extractor-mcp
+
 **LinkedIn (可选 — linkedin-scraper-mcp):**
 > "LinkedIn 基本内容可通过 Jina Reader 读取。完整功能（Profile 详情、职位搜索）需要 linkedin-scraper-mcp。"
 


### PR DESCRIPTION
## Summary
- document `social-post-extractor-mcp` as an alternative MCP implementation for the existing `douyin` mcporter alias
- keep the current default `douyin-mcp-server` recommendation unchanged
- add installation/config examples for users who want one MCP for Douyin videos, XiaoHongShu video notes, and XiaoHongShu image notes

## Why
Agent Reach already treats channel backends as swappable upstream tools. This PR keeps that design, but documents a more capable optional implementation for users whose workflow is:
- paste a Douyin or XiaoHongShu link
- get `script.md` and `info.json`

The alternative MCP keeps backward compatibility with existing Douyin tool names while adding unified tools for social-post extraction.

## Scope
- docs only
- no code-path changes
- no default backend replacement
