### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "agent-reach",
+  "version": "0.1.0",
+  "description": "Read and search Twitter, Reddit, YouTube, GitHub and more from Codex",
+  "author": {
+    "name": "Panniantong",
+    "url": "https://github.com/Panniantong/Agent-Reach"
+  },
+  "homepage": "https://github.com/Panniantong/Agent-Reach",
+  "repository": "https://github.com/Panniantong/Agent-Reach",
+  "keywords": [
+    "mcp",
+    "agent",
+    "search",
+    "social",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Agent Reach",
+    "shortDescription": "Search the internet from Codex - Twitter, Reddit, YouTube, GitHub",
+    "longDescription": "Give your AI agent eyes to see the entire internet. Read and search Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu via one CLI.",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/Panniantong/Agent-Reach"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "agent-reach": {
+      "command": "agent-reach",
+      "args": []
+    }
+  }
+}

--- a/skills/agent-reach/SKILL.md
+++ b/skills/agent-reach/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: agent-reach
+description: Read and search Twitter, Reddit, YouTube, GitHub from Codex.
+---
+
+# Agent Reach for Codex
+
+Search the internet across multiple platforms. See https://github.com/Panniantong/Agent-Reach for setup.


### PR DESCRIPTION
Adds a `.codex-plugin/plugin.json` manifest so Agent Reach can be installed as a Codex CLI plugin.

**What this adds:**
- `.codex-plugin/plugin.json` — Plugin manifest
- `.mcp.json` — MCP server reference (agent-reach CLI)
- `skills/agent-reach/SKILL.md` — Usage guide

**Related:**
- [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) — Curated Codex plugins directory (submit a PR!)
- [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner) — Security scanner for Codex plugins