### PR TITLE
Add SECURITY.md — security policy and responsible disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | ✅ Yes    |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Agent-Reach, please report 
+it responsibly by using GitHub's private security advisory feature:
+
+👉 **[Report a vulnerability](https://github.com/Panniantong/Agent-Reach/security/advisories/new)**
+
+Please do NOT open a public GitHub issue for security vulnerabilities.
+
+## What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+- Suggested fix (if any)
+
+## Response Timeline
+
+- Acknowledgement within **48 hours**
+- Status update within **7 days**
+- Fix timeline communicated within **14 days**
+
+## Scope
+
+The following are considered in scope:
+- Authentication and authorization bypass
+- Remote code execution
+- Path traversal / arbitrary file read
+- Server-Side Request Forgery (SSRF)
+- Injection vulnerabilities (SQL, command, prompt)
+- Sensitive data exposure
+
+## Out of Scope
+
+- Vulnerabilities in dependencies (report to the dependency maintainer)
+- Social engineering attacks
+- Denial of service via resource exhaustion
+
+## Credits
+
+We appreciate responsible disclosure and will credit researchers 
+in our release notes unless anonymity is requested.


### PR DESCRIPTION
## Summary
This PR adds a SECURITY.md file to establish a clear security policy 
and responsible disclosure process for Agent-Reach.

## Why this matters
Agent-Reach has 16.7k stars and connects to Twitter, Reddit, YouTube, 
GitHub, Bilibili and XiaoHongShu APIs. A clear security policy helps:

- Researchers know how to report vulnerabilities privately
- Maintainers receive structured, actionable reports
- Users trust the project takes security seriously

## What's included
- Supported versions table
- Private reporting instructions (GitHub Security Advisories)
- Response timeline commitments
- Scope definition (in/out of scope)
- Researcher credit policy

Happy to adjust any details based on your preferences!