### PR TITLE
feat(channels): add Instagram and TikTok support

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -17,6 +17,8 @@ from .bilibili import BilibiliChannel
 from .exa_search import ExaSearchChannel
 from .xiaohongshu import XiaoHongShuChannel
 from .douyin import DouyinChannel
+from .instagram import InstagramChannel
+from .tiktok import TikTokChannel
 from .linkedin import LinkedInChannel
 from .wechat import WeChatChannel
 from .weibo import WeiboChannel
@@ -33,6 +35,8 @@ ALL_CHANNELS: List[Channel] = [
     BilibiliChannel(),
     XiaoHongShuChannel(),
     DouyinChannel(),
+    InstagramChannel(),
+    TikTokChannel(),
     LinkedInChannel(),
     WeChatChannel(),
     WeiboChannel(),

--- a/agent_reach/channels/instagram.py
+++ b/agent_reach/channels/instagram.py
@@ -2,6 +2,7 @@
 """Instagram — check if yt-dlp is available for public posts and reels."""
 
 import shutil
+
 from .base import Channel
 
 
@@ -13,6 +14,7 @@ class InstagramChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         d = urlparse(url).netloc.lower()
         return "instagram.com" in d or "instagr.am" in d
 

--- a/agent_reach/channels/instagram.py
+++ b/agent_reach/channels/instagram.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Instagram — check if yt-dlp is available for public posts and reels."""
+
+import shutil
+from .base import Channel
+
+
+class InstagramChannel(Channel):
+    name = "instagram"
+    description = "Instagram 公开帖子和 Reels"
+    backends = ["yt-dlp"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "instagram.com" in d or "instagr.am" in d
+
+    def check(self, config=None):
+        if not shutil.which("yt-dlp"):
+            return "off", (
+                "yt-dlp 未安装。安装：pip install yt-dlp\n"
+                "  支持公开帖子和 Reels，私密内容需登录 cookie。"
+            )
+        return "ok", "可提取公开帖子和 Reels 的元数据（需 cookie 访问私密内容）"

--- a/agent_reach/channels/tiktok.py
+++ b/agent_reach/channels/tiktok.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""TikTok — check if yt-dlp is available for public videos."""
+
+import shutil
+from .base import Channel
+
+
+class TikTokChannel(Channel):
+    name = "tiktok"
+    description = "TikTok 短视频"
+    backends = ["yt-dlp"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "tiktok.com" in d or "vm.tiktok.com" in d
+
+    def check(self, config=None):
+        if not shutil.which("yt-dlp"):
+            return "off", (
+                "yt-dlp 未安装。安装：pip install yt-dlp\n"
+                "  支持公开视频的元数据和字幕提取。"
+            )
+        return "ok", "可提取公开视频元数据和字幕"

--- a/agent_reach/channels/tiktok.py
+++ b/agent_reach/channels/tiktok.py
@@ -2,6 +2,7 @@
 """TikTok — check if yt-dlp is available for public videos."""
 
 import shutil
+
 from .base import Channel
 
 
@@ -13,13 +14,13 @@ class TikTokChannel(Channel):
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse
+
         d = urlparse(url).netloc.lower()
         return "tiktok.com" in d or "vm.tiktok.com" in d
 
     def check(self, config=None):
         if not shutil.which("yt-dlp"):
             return "off", (
-                "yt-dlp 未安装。安装：pip install yt-dlp\n"
-                "  支持公开视频的元数据和字幕提取。"
+                "yt-dlp 未安装。安装：pip install yt-dlp\n  支持公开视频的元数据和字幕提取。"
             )
         return "ok", "可提取公开视频元数据和字幕"

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -7,6 +7,8 @@ import subprocess
 from urllib.error import URLError
 
 from agent_reach.channels import get_all_channels, get_channel
+from agent_reach.channels.instagram import InstagramChannel
+from agent_reach.channels.tiktok import TikTokChannel
 from agent_reach.channels.v2ex import V2EXChannel
 from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
 from agent_reach.channels.xueqiu import XueqiuChannel
@@ -742,3 +744,55 @@ class TestXiaoHongShuChannel:
         status, msg = XiaoHongShuChannel().check()
         assert status == "off"
         assert "xiaohongshu-cli" in msg
+
+
+class TestInstagramChannel:
+    def test_can_handle_instagram_urls(self):
+        ch = InstagramChannel()
+        assert ch.can_handle("https://www.instagram.com/p/abc123/")
+        assert ch.can_handle("https://instagram.com/reel/xyz789/")
+        assert ch.can_handle("https://instagr.am/p/abc123/")
+        assert not ch.can_handle("https://twitter.com/user")
+        assert not ch.can_handle("https://tiktok.com/@user/video/1")
+
+    def test_check_ok_when_ytdlp_installed(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None)
+        status, msg = InstagramChannel().check()
+        assert status == "ok"
+        assert "Reels" in msg
+
+    def test_check_off_when_ytdlp_missing(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+        status, msg = InstagramChannel().check()
+        assert status == "off"
+        assert "yt-dlp" in msg
+
+    def test_registered_in_all_channels(self):
+        names = [ch.name for ch in get_all_channels()]
+        assert "instagram" in names
+
+
+class TestTikTokChannel:
+    def test_can_handle_tiktok_urls(self):
+        ch = TikTokChannel()
+        assert ch.can_handle("https://www.tiktok.com/@user/video/123456789")
+        assert ch.can_handle("https://tiktok.com/@user/video/1")
+        assert ch.can_handle("https://vm.tiktok.com/abc123/")
+        assert not ch.can_handle("https://instagram.com/p/abc/")
+        assert not ch.can_handle("https://youtube.com/watch?v=abc")
+
+    def test_check_ok_when_ytdlp_installed(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None)
+        status, msg = TikTokChannel().check()
+        assert status == "ok"
+        assert "字幕" in msg or "metadata" in msg.lower() or "元数据" in msg
+
+    def test_check_off_when_ytdlp_missing(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+        status, msg = TikTokChannel().check()
+        assert status == "off"
+        assert "yt-dlp" in msg
+
+    def test_registered_in_all_channels(self):
+        names = [ch.name for ch in get_all_channels()]
+        assert "tiktok" in names

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -129,15 +129,27 @@ class TestV2EXChannel:
         import urllib.request
 
         fake_data = [
-            {"id": i, "title": f"Topic {i}", "url": f"https://v2ex.com/t/{i}", "replies": i,
-             "content": "", "created": 1700000000 + i, "node": {"name": "tech", "title": "Tech"}}
+            {
+                "id": i,
+                "title": f"Topic {i}",
+                "url": f"https://v2ex.com/t/{i}",
+                "replies": i,
+                "content": "",
+                "created": 1700000000 + i,
+                "node": {"name": "tech", "title": "Tech"},
+            }
             for i in range(10)
         ]
 
         class FakeResponse:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(fake_data).encode()
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_data).encode()
 
         monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
         topics = V2EXChannel().get_hot_topics(limit=3)
@@ -148,14 +160,26 @@ class TestV2EXChannel:
 
         long_content = "A" * 300
         fake_data = [
-            {"id": 1, "title": "Long post", "url": "https://v2ex.com/t/1", "replies": 0,
-             "content": long_content, "created": 1700000000, "node": {"name": "tech", "title": "Tech"}}
+            {
+                "id": 1,
+                "title": "Long post",
+                "url": "https://v2ex.com/t/1",
+                "replies": 0,
+                "content": long_content,
+                "created": 1700000000,
+                "node": {"name": "tech", "title": "Tech"},
+            }
         ]
 
         class FakeResponse:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(fake_data).encode()
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_data).encode()
 
         monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
         topics = V2EXChannel().get_hot_topics(limit=1)
@@ -181,9 +205,14 @@ class TestV2EXChannel:
         ]
 
         class FakeResponse:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(fake_data).encode()
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_data).encode()
 
         monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
         topics = V2EXChannel().get_node_topics("python")
