### PR TITLE
fix(web): add read() via Jina Reader + skill install fallback

### DIFF
--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 """Web — any URL via Jina Reader. Always available."""
 
+import urllib.request
 from .base import Channel
+
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 
 
 class WebChannel(Channel):
@@ -15,3 +18,15 @@ class WebChannel(Channel):
 
     def check(self, config=None):
         return "ok", "通过 Jina Reader 读取任意网页（curl https://r.jina.ai/URL）"
+
+    def read(self, url: str) -> str:
+        """通过 Jina Reader 读取网页，返回 Markdown 全文。"""
+        if not url.startswith(("http://", "https://")):
+            url = "https://" + url
+        jina_url = f"https://r.jina.ai/{url}"
+        req = urllib.request.Request(
+            jina_url,
+            headers={"User-Agent": _UA, "Accept": "text/plain"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8")

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -334,12 +334,17 @@ def _install_skill():
                 shutil.rmtree(target)
             os.makedirs(target, exist_ok=True)
 
-            # Get skill directory from package
-            skill_pkg = importlib.resources.files("agent_reach").joinpath("skill")
+            # Get skill directory from package (with fallback for editable installs)
+            try:
+                skill_pkg = importlib.resources.files("agent_reach").joinpath("skill")
+                skill_md = skill_pkg.joinpath("SKILL.md").read_text(encoding="utf-8")
+            except Exception:
+                from pathlib import Path
+                skill_pkg = Path(__file__).resolve().parent / "skill"
+                skill_md = (skill_pkg / "SKILL.md").read_text(encoding="utf-8")
 
             # Copy SKILL.md
-            skill_md = skill_pkg.joinpath("SKILL.md").read_text()
-            with open(os.path.join(target, "SKILL.md"), "w") as f:
+            with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
                 f.write(skill_md)
 
             # Copy references/ directory
@@ -348,9 +353,10 @@ def _install_skill():
             os.makedirs(refs_target, exist_ok=True)
 
             for ref_file in refs_pkg.iterdir():
-                if ref_file.suffix == ".md":
-                    content = ref_file.read_text()
-                    with open(os.path.join(refs_target, ref_file.name), "w") as f:
+                name = ref_file.name if hasattr(ref_file, 'name') else str(ref_file).split('/')[-1]
+                if name.endswith(".md"):
+                    content = ref_file.read_text(encoding="utf-8") if hasattr(ref_file, 'read_text') else ref_file.read_text()
+                    with open(os.path.join(refs_target, name), "w", encoding="utf-8") as f:
                         f.write(content)
 
             return True


### PR DESCRIPTION
## Summary
- `WebChannel.read()`: reads any URL via Jina Reader, returns Markdown
- `_install_skill()`: fallback from `importlib.resources` to `Path(__file__)` for editable installs
- UTF-8 encoding on all skill file operations

Inspired by #215, implemented with Jina Reader (not raw requests).

Closes #215

## Test plan
- [x] 77 tests passing