### PR TITLE
feat(channels): add Xquik as X/Twitter search source via API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,8 @@
 # Reddit ISP Proxy (optional, for full Reddit access)
 # REDDIT_PROXY=http://user:pass@ip:port
 
+# Xquik (optional, X/Twitter search & user lookup via API key) — https://xquik.com
+# XQUIK_API_KEY=xk_your_key_here
+
 # Groq Whisper (optional, for video transcription) — https://console.groq.com
 # GROQ_API_KEY=gsk_your_key_here

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@
 # Reddit ISP Proxy (optional, for full Reddit access)
 # REDDIT_PROXY=http://user:pass@ip:port
 
+# Xquik (optional, X/Twitter search & user lookup via API key) — https://xquik.com
+# XQUIK_API_KEY=xk_your_key_here
+
 # Groq Whisper (optional, for video transcription) — https://console.groq.com
 # GROQ_API_KEY=gsk_your_key_here
 

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -23,11 +23,13 @@ from .weibo import WeiboChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .v2ex import V2EXChannel
 from .xueqiu import XueqiuChannel
+from .xquik import XquikChannel
 
 
 ALL_CHANNELS: List[Channel] = [
     GitHubChannel(),
     TwitterChannel(),
+    XquikChannel(),
     YouTubeChannel(),
     RedditChannel(),
     BilibiliChannel(),

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,11 +20,13 @@ from .linkedin import LinkedInChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .v2ex import V2EXChannel
 from .xueqiu import XueqiuChannel
+from .xquik import XquikChannel
 
 
 ALL_CHANNELS: List[Channel] = [
     GitHubChannel(),
     TwitterChannel(),
+    XquikChannel(),
     YouTubeChannel(),
     RedditChannel(),
     BilibiliChannel(),

--- a/agent_reach/channels/xquik.py
+++ b/agent_reach/channels/xquik.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""Xquik — X/Twitter search, tweet lookup, user profiles & trends via API key."""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from .base import Channel
+
+_BASE = "https://xquik.com/api/v1"
+_UA = "agent-reach/1.0"
+_TIMEOUT = 15
+
+
+def _get_api_key() -> str:
+    """Return the Xquik API key from env or empty string."""
+    return os.environ.get("XQUIK_API_KEY", "")
+
+
+def _get_json(path: str, params: dict[str, Any] | None = None) -> Any:
+    """Fetch *path* from the Xquik API and return parsed JSON.
+
+    Raises urllib.error.HTTPError on non-2xx or ValueError on bad JSON.
+    """
+    api_key = _get_api_key()
+    url = f"{_BASE}{path}"
+    if params:
+        qs = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
+        url = f"{url}?{qs}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": _UA,
+            "X-API-Key": api_key,
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class XquikChannel(Channel):
+    name = "xquik"
+    description = "X/Twitter 搜索、推文、用户与趋势（API Key）"
+    backends = ["Xquik API"]
+    tier = 1
+
+    # ------------------------------------------------------------------ #
+    # URL routing
+    # ------------------------------------------------------------------ #
+
+    def can_handle(self, url: str) -> bool:
+        d = urllib.parse.urlparse(url).netloc.lower()
+        return "x.com" in d or "twitter.com" in d
+
+    # ------------------------------------------------------------------ #
+    # Health check
+    # ------------------------------------------------------------------ #
+
+    def check(self, config=None):
+        api_key = _get_api_key()
+        if not api_key:
+            return "off", (
+                "Xquik API Key 未配置。获取方式：\n"
+                "  1. 注册 https://xquik.com\n"
+                '  2. 设置环境变量：export XQUIK_API_KEY="xk_your_key"'
+            )
+        try:
+            data = _get_json("/trends", {"count": 1})
+            if data.get("trends"):
+                return "ok", (
+                    "Xquik API 可用（搜索推文、用户查询、趋势，"
+                    "含互动数据：点赞/转发/回复/引用/浏览/收藏）"
+                )
+            return "warn", "Xquik API Key 有效但返回数据为空"
+        except urllib.error.HTTPError as e:
+            if e.code == 401:
+                return "warn", (
+                    "Xquik API Key 无效或过期。请检查：https://xquik.com/dashboard/api-keys"
+                )
+            return "warn", f"Xquik API 连接失败（HTTP {e.code}）"
+        except Exception as e:
+            return "warn", f"Xquik API 连接失败：{e}"
+
+    # ------------------------------------------------------------------ #
+    # Data-fetching methods
+    # ------------------------------------------------------------------ #
+
+    def search_tweets(
+        self,
+        query: str,
+        limit: int = 20,
+        query_type: str = "Latest",
+        cursor: str | None = None,
+    ) -> dict:
+        """搜索推文。
+
+        支持 X 搜索语法：关键词、#标签、from:用户、"精确匹配"、
+        since:YYYY-MM-DD、until:YYYY-MM-DD、min_faves:N。
+
+        Args:
+            query:      搜索关键词
+            limit:      最多返回条数（上限 200）
+            query_type: "Latest"（最新）或 "Top"（热门）
+            cursor:     分页游标（来自上一次响应的 next_cursor）
+
+        Returns a dict with keys:
+          tweets (list), has_next_page (bool), next_cursor (str|None)
+
+        Each tweet dict contains:
+          id, text, createdAt, likeCount, retweetCount, replyCount,
+          quoteCount, viewCount, bookmarkCount,
+          author: {id, username, name, verified}
+        """
+        data = _get_json(
+            "/x/tweets/search",
+            {
+                "q": query,
+                "limit": min(limit, 200),
+                "queryType": query_type,
+                "cursor": cursor,
+            },
+        )
+        return {
+            "tweets": data.get("tweets", []),
+            "has_next_page": data.get("has_next_page", False),
+            "next_cursor": data.get("next_cursor"),
+        }
+
+    def get_tweet(self, tweet_id: str) -> dict:
+        """获取单条推文详情。
+
+        Args:
+            tweet_id: 推文 ID（数字字符串，或完整 URL 中的 ID 部分）
+
+        Returns a dict with keys:
+          id, text, createdAt, likeCount, retweetCount, replyCount,
+          quoteCount, viewCount, bookmarkCount, type, source, media,
+          author: {id, username, name, followers, verified, profilePicture}
+        """
+        return _get_json(f"/x/tweets/{tweet_id}")
+
+    def search_users(self, query: str, cursor: str | None = None) -> dict:
+        """搜索用户。
+
+        Args:
+            query:  用户名或显示名搜索
+            cursor: 分页游标
+
+        Returns a dict with keys:
+          users (list), has_next_page (bool), next_cursor (str|None)
+
+        Each user dict contains:
+          id, username, name, description, followers, following,
+          verified, profilePicture, location, createdAt, statusesCount
+        """
+        data = _get_json(
+            "/x/users/search",
+            {"q": query, "cursor": cursor},
+        )
+        return {
+            "users": data.get("users", []),
+            "has_next_page": data.get("has_next_page", False),
+            "next_cursor": data.get("next_cursor"),
+        }
+
+    def get_user(self, username: str) -> dict:
+        """获取用户资料。
+
+        Args:
+            username: X 用户名（不含 @）或数字 ID
+
+        Returns a dict with keys:
+          id, username, name, description, followers, following,
+          verified, profilePicture, location, createdAt, statusesCount
+        """
+        return _get_json(f"/x/users/{username}")
+
+    def get_trends(self, woeid: int = 1, count: int = 30) -> list:
+        """获取热门趋势。
+
+        Args:
+            woeid: 地区 WOEID（1=全球，23424977=美国，23424975=英国，
+                   23424969=土耳其，23424781=日本，23424756=中国台湾）
+            count: 返回条数（上限 50）
+
+        Returns a list of dicts with keys:
+          name, description, query, rank
+        """
+        data = _get_json("/trends", {"woeid": woeid, "count": min(count, 50)})
+        return data.get("trends", [])

--- a/agent_reach/channels/xquik.py
+++ b/agent_reach/channels/xquik.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Xquik — X/Twitter search, tweet lookup, user profiles & trends via API key."""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any, Optional
+
+from .base import Channel
+
+_BASE = "https://xquik.com/api/v1"
+_UA = "agent-reach/1.0"
+_TIMEOUT = 15
+
+
+def _get_api_key(config=None) -> str:
+    """Return the Xquik API key from config, env, or empty string."""
+    if config:
+        configured = config.get("xquik_api_key")
+        if configured:
+            return configured
+    return os.environ.get("XQUIK_API_KEY", "")
+
+
+def _get_json(
+    path: str,
+    params: Optional[dict[str, Any]] = None,
+    api_key: Optional[str] = None,
+) -> Any:
+    """Fetch *path* from the Xquik API and return parsed JSON.
+
+    Raises urllib.error.HTTPError on non-2xx or ValueError on bad JSON.
+    """
+    request_api_key = api_key if api_key is not None else _get_api_key()
+    url = f"{_BASE}{path}"
+    if params:
+        qs = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
+        url = f"{url}?{qs}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": _UA,
+            "X-API-Key": request_api_key,
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class XquikChannel(Channel):
+    name = "xquik"
+    description = "X/Twitter 搜索、推文、用户与趋势（API Key）"
+    backends = ["Xquik API"]
+    tier = 1
+
+    # ------------------------------------------------------------------ #
+    # URL routing
+    # ------------------------------------------------------------------ #
+
+    def can_handle(self, url: str) -> bool:
+        d = urllib.parse.urlparse(url).netloc.lower()
+        return "x.com" in d or "twitter.com" in d
+
+    # ------------------------------------------------------------------ #
+    # Health check
+    # ------------------------------------------------------------------ #
+
+    def check(self, config=None):
+        api_key = _get_api_key(config)
+        if not api_key:
+            self.active_backend = None
+            return "off", (
+                "Xquik API Key 未配置。获取方式：\n"
+                "  1. 注册 https://xquik.com\n"
+                '  2. 设置环境变量：export XQUIK_API_KEY="xk_your_key"'
+            )
+        try:
+            data = _get_json("/trends", {"count": 1}, api_key=api_key)
+            if data.get("trends"):
+                self.active_backend = "Xquik API"
+                return "ok", (
+                    "Xquik API 可用（搜索推文、用户查询、趋势，"
+                    "含互动数据：点赞/转发/回复/引用/浏览/收藏）"
+                )
+            self.active_backend = "Xquik API"
+            return "warn", "Xquik API Key 有效但返回数据为空"
+        except urllib.error.HTTPError as e:
+            self.active_backend = None
+            if e.code == 401:
+                return "warn", (
+                    "Xquik API Key 无效或过期。请检查：https://xquik.com/dashboard/api-keys"
+                )
+            return "warn", f"Xquik API 连接失败（HTTP {e.code}）"
+        except Exception as e:
+            self.active_backend = None
+            return "warn", f"Xquik API 连接失败：{e}"
+
+    # ------------------------------------------------------------------ #
+    # Data-fetching methods
+    # ------------------------------------------------------------------ #
+
+    def search_tweets(
+        self,
+        query: str,
+        limit: int = 20,
+        query_type: str = "Latest",
+        cursor: Optional[str] = None,
+    ) -> dict:
+        """搜索推文。
+
+        支持 X 搜索语法：关键词、#标签、from:用户、"精确匹配"、
+        since:YYYY-MM-DD、until:YYYY-MM-DD、min_faves:N。
+
+        Args:
+            query:      搜索关键词
+            limit:      最多返回条数（上限 200）
+            query_type: "Latest"（最新）或 "Top"（热门）
+            cursor:     分页游标（来自上一次响应的 next_cursor）
+
+        Returns a dict with keys:
+          tweets (list), has_next_page (bool), next_cursor (str or None)
+
+        Each tweet dict contains:
+          id, text, createdAt, likeCount, retweetCount, replyCount,
+          quoteCount, viewCount, bookmarkCount,
+          author: {id, username, name, verified}
+        """
+        data = _get_json(
+            "/x/tweets/search",
+            {
+                "q": query,
+                "limit": min(limit, 200),
+                "queryType": query_type,
+                "cursor": cursor,
+            },
+        )
+        return {
+            "tweets": data.get("tweets", []),
+            "has_next_page": data.get("has_next_page", False),
+            "next_cursor": data.get("next_cursor"),
+        }
+
+    def get_tweet(self, tweet_id: str) -> dict:
+        """获取单条推文详情。
+
+        Args:
+            tweet_id: 推文 ID（数字字符串，或完整 URL 中的 ID 部分）
+
+        Returns a dict with keys:
+          id, text, createdAt, likeCount, retweetCount, replyCount,
+          quoteCount, viewCount, bookmarkCount, type, source, media,
+          author: {id, username, name, followers, verified, profilePicture}
+        """
+        return _get_json(f"/x/tweets/{tweet_id}")
+
+    def search_users(self, query: str, cursor: Optional[str] = None) -> dict:
+        """搜索用户。
+
+        Args:
+            query:  用户名或显示名搜索
+            cursor: 分页游标
+
+        Returns a dict with keys:
+          users (list), has_next_page (bool), next_cursor (str or None)
+
+        Each user dict contains:
+          id, username, name, description, followers, following,
+          verified, profilePicture, location, createdAt, statusesCount
+        """
+        data = _get_json(
+            "/x/users/search",
+            {"q": query, "cursor": cursor},
+        )
+        return {
+            "users": data.get("users", []),
+            "has_next_page": data.get("has_next_page", False),
+            "next_cursor": data.get("next_cursor"),
+        }
+
+    def get_user(self, username: str) -> dict:
+        """获取用户资料。
+
+        Args:
+            username: X 用户名（不含 @）或数字 ID
+
+        Returns a dict with keys:
+          id, username, name, description, followers, following,
+          verified, profilePicture, location, createdAt, statusesCount
+        """
+        return _get_json(f"/x/users/{username}")
+
+    def get_trends(self, woeid: int = 1, count: int = 30) -> list:
+        """获取热门趋势。
+
+        Args:
+            woeid: 地区 WOEID（1=全球，23424977=美国，23424975=英国，
+                   23424969=土耳其，23424781=日本，23424756=中国台湾）
+            count: 返回条数（上限 50）
+
+        Returns a list of dicts with keys:
+          name, description, query, rank
+        """
+        data = _get_json("/trends", {"woeid": woeid, "count": min(count, 50)})
+        return data.get("trends", [])

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -22,6 +22,7 @@ class Config:
     FEATURE_REQUIREMENTS = {
         "exa_search": ["exa_api_key"],
         "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by bird CLI
+        "xquik": ["xquik_api_key"],
         "groq_whisper": ["groq_api_key"],
         "github_token": ["github_token"],
     }

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -22,6 +22,7 @@ class Config:
     FEATURE_REQUIREMENTS = {
         "exa_search": ["exa_api_key"],
         "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
+        "xquik": ["xquik_api_key"],
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],
         "github_token": ["github_token"],

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -15,7 +15,7 @@ triggers:
   - social:
     - 小红书: xiaohongshu/xhs/小红书/红书
     - 抖音: douyin/抖音
-    - Twitter: twitter/推特/x.com/推文
+    - Twitter: twitter/推特/x.com/推文/xquik
     - 微博: weibo/微博
     - B站: bilibili/b站/哔哩哔哩
     - V2EX: v2ex
@@ -57,8 +57,11 @@ curl -s "https://r.jina.ai/URL"
 # GitHub 搜索
 gh search repos "query" --sort stars --limit 10
 
-# Twitter 搜索
+# Twitter 搜索（twitter-cli，需 Cookie）
 twitter search "query" --limit 10
+
+# Twitter 搜索（Xquik API，需 API Key，更稳定）
+curl -s "https://xquik.com/api/v1/x/tweets/search?q=query&limit=10" -H "X-API-Key: $XQUIK_API_KEY"
 
 # YouTube/B站字幕
 yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -24,7 +24,7 @@ triggers:
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
   - social:
     - 小红书: xiaohongshu/xhs/小红书/红书
-    - Twitter: twitter/推特/x.com/推文
+    - Twitter: twitter/推特/x.com/推文/xquik
     - B站: bilibili/b站/哔哩哔哩
     - V2EX: v2ex
     - Reddit: reddit
@@ -77,6 +77,9 @@ curl -s "https://r.jina.ai/URL"
 
 # GitHub 搜索
 gh search repos "query" --sort stars --limit 10
+
+# Twitter 搜索（Xquik API，需 API Key）
+curl -s "https://xquik.com/api/v1/x/tweets/search?q=query&limit=10" -H "X-API-Key: $XQUIK_API_KEY"
 
 # YouTube 字幕（注意：B站不要用 yt-dlp，见 video.md）
 yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -101,6 +101,74 @@ twitter likes
 >
 > **输出格式**: 建议用 `--yaml` 或 `--json` 获得结构化输出，对 AI agent 更友好。
 
+## Twitter/X — Xquik API（替代方案）
+
+API Key 认证，无需浏览器 Cookie，搜索结果稳定（不受 GraphQL 端点变化影响）。
+含完整互动数据：点赞、转发、回复、引用、浏览量、收藏。
+
+### curl 命令
+
+```bash
+# 搜索推文
+curl -s "https://xquik.com/api/v1/x/tweets/search?q=query&limit=10" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取单条推文
+curl -s "https://xquik.com/api/v1/x/tweets/TWEET_ID" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 搜索用户
+curl -s "https://xquik.com/api/v1/x/users/search?q=query" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取用户资料
+curl -s "https://xquik.com/api/v1/x/users/USERNAME" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取趋势（woeid=1 全球，23424977=美国）
+curl -s "https://xquik.com/api/v1/trends?woeid=1&count=20" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+```
+
+### Python 调用示例
+
+```python
+from agent_reach.channels.xquik import XquikChannel
+
+ch = XquikChannel()
+
+# 搜索推文（支持 X 搜索语法：from:user、#标签、"精确匹配"、min_faves:N）
+result = ch.search_tweets("AI agents", limit=10)
+for t in result["tweets"]:
+    print(f"@{t['author']['username']}: {t['text'][:80]}")
+    print(f"  likes={t['likeCount']} rt={t['retweetCount']} views={t['viewCount']}")
+
+# 获取单条推文
+tweet = ch.get_tweet("1234567890")
+
+# 获取用户资料
+user = ch.get_user("elonmusk")
+print(f"{user['name']} — {user['followers']} followers")
+
+# 搜索用户
+result = ch.search_users("OpenAI")
+
+# 获取全球趋势
+trends = ch.get_trends(woeid=1, count=10)
+for t in trends:
+    print(f"#{t['rank']} {t['name']}")
+```
+
+### 重要注意事项
+
+> **安装**: 无需安装 CLI 工具。设置环境变量 `XQUIK_API_KEY` 即可。
+>
+> **获取 API Key**: 注册 https://xquik.com → Dashboard → API Keys。
+>
+> **搜索语法**: 支持 X 标准搜索语法，包括 `from:user`、`#hashtag`、`"exact phrase"`、`since:2025-01-01`、`until:2025-12-31`、`min_faves:100`。
+>
+> **与 twitter-cli 的区别**: Xquik 通过 API Key 认证（无需浏览器 Cookie），搜索不受 GraphQL 端点变化影响。返回更多互动数据（浏览量、收藏数）。两者可以共存，按需选择。
+
 ## 微博 / Weibo
 
 ```bash

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -169,6 +169,18 @@ for t in trends:
 >
 > **与 twitter-cli 的区别**: Xquik 通过 API Key 认证（无需浏览器 Cookie），搜索不受 GraphQL 端点变化影响。返回更多互动数据（浏览量、收藏数）。两者可以共存，按需选择。
 
+### OpenClaw 插件模式
+
+如果用户在 OpenClaw 里想要插件工具，而不是 Agent Reach 的 shell/curl 调用，可以安装 TweetClaw：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw 使用同一组 Xquik API 能力，提供 `explore` 和 `tweetclaw` 两个 OpenClaw 工具，适合搜索推文、搜索回复、发推、回复、粉丝导出、媒体上传/下载、监控、webhooks 和抽奖。写入、付费、监控、webhook 等操作仍需用户确认。
+
+文档: https://github.com/Xquik-dev/tweetclaw 和 https://context7.com/xquik-dev/tweetclaw。
+
 ## 微博 / Weibo
 
 ```bash

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -113,6 +113,71 @@ twitter likes
 >
 > **输出格式**: 建议用 `--yaml` 或 `--json` 获得结构化输出，对 AI agent 更友好。
 
+## Twitter/X: Xquik API
+
+API Key 认证，无需浏览器 Cookie。适合需要 API Key 工作流、搜索、用户资料、单条推文或趋势数据的任务。
+
+### curl 命令
+
+```bash
+# 搜索推文
+curl -s "https://xquik.com/api/v1/x/tweets/search?q=query&limit=10" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取单条推文
+curl -s "https://xquik.com/api/v1/x/tweets/TWEET_ID" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 搜索用户
+curl -s "https://xquik.com/api/v1/x/users/search?q=query" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取用户资料
+curl -s "https://xquik.com/api/v1/x/users/USERNAME" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+
+# 获取趋势（woeid=1 全球，23424977=美国）
+curl -s "https://xquik.com/api/v1/trends?woeid=1&count=20" \
+  -H "X-API-Key: $XQUIK_API_KEY"
+```
+
+### Python 调用示例
+
+```python
+from agent_reach.channels.xquik import XquikChannel
+
+ch = XquikChannel()
+
+# 搜索推文
+result = ch.search_tweets("AI agents", limit=10)
+for t in result["tweets"]:
+    print(f"@{t['author']['username']}: {t['text'][:80]}")
+    print(f"  likes={t['likeCount']} rt={t['retweetCount']} views={t['viewCount']}")
+
+# 获取单条推文
+tweet = ch.get_tweet("1234567890")
+
+# 获取用户资料
+user = ch.get_user("elonmusk")
+print(f"{user['name']} — {user['followers']} followers")
+
+# 搜索用户
+result = ch.search_users("OpenAI")
+
+# 获取全球趋势
+trends = ch.get_trends(woeid=1, count=10)
+for t in trends:
+    print(f"#{t['rank']} {t['name']}")
+```
+
+### 重要注意事项
+
+> **安装**: 无需安装 CLI 工具。设置环境变量 `XQUIK_API_KEY` 即可。
+>
+> **获取 API Key**: 注册 https://xquik.com ，在 Dashboard API Keys 中创建。
+>
+> **搜索语法**: 支持常见 X 搜索语法，包括 `from:user`、`#hashtag`、`"exact phrase"`、`since:2025-01-01`、`until:2025-12-31`、`min_faves:100`。
+>
 ## B站 / Bilibili
 
 > ⚠️ **不要用 yt-dlp 读 B站**（风控已全面 412 拦截，实测无解）。用 bili-cli / OpenCLI。

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -145,6 +145,7 @@ def test_channel_can_handle_contract():
         "linkedin": "https://www.linkedin.com/in/test",
         "weibo": "https://weibo.com/u/1749127163",
         "rss": "https://example.com/feed.xml",
+        "xquik": "https://x.com/user/status/123",
         "xueqiu": "https://xueqiu.com/S/SH600519",
         "exa_search": "https://example.com",
         "web": "https://example.com",

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -173,6 +173,7 @@ def test_channel_can_handle_contract():
         "xiaohongshu": "https://www.xiaohongshu.com/explore/123",
         "linkedin": "https://www.linkedin.com/in/test",
         "rss": "https://example.com/feed.xml",
+        "xquik": "https://x.com/user/status/123",
         "xueqiu": "https://xueqiu.com/S/SH600519",
         "exa_search": "https://example.com",
         "web": "https://example.com",

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -27,6 +27,7 @@ class TestChannelRegistry:
         assert "web" in names
         assert "github" in names
         assert "twitter" in names
+        assert "xquik" in names
         assert "v2ex" in names
 
 

--- a/tests/test_xquik_channel.py
+++ b/tests/test_xquik_channel.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+"""Tests for XquikChannel — API-key-based X/Twitter channel."""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from agent_reach.channels.xquik import XquikChannel, _get_json
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture()
+def channel():
+    return XquikChannel()
+
+
+# ------------------------------------------------------------------ #
+# can_handle
+# ------------------------------------------------------------------ #
+
+
+class TestCanHandle:
+    def test_x_dot_com(self, channel):
+        assert channel.can_handle("https://x.com/elonmusk/status/123")
+
+    def test_twitter_dot_com(self, channel):
+        assert channel.can_handle("https://twitter.com/user/status/456")
+
+    def test_www_x_dot_com(self, channel):
+        assert channel.can_handle("https://www.x.com/user")
+
+    def test_mobile_twitter(self, channel):
+        assert channel.can_handle("https://mobile.twitter.com/user/status/1")
+
+    def test_rejects_github(self, channel):
+        assert not channel.can_handle("https://github.com/user/repo")
+
+    def test_rejects_reddit(self, channel):
+        assert not channel.can_handle("https://reddit.com/r/Python")
+
+    def test_rejects_xquik(self, channel):
+        assert not channel.can_handle("https://xquik.com/dashboard")
+
+
+# ------------------------------------------------------------------ #
+# check — health diagnostics
+# ------------------------------------------------------------------ #
+
+
+class TestCheck:
+    def test_no_api_key(self, channel, monkeypatch):
+        monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+        status, msg = channel.check()
+        assert status == "off"
+        assert "XQUIK_API_KEY" in msg
+
+    def test_api_key_valid(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key_123")
+
+        fake_response = json.dumps({"trends": [{"name": "#AI", "rank": 1}]}).encode()
+
+        class FakeResp:
+            def read(self):
+                return fake_response
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        status, msg = channel.check()
+        assert status == "ok"
+        assert "搜索推文" in msg
+
+    def test_api_key_invalid_401(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_bad_key")
+
+        def raise_401(req, timeout=None):
+            raise urllib.error.HTTPError(url="", code=401, msg="Unauthorized", hdrs={}, fp=None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_401)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "无效" in msg or "过期" in msg
+
+    def test_api_server_error(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        def raise_500(req, timeout=None):
+            raise urllib.error.HTTPError(url="", code=500, msg="Server Error", hdrs={}, fp=None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_500)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "500" in msg
+
+    def test_api_network_error(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        def raise_conn(req, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_conn)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "连接失败" in msg
+
+    def test_api_empty_trends(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        fake_response = json.dumps({"trends": []}).encode()
+
+        class FakeResp:
+            def read(self):
+                return fake_response
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "空" in msg
+
+
+# ------------------------------------------------------------------ #
+# search_tweets
+# ------------------------------------------------------------------ #
+
+
+class TestSearchTweets:
+    def test_basic_search(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "tweets": [
+                {
+                    "id": "111",
+                    "text": "Hello world",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                    "likeCount": 10,
+                    "retweetCount": 2,
+                    "replyCount": 1,
+                    "quoteCount": 0,
+                    "viewCount": 500,
+                    "bookmarkCount": 3,
+                    "author": {
+                        "id": "999",
+                        "username": "testuser",
+                        "name": "Test",
+                        "verified": False,
+                    },
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": None,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        result = channel.search_tweets("test query", limit=10)
+        assert len(result["tweets"]) == 1
+        assert result["tweets"][0]["text"] == "Hello world"
+        assert result["tweets"][0]["author"]["username"] == "testuser"
+        assert result["has_next_page"] is False
+
+    def test_limit_capped_at_200(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps({"tweets": [], "has_next_page": False}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.search_tweets("test", limit=500)
+        assert "limit=200" in captured_urls[0]
+
+    def test_pagination_cursor(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(
+                    {"tweets": [], "has_next_page": False, "next_cursor": None}
+                ).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.search_tweets("test", cursor="DAACCgACGR")
+        assert "cursor=DAACCgACGR" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# get_tweet
+# ------------------------------------------------------------------ #
+
+
+class TestGetTweet:
+    def test_get_tweet_by_id(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "id": "123456",
+            "text": "A tweet",
+            "createdAt": "2025-06-01T12:00:00Z",
+            "likeCount": 42,
+            "retweetCount": 5,
+            "replyCount": 3,
+            "quoteCount": 1,
+            "viewCount": 1500,
+            "bookmarkCount": 2,
+            "author": {
+                "id": "789",
+                "username": "poster",
+                "name": "Poster",
+                "followers": 1000,
+                "verified": True,
+                "profilePicture": "https://example.com/pic.jpg",
+            },
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        captured_urls = []
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        tweet = channel.get_tweet("123456")
+        assert tweet["id"] == "123456"
+        assert tweet["author"]["verified"] is True
+        assert "/x/tweets/123456" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# search_users
+# ------------------------------------------------------------------ #
+
+
+class TestSearchUsers:
+    def test_search_users(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "users": [
+                {
+                    "id": "100",
+                    "username": "openai",
+                    "name": "OpenAI",
+                    "description": "AI research lab",
+                    "followers": 5000000,
+                    "following": 50,
+                    "verified": True,
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": None,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        result = channel.search_users("OpenAI")
+        assert len(result["users"]) == 1
+        assert result["users"][0]["username"] == "openai"
+        assert result["users"][0]["verified"] is True
+
+
+# ------------------------------------------------------------------ #
+# get_user
+# ------------------------------------------------------------------ #
+
+
+class TestGetUser:
+    def test_get_user_by_username(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "id": "200",
+            "username": "elonmusk",
+            "name": "Elon Musk",
+            "description": "Mars",
+            "followers": 150000000,
+            "following": 500,
+            "verified": True,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        captured_urls = []
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        user = channel.get_user("elonmusk")
+        assert user["username"] == "elonmusk"
+        assert user["followers"] == 150000000
+        assert "/x/users/elonmusk" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# get_trends
+# ------------------------------------------------------------------ #
+
+
+class TestGetTrends:
+    def test_get_global_trends(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "trends": [
+                {
+                    "name": "#AI",
+                    "description": "Artificial intelligence",
+                    "query": "%23AI",
+                    "rank": 1,
+                },
+                {"name": "#Python", "description": "", "query": "%23Python", "rank": 2},
+            ],
+            "total": 2,
+            "woeid": 1,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        trends = channel.get_trends(woeid=1, count=10)
+        assert len(trends) == 2
+        assert trends[0]["name"] == "#AI"
+        assert trends[1]["rank"] == 2
+
+    def test_count_capped_at_50(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps({"trends": []}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.get_trends(count=999)
+        assert "count=50" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# _get_json internals
+# ------------------------------------------------------------------ #
+
+
+class TestGetJson:
+    def test_sends_api_key_header(self, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_secret_key")
+        captured_requests = []
+
+        class FakeResp:
+            def read(self):
+                return b'{"ok": true}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_requests.append(req)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        _get_json("/test")
+        assert captured_requests[0].get_header("X-api-key") == "xk_secret_key"
+
+    def test_skips_none_params(self, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return b'{"ok": true}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        _get_json("/test", {"q": "hello", "cursor": None})
+        assert "cursor" not in captured_urls[0]
+        assert "q=hello" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# Channel metadata
+# ------------------------------------------------------------------ #
+
+
+class TestMetadata:
+    def test_name(self, channel):
+        assert channel.name == "xquik"
+
+    def test_tier(self, channel):
+        assert channel.tier == 1
+
+    def test_backends(self, channel):
+        assert channel.backends == ["Xquik API"]
+
+    def test_description_nonempty(self, channel):
+        assert channel.description

--- a/tests/test_xquik_channel.py
+++ b/tests/test_xquik_channel.py
@@ -1,0 +1,524 @@
+# -*- coding: utf-8 -*-
+"""Tests for XquikChannel — API-key-based X/Twitter channel."""
+
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from agent_reach.channels.xquik import XquikChannel, _get_json
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture()
+def channel():
+    return XquikChannel()
+
+
+# ------------------------------------------------------------------ #
+# can_handle
+# ------------------------------------------------------------------ #
+
+
+class TestCanHandle:
+    def test_x_dot_com(self, channel):
+        assert channel.can_handle("https://x.com/elonmusk/status/123")
+
+    def test_twitter_dot_com(self, channel):
+        assert channel.can_handle("https://twitter.com/user/status/456")
+
+    def test_www_x_dot_com(self, channel):
+        assert channel.can_handle("https://www.x.com/user")
+
+    def test_mobile_twitter(self, channel):
+        assert channel.can_handle("https://mobile.twitter.com/user/status/1")
+
+    def test_rejects_github(self, channel):
+        assert not channel.can_handle("https://github.com/user/repo")
+
+    def test_rejects_reddit(self, channel):
+        assert not channel.can_handle("https://reddit.com/r/Python")
+
+    def test_rejects_xquik(self, channel):
+        assert not channel.can_handle("https://xquik.com/dashboard")
+
+
+# ------------------------------------------------------------------ #
+# check — health diagnostics
+# ------------------------------------------------------------------ #
+
+
+class TestCheck:
+    def test_no_api_key(self, channel, monkeypatch):
+        monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+        status, msg = channel.check()
+        assert status == "off"
+        assert "XQUIK_API_KEY" in msg
+
+    def test_api_key_valid(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key_123")
+
+        fake_response = json.dumps({"trends": [{"name": "#AI", "rank": 1}]}).encode()
+
+        class FakeResp:
+            def read(self):
+                return fake_response
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        status, msg = channel.check()
+        assert status == "ok"
+        assert "搜索推文" in msg
+
+    def test_api_key_from_config(self, channel, monkeypatch):
+        monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+
+        class FakeConfig:
+            def get(self, key):
+                assert key == "xquik_api_key"
+                return "xk_config_key"
+
+        class FakeResp:
+            def read(self):
+                return json.dumps({"trends": [{"name": "#AI", "rank": 1}]}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        captured_headers = []
+
+        def capture_urlopen(req, timeout=None):
+            captured_headers.append(req.headers)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        status, msg = channel.check(config=FakeConfig())
+        assert status == "ok"
+        assert "搜索推文" in msg
+        assert captured_headers[0]["X-api-key"] == "xk_config_key"
+
+    def test_api_key_invalid_401(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_bad_key")
+
+        def raise_401(req, timeout=None):
+            raise urllib.error.HTTPError(url="", code=401, msg="Unauthorized", hdrs={}, fp=None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_401)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "无效" in msg or "过期" in msg
+
+    def test_api_server_error(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        def raise_500(req, timeout=None):
+            raise urllib.error.HTTPError(url="", code=500, msg="Server Error", hdrs={}, fp=None)
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_500)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "500" in msg
+
+    def test_api_network_error(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        def raise_conn(req, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", raise_conn)
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "连接失败" in msg
+
+    def test_api_empty_trends(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test_key")
+
+        fake_response = json.dumps({"trends": []}).encode()
+
+        class FakeResp:
+            def read(self):
+                return fake_response
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        status, msg = channel.check()
+        assert status == "warn"
+        assert "空" in msg
+
+
+# ------------------------------------------------------------------ #
+# search_tweets
+# ------------------------------------------------------------------ #
+
+
+class TestSearchTweets:
+    def test_basic_search(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "tweets": [
+                {
+                    "id": "111",
+                    "text": "Hello world",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                    "likeCount": 10,
+                    "retweetCount": 2,
+                    "replyCount": 1,
+                    "quoteCount": 0,
+                    "viewCount": 500,
+                    "bookmarkCount": 3,
+                    "author": {
+                        "id": "999",
+                        "username": "testuser",
+                        "name": "Test",
+                        "verified": False,
+                    },
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": None,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        result = channel.search_tweets("test query", limit=10)
+        assert len(result["tweets"]) == 1
+        assert result["tweets"][0]["text"] == "Hello world"
+        assert result["tweets"][0]["author"]["username"] == "testuser"
+        assert result["has_next_page"] is False
+
+    def test_limit_capped_at_200(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps({"tweets": [], "has_next_page": False}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.search_tweets("test", limit=500)
+        assert "limit=200" in captured_urls[0]
+
+    def test_pagination_cursor(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(
+                    {"tweets": [], "has_next_page": False, "next_cursor": None}
+                ).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.search_tweets("test", cursor="DAACCgACGR")
+        assert "cursor=DAACCgACGR" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# get_tweet
+# ------------------------------------------------------------------ #
+
+
+class TestGetTweet:
+    def test_get_tweet_by_id(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "id": "123456",
+            "text": "A tweet",
+            "createdAt": "2025-06-01T12:00:00Z",
+            "likeCount": 42,
+            "retweetCount": 5,
+            "replyCount": 3,
+            "quoteCount": 1,
+            "viewCount": 1500,
+            "bookmarkCount": 2,
+            "author": {
+                "id": "789",
+                "username": "poster",
+                "name": "Poster",
+                "followers": 1000,
+                "verified": True,
+                "profilePicture": "https://example.com/pic.jpg",
+            },
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        captured_urls = []
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        tweet = channel.get_tweet("123456")
+        assert tweet["id"] == "123456"
+        assert tweet["author"]["verified"] is True
+        assert "/x/tweets/123456" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# search_users
+# ------------------------------------------------------------------ #
+
+
+class TestSearchUsers:
+    def test_search_users(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "users": [
+                {
+                    "id": "100",
+                    "username": "openai",
+                    "name": "OpenAI",
+                    "description": "AI research lab",
+                    "followers": 5000000,
+                    "following": 50,
+                    "verified": True,
+                }
+            ],
+            "has_next_page": False,
+            "next_cursor": None,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        result = channel.search_users("OpenAI")
+        assert len(result["users"]) == 1
+        assert result["users"][0]["username"] == "openai"
+        assert result["users"][0]["verified"] is True
+
+
+# ------------------------------------------------------------------ #
+# get_user
+# ------------------------------------------------------------------ #
+
+
+class TestGetUser:
+    def test_get_user_by_username(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "id": "200",
+            "username": "elonmusk",
+            "name": "Elon Musk",
+            "description": "Mars",
+            "followers": 150000000,
+            "following": 500,
+            "verified": True,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        captured_urls = []
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        user = channel.get_user("elonmusk")
+        assert user["username"] == "elonmusk"
+        assert user["followers"] == 150000000
+        assert "/x/users/elonmusk" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# get_trends
+# ------------------------------------------------------------------ #
+
+
+class TestGetTrends:
+    def test_get_global_trends(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        api_response = {
+            "trends": [
+                {
+                    "name": "#AI",
+                    "description": "Artificial intelligence",
+                    "query": "%23AI",
+                    "rank": 1,
+                },
+                {"name": "#Python", "description": "", "query": "%23Python", "rank": 2},
+            ],
+            "total": 2,
+            "woeid": 1,
+        }
+
+        class FakeResp:
+            def read(self):
+                return json.dumps(api_response).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=None: FakeResp())
+        trends = channel.get_trends(woeid=1, count=10)
+        assert len(trends) == 2
+        assert trends[0]["name"] == "#AI"
+        assert trends[1]["rank"] == 2
+
+    def test_count_capped_at_50(self, channel, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return json.dumps({"trends": []}).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        channel.get_trends(count=999)
+        assert "count=50" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# _get_json internals
+# ------------------------------------------------------------------ #
+
+
+class TestGetJson:
+    def test_sends_api_key_header(self, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_secret_key")
+        captured_requests = []
+
+        class FakeResp:
+            def read(self):
+                return b'{"ok": true}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_requests.append(req)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        _get_json("/test")
+        assert captured_requests[0].get_header("X-api-key") == "xk_secret_key"
+
+    def test_skips_none_params(self, monkeypatch):
+        monkeypatch.setenv("XQUIK_API_KEY", "xk_test")
+        captured_urls = []
+
+        class FakeResp:
+            def read(self):
+                return b'{"ok": true}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def capture_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return FakeResp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", capture_urlopen)
+        _get_json("/test", {"q": "hello", "cursor": None})
+        assert "cursor" not in captured_urls[0]
+        assert "q=hello" in captured_urls[0]
+
+
+# ------------------------------------------------------------------ #
+# Channel metadata
+# ------------------------------------------------------------------ #
+
+
+class TestMetadata:
+    def test_name(self, channel):
+        assert channel.name == "xquik"
+
+    def test_tier(self, channel):
+        assert channel.tier == 1
+
+    def test_backends(self, channel):
+        assert channel.backends == ["Xquik API"]
+
+    def test_description_nonempty(self, channel):
+        assert channel.description


### PR DESCRIPTION
## Summary

- Add [Xquik](https://xquik.com) as a new X/Twitter channel using its REST API
- Returns full engagement metrics: likes, retweets, replies, quotes, views, bookmarks
- Uses stdlib `urllib` only - zero new dependencies
- 27 unit tests covering all methods and edge cases

## Why

The existing Twitter channel requires `twitter-cli` (cookie-based, GraphQL scraping). Xquik provides an alternative X/Twitter backend that:

- Works with a simple API key (no browser cookies, no `AUTH_TOKEN`/`CT0` extraction needed)
- Search is stable (not affected by Twitter's frequent GraphQL endpoint changes - the current `social.md` warns search "可能不稳定")
- Returns richer engagement data (views + bookmarks on top of likes/retweets/replies/quotes)
- Uses pure Python with no subprocess spawning or CLI tool installation
- Works in SSH, Docker, headless, and CI environments where browser cookie extraction isn't possible

Users who have an Xquik API key get X/Twitter search, tweet lookup, user profiles, and trends without needing to install `twitter-cli` or extract browser cookies. Both channels can coexist - users choose based on their setup.

## Changes

| File | What |
|------|------|
| `agent_reach/channels/xquik.py` | Channel module: `search_tweets()`, `get_tweet()`, `search_users()`, `get_user()`, `get_trends()` |
| `tests/test_xquik_channel.py` | 27 unit tests (check, search, lookup, trends, edge cases, internals) |
| `agent_reach/channels/__init__.py` | Register `XquikChannel` in `ALL_CHANNELS` |
| `agent_reach/config.py` | Add `xquik` to `FEATURE_REQUIREMENTS` |
| `agent_reach/skill/SKILL.md` | Add Xquik search command + trigger keyword |
| `agent_reach/skill/references/social.md` | Full usage guide with curl + Python examples |
| `agent_reach/skill/references/social.md` | Add TweetClaw as the OpenClaw plugin option for users who want Xquik through plugin tools |
| `.env.example` | Add `XQUIK_API_KEY` |
| `tests/test_channel_contracts.py` | Add xquik URL sample to contract test |
| `tests/test_channels.py` | Assert xquik is registered in channel list |

## Test plan

- [x] `python -m pytest tests/test_xquik_channel.py -v` - 27/27 pass
- [x] `python -m pytest tests/ -v` - 105/105 pass (zero regressions)
- [x] `ruff check` - clean
- [x] `ruff format --check` - clean
- [x] Existing `test_twitter_channel` tests still pass (no changes to twitter.py)
- [x] Docs-only follow-up: `git diff --check` clean and TweetClaw docs links verified

Built with [Claude Code](https://claude.ai/code)