@@ -229,9 +258,14 @@ class TestV2EXChannel:
             def __init__(self, payload):
                 self._payload = payload
 
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(self._payload).encode()
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(self._payload).encode()
 
         def fake_urlopen(req, timeout=None):
             url = req.full_url
@@ -267,10 +301,17 @@ class TestV2EXChannel:
         ]
 
         class FakeResponse:
-            def __init__(self, payload): self._payload = payload
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(self._payload).encode()
+            def __init__(self, payload):
+                self._payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(self._payload).encode()
 
         def fake_urlopen(req, timeout=None):
             if "replies" in req.full_url:
@@ -304,9 +345,14 @@ class TestV2EXChannel:
         }
 
         class FakeResponse:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return json.dumps(fake_user).encode()
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_user).encode()
 
         monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResponse())
         user = V2EXChannel().get_user("alice")
@@ -344,9 +390,7 @@ class TestXueqiuChannel:
 
         fake_response_data = {
             "data": {
-                "items": [
-                    {"quote": {"symbol": "SH000001", "name": "上证指数", "current": 3200.0}}
-                ]
+                "items": [{"quote": {"symbol": "SH000001", "name": "上证指数", "current": 3200.0}}]
             }
         }
 
@@ -487,7 +531,14 @@ class TestXueqiuChannel:
 
         fake_data = {
             "list": [
-                make_item(111, "市场分析", "<p>今天大盘走势&amp;分析</p>", "投资者A", 42, "/1234567890/111"),
+                make_item(
+                    111,
+                    "市场分析",
+                    "<p>今天大盘走势&amp;分析</p>",
+                    "投资者A",
+                    42,
+                    "/1234567890/111",
+                ),
                 make_item(222, "", "短评", "投资者B", 10, "/9876543210/222"),
             ]
         }
@@ -520,14 +571,16 @@ class TestXueqiuChannel:
         fake_data = {
             "list": [
                 {
-                    "data": json.dumps({
-                        "id": i,
-                        "title": f"Post {i}",
-                        "text": f"Content {i}",
-                        "user": {"screen_name": f"User {i}"},
-                        "like_count": i,
-                        "target": f"/user/{i}",
-                    }),
+                    "data": json.dumps(
+                        {
+                            "id": i,
+                            "title": f"Post {i}",
+                            "text": f"Content {i}",
+                            "user": {"screen_name": f"User {i}"},
+                            "like_count": i,
+                            "target": f"/user/{i}",
+                        }
+                    ),
                     "original_status": None,
                 }
                 for i in range(10)
@@ -603,18 +656,24 @@ class TestXueqiuChannel:
                 return default
 
         import agent_reach.channels.xueqiu as xq_mod
+
         monkeypatch.setattr(
             xq_mod,
             "_load_cookies_from_config",
-            lambda: (xq_mod._inject_cookie_string("xq_a_token=TESTTOKEN; xq_is_login=1") or True),
+            lambda: xq_mod._inject_cookie_string("xq_a_token=TESTTOKEN; xq_is_login=1") or True,
         )
         monkeypatch.setattr(xq_mod, "_load_cookies_from_browser", lambda: False)
 
         # Patch opener so no real HTTP call is made
         class FakeResp:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return b'{"data":{"items":[]}}'
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return b'{"data":{"items":[]}}'
 
         monkeypatch.setattr(xq_mod._opener, "open", lambda req, timeout=None: FakeResp())
 
@@ -631,9 +690,14 @@ class TestXueqiuChannel:
         captured = {}
 
         class FakeResp:
-            def __enter__(self): return self
-            def __exit__(self, *_): pass
-            def read(self): return b'{"data":{"items":[]}}'
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return b'{"data":{"items":[]}}'
 
         def fake_open(req, timeout=None):
             captured["ua"] = req.get_header("User-agent")
@@ -731,7 +795,9 @@ class TestXiaoHongShuChannel:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "", "ok: false\nerror:\n  code: not_authenticated\n")
+            return subprocess.CompletedProcess(
+                cmd, 1, "", "ok: false\nerror:\n  code: not_authenticated\n"
+            )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -756,7 +822,9 @@ class TestInstagramChannel:
         assert not ch.can_handle("https://tiktok.com/@user/video/1")
 
     def test_check_ok_when_ytdlp_installed(self, monkeypatch):
-        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None)
+        monkeypatch.setattr(
+            shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None
+        )
         status, msg = InstagramChannel().check()
         assert status == "ok"
         assert "Reels" in msg
@@ -782,7 +850,9 @@ class TestTikTokChannel:
         assert not ch.can_handle("https://youtube.com/watch?v=abc")
 
     def test_check_ok_when_ytdlp_installed(self, monkeypatch):
-        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None)
+        monkeypatch.setattr(
+            shutil, "which", lambda cmd: "/usr/local/bin/yt-dlp" if cmd == "yt-dlp" else None
+        )
         status, msg = TikTokChannel().check()
         assert status == "ok"
         assert "字幕" in msg or "metadata" in msg.lower() or "元数据" in msg


### PR DESCRIPTION
## What

Adds `InstagramChannel` and `TikTokChannel` using `yt-dlp` as the backend, following the same pattern as the existing `YouTubeChannel` and `BilibiliChannel`.

## Changes

- `agent_reach/channels/instagram.py` — handles `instagram.com` and `instagr.am` URLs; tier-0 (yt-dlp already a dependency); supports public posts and Reels; notes cookie requirement for private content
- `agent_reach/channels/tiktok.py` — handles `tiktok.com` and `vm.tiktok.com` URLs; tier-0; supports public video metadata and subtitle extraction
- `agent_reach/channels/__init__.py` — registers both new channels in `ALL_CHANNELS`
- `tests/test_channels.py` — adds `TestInstagramChannel` and `TestTikTokChannel` with `can_handle()`, `check()` (yt-dlp present/absent), and registry assertions

## Testing

- [x] `TestInstagramChannel` — can_handle, check ok, check off, registry — PASSED
- [x] `TestTikTokChannel` — can_handle, check ok, check off, registry — PASSED
- [x] Follows existing channel contract (`can_handle`, `check`, `name`, `description`, `backends`, `tier`)

## Related

Closes #184