### PR TITLE
fix(skill): show real error and helpful tip when skill install fails

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -327,8 +327,9 @@ def _install_skill():
             with open(os.path.join(target, "SKILL.md"), "w") as f:
                 f.write(skill_md)
             print(f"Skill installed: {target}")
-        except Exception:
-            print("  -- Could not install agent skill (optional)")
+        except Exception as e:
+            print(f"  -- Could not install agent skill (optional): {e}")
+            print("  -- Tip: install OpenClaw, Claude Code, or create ~/.agents/skills/ manually")
 
 
 def _uninstall_skill():


### PR DESCRIPTION
## Problem

Fixes #212

When no agent framework directory exists (~/.openclaw/skills, ~/.claude/skills, ~/.agents/skills), the fallback `os.makedirs` call silently swallows the real exception and prints a generic message:

```
-- Could not install agent skill (optional)
```

Users have no idea why it failed or what to do next.

## Changes

- Print the actual exception message alongside the existing notice
- Add a helpful tip pointing users to install OpenClaw/Claude Code or create `~/.agents/skills/` manually

## Testing

72 passed (1 pre-existing XiaoHongShu MCP test skipped — unrelated local env issue, passes on clean checkout)