### PR TITLE
feat(channels): restore Toutiao search + read with retries and dedup

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -23,6 +23,7 @@ from .weibo import WeiboChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .v2ex import V2EXChannel
 from .xueqiu import XueqiuChannel
+from .toutiao import ToutiaoChannel
 
 
 ALL_CHANNELS: List[Channel] = [
@@ -39,6 +40,7 @@ ALL_CHANNELS: List[Channel] = [
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),
+    ToutiaoChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/toutiao.py
+++ b/agent_reach/channels/toutiao.py
@@ -9,7 +9,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 from .base import Channel
 

--- a/agent_reach/channels/toutiao.py
+++ b/agent_reach/channels/toutiao.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Toutiao (今日头条) — search articles and trending content."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Dict, List, Tuple
+
+from .base import Channel
+
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+_TIMEOUT_SEARCH = 22.0
+_TIMEOUT_READ = 30.0
+_SEARCH_ATTEMPTS = 3
+_READ_ATTEMPTS = 3
+_SEARCH_URL = (
+    "https://so.toutiao.com/search"
+    "?dvpf=pc&source=input&keyword={keyword}&enable_druid_v2=1"
+)
+
+_SKIP_TEMPLATES = ("Search", "Bottom", "76-", "20-", "26-", "67-baike")
+
+
+def _should_retry_http(err: urllib.error.HTTPError) -> bool:
+    code = getattr(err, "code", 0) or 0
+    return code == 429 or code >= 500
+
+
+def _request_body(
+    url: str,
+    *,
+    headers: Dict[str, str],
+    timeout: float,
+    attempts: int,
+) -> bytes:
+    """GET url with retries on transient network / server errors."""
+    last_exc: BaseException | None = None
+    for i in range(attempts):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            last_exc = e
+            if _should_retry_http(e) and i < attempts - 1:
+                time.sleep(0.4 * (2**i))
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_exc = e
+            if i < attempts - 1:
+                time.sleep(0.4 * (2**i))
+                continue
+            raise
+    assert last_exc is not None
+    raise last_exc
+
+
+def _fetch_html(url: str) -> str:
+    data = _request_body(
+        url,
+        headers={"User-Agent": _UA},
+        timeout=_TIMEOUT_SEARCH,
+        attempts=_SEARCH_ATTEMPTS,
+    )
+    return data.decode("utf-8", errors="replace")
+
+
+def _parse_search_results(html: str) -> list:
+    """Extract article results from Toutiao search page HTML.
+
+    The page embeds each search result as a JSON object inside a <script> tag.
+    """
+    scripts = re.findall(r"<script[^>]*>(.*?)</script>", html, re.DOTALL)
+    articles: list = []
+    seen_urls: set[str] = set()
+    for s in scripts:
+        if len(s) < 1000:
+            continue
+        if not s.strip().startswith("{"):
+            continue
+        try:
+            data = json.loads(s).get("data", {})
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        title = data.get("title", "")
+        tpl = data.get("template_key", "")
+        if not title:
+            continue
+        if any(tpl.startswith(p) for p in _SKIP_TEMPLATES):
+            continue
+
+        # article_url is the primary field; display paths are fallbacks
+        article_url = (
+            data.get("article_url", "")
+            or data.get("source_url", "")
+            or (data.get("display") or {}).get("info", {}).get("url", "")
+        )
+
+        if not article_url or article_url in seen_urls:
+            continue
+        seen_urls.add(article_url)
+
+        articles.append({
+            "title": title,
+            "url": article_url,
+            "source": data.get("media_name", "") or data.get("source", ""),
+            "abstract": (data.get("abstract", "") or "")[:300],
+            "publish_time": data.get("publish_time"),
+            "read_count": data.get("read_count"),
+            "comment_count": data.get("comment_count"),
+        })
+    return articles
+
+
+class ToutiaoChannel(Channel):
+    name = "toutiao"
+    description = "今日头条搜索与资讯"
+    backends = ["Toutiao Web (public)"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+
+        d = urlparse(url).netloc.lower()
+        return "toutiao.com" in d
+
+    def check(self, config=None) -> Tuple[str, str]:
+        try:
+            test_url = _SEARCH_URL.format(keyword="test")
+            content = _request_body(
+                test_url,
+                headers={"User-Agent": _UA},
+                timeout=_TIMEOUT_SEARCH,
+                attempts=_SEARCH_ATTEMPTS,
+            ).decode("utf-8", errors="replace")
+            if "data" in content or "title" in content:
+                return "ok", "头条搜索可用（搜索文章、视频、资讯；依赖页面内嵌 JSON，可能随站点改版变化）"
+            return "warn", "头条搜索返回非预期内容"
+        except Exception as e:
+            return "warn", f"头条搜索连接失败（可稍后重试或检查网络/代理）：{e}"
+
+    def read(self, url: str) -> str:
+        """通过 Jina Reader 读取头条文章正文。"""
+        if not url.startswith(("http://", "https://")):
+            url = "https://" + url
+        jina_url = f"https://r.jina.ai/{url}"
+        data = _request_body(
+            jina_url,
+            headers={"User-Agent": _UA, "Accept": "text/plain"},
+            timeout=_TIMEOUT_READ,
+            attempts=_READ_ATTEMPTS,
+        )
+        return data.decode("utf-8", errors="replace")
+
+    def search(self, keyword: str, limit: int = 10) -> list:
+        """搜索头条文章。
+
+        Args:
+            keyword: 搜索关键词
+            limit:   最多返回条数
+
+        Returns:
+            list of dicts with keys:
+              title, url, source, abstract, publish_time, read_count, comment_count
+        """
+        encoded = urllib.parse.quote(keyword)
+        url = _SEARCH_URL.format(keyword=encoded)
+        html = _fetch_html(url)
+        return _parse_search_results(html)[:limit]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -28,6 +28,7 @@ class TestChannelRegistry:
         assert "github" in names
         assert "twitter" in names
         assert "v2ex" in names
+        assert "toutiao" in names
 
 
 class TestV2EXChannel:

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -35,7 +35,7 @@ class TestSkillCommand(unittest.TestCase):
                 if "SKILL.md" in filenames:
                     found = True
                     # Verify content is non-empty
-                    with open(os.path.join(dirpath, "SKILL.md")) as f:
+                    with open(os.path.join(dirpath, "SKILL.md"), encoding="utf-8") as f:
                         content = f.read()
                     self.assertIn("Agent Reach", content)
             # _install_skill may or may not find dirs depending on mock; just ensure no crash
@@ -81,7 +81,7 @@ class TestSkillCommand(unittest.TestCase):
 
             target = os.path.join(skill_parent, "agent-reach", "SKILL.md")
             self.assertTrue(os.path.exists(target))
-            with open(target) as f:
+            with open(target, encoding="utf-8") as f:
                 content = f.read()
             self.assertIn("Agent Reach", content)
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -28,12 +28,9 @@ class TestSkillCommand(unittest.TestCase):
                 with patch.dict(os.environ, env, clear=True):
                     _install_skill()
 
-            target = os.path.join(skill_dir, "agent-reach", "SKILL.md")
             # Check at least one known skill dir pattern
-            found = False
             for dirpath, _, filenames in os.walk(tmpdir):
                 if "SKILL.md" in filenames:
-                    found = True
                     # Verify content is non-empty
                     with open(os.path.join(dirpath, "SKILL.md"), encoding="utf-8") as f:
                         content = f.read()

--- a/tests/test_toutiao_channel.py
+++ b/tests/test_toutiao_channel.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Tests for ToutiaoChannel."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_reach.channels.toutiao import ToutiaoChannel, _parse_search_results
+
+
+@pytest.fixture
+def ch():
+    return ToutiaoChannel()
+
+
+class TestToutiaoChannelAttributes:
+    def test_name(self, ch):
+        assert ch.name == "toutiao"
+
+    def test_tier(self, ch):
+        assert ch.tier == 0
+
+    def test_backends(self, ch):
+        assert ch.backends
+
+
+class TestToutiaoCanHandle:
+    def test_matches_toutiao(self, ch):
+        assert ch.can_handle("https://www.toutiao.com/article/123")
+
+    def test_matches_search(self, ch):
+        assert ch.can_handle("https://so.toutiao.com/search?keyword=ai")
+
+    def test_rejects_other(self, ch):
+        assert not ch.can_handle("https://www.baidu.com")
+
+
+class TestToutiaoCheck:
+    def test_check_ok(self, ch):
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"data": {"title": "test"}}'
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            status, msg = ch.check()
+        assert status == "ok"
+
+    def test_check_exception(self, ch):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            status, msg = ch.check()
+        assert status == "warn"
+        assert "timeout" in msg
+
+
+class TestParseSearchResults:
+    def _make_script(self, data: dict) -> str:
+        # Production code skips scripts < 1000 chars; pad to exceed threshold
+        payload = json.dumps({"data": data})
+        padding = "x" * max(0, 1001 - len(payload))
+        padded = payload[:-1] + f',"_pad":"{padding}"' + payload[-1]
+        return f'<script type="text/javascript">{padded}</script>'
+
+    def test_extracts_article_url_first(self):
+        html = self._make_script({
+            "title": "测试文章",
+            "article_url": "https://www.toutiao.com/article/1",
+            "template_key": "undefined-default",
+        })
+        results = _parse_search_results(html)
+        assert len(results) == 1
+        assert results[0]["url"] == "https://www.toutiao.com/article/1"
+        assert results[0]["title"] == "测试文章"
+
+    def test_fallback_to_source_url(self):
+        html = self._make_script({
+            "title": "备用 URL 文章",
+            "source_url": "https://www.toutiao.com/source/1",
+            "template_key": "undefined-default",
+        })
+        results = _parse_search_results(html)
+        assert len(results) == 1
+        assert results[0]["url"] == "https://www.toutiao.com/source/1"
+
+    def test_skips_entries_without_url(self):
+        html = self._make_script({
+            "title": "无 URL 文章",
+            "template_key": "undefined-default",
+        })
+        results = _parse_search_results(html)
+        assert results == []
+
+    def test_skips_entries_without_title(self):
+        html = self._make_script({
+            "article_url": "https://www.toutiao.com/article/1",
+            "template_key": "undefined-default",
+        })
+        results = _parse_search_results(html)
+        assert results == []
+
+    def test_skips_skip_templates(self):
+        html = self._make_script({
+            "title": "广告",
+            "article_url": "https://www.toutiao.com/article/1",
+            "template_key": "Bottom-ad",
+        })
+        results = _parse_search_results(html)
+        assert results == []
+
+    def test_deduplicates_same_url(self):
+        block = {
+            "title": "同一链接",
+            "article_url": "https://www.toutiao.com/article/9",
+            "template_key": "undefined-default",
+        }
+        html = self._make_script(block) + self._make_script(block)
+        results = _parse_search_results(html)
+        assert len(results) == 1
+
+    def test_empty_html(self):
+        assert _parse_search_results("") == []
+
+    def test_short_scripts_ignored(self):
+        # script < 1000 chars should be skipped
+        html = '<script>{"data": {"title": "x", "article_url": "y"}}</script>'
+        assert _parse_search_results(html) == []


### PR DESCRIPTION
Responds to concerns in #234 about '抓取脆弱' (fragile scraping):

- Added request retries with exponential backoff
- Added timeouts for search and Jina read operations
- Added URL-based deduplication of results
- Added risk notes in check about embedded JSON that may change with site updates

Also includes UTF-8 reading fix for Windows skill testing.

Background: #207, #229