### PR TITLE
docs: fix Douyin MCP installation and configuration instructions

### DIFF
--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -44,6 +44,27 @@ xhs favorites              # 可能返回 API error
 
 ## 抖音 / Douyin
 
+### 安装与配置
+
+`douyin-mcp-server` 是 **stdio 模式**的 MCP server，需先安装再注册到 mcporter：
+
+```bash
+# 1. 安装
+pipx install douyin-mcp-server
+
+# 2. 查找安装路径
+pipx runpip douyin-mcp-server show -f 2>/dev/null | grep "Location" \
+  || find ~/.local -name "douyin-mcp-server" 2>/dev/null | head -1
+
+# 3. 注册到 mcporter（使用 stdio 模式，将路径替换为上一步的输出）
+mcporter config add douyin --command "/path/to/douyin-mcp-server" --scope home
+```
+
+> **注意**：`agent-reach install --channels douyin` 暂不支持抖音渠道（抖音在"可选渠道待解锁"列表）。
+> HTTP 模式（`mcporter config add douyin http://localhost:18070/mcp`）**无法正常工作**，请使用上方 stdio 方式。
+
+### 用法
+
 ```bash
 # 解析视频信息
 mcporter call 'douyin.parse_douyin_video_info(share_link: "https://v.douyin.com/xxx/")'


### PR DESCRIPTION
## What

The Douyin section in `agent_reach/skill/references/social.md` had three errors that prevented users from successfully setting up the Douyin MCP channel.

## Errors Fixed

1. **Missing install command** — `agent-reach install --channels douyin` is not a valid command (Douyin appears in the "optional channels pending unlock" list in doctor output). Added the correct `pipx install douyin-mcp-server` step.

2. **HTTP mode does not work** — `mcporter config add douyin http://localhost:18070/mcp` was implied as the setup method but the service cannot start in HTTP mode. Added a note that HTTP mode is broken.

3. **Correct stdio mode not documented** — `douyin-mcp-server` is a stdio MCP server. Added the correct registration command using `--command` flag, plus a tip for finding the pipx install path.

## Testing

- [x] Verified against issue report and `douyin-mcp-server` documentation
- [x] Existing usage commands (`parse_douyin_video_info`, `get_douyin_download_link`, `extract_douyin_text`) unchanged
- [x] Docs-only change — no code modified

## Related

Closes #256