### PR TITLE
fix(wechat): Windows 系统上 doctor 误判微信公众号渠道不可用

### DIFF
--- a/agent_reach/channels/wechat.py
+++ b/agent_reach/channels/wechat.py
@@ -17,7 +17,7 @@ def _exa_available() -> bool:
     try:
         r = subprocess.run(
             [mcporter, "config", "list"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=5,
         )
         return "exa" in r.stdout.lower()
     except Exception:


### PR DESCRIPTION
## 问题描述

修复 Windows 中文系统上 `agent-reach doctor` 因编码问题误判微信公众号文章渠道不可用的 bug。

## 根因分析

`agent_reach/channels/wechat.py` 中 `_exa_available()` 使用 `subprocess.run(..., text=True, ...)`，在未指定编码时，Windows 中文环境默认使用 **gbk** 解码 `mcporter config list` 的输出。当输出中包含 UTF-8 特殊字符（如 `0x94`）时，抛出 `UnicodeDecodeError`，异常被捕获后函数返回 `False`，导致 doctor 显示 `[X]`。但这是**假阴性**，mcporter + Exa 实际完全可用。

## 改动内容

- 将 `text=True` 改为 `encoding="utf-8", errors="replace"`
- 与 `exa_search.py` 中的处理方式保持一致

## 验证结果

修复前：
- `UnicodeDecodeError: 'gbk' codec can't decode byte 0x94`
- doctor 状态：8/16，微信公众号显示 `[X]`

修复后：
- doctor 无异常
- doctor 状态：9/16，微信公众号显示 ✅
- `exa.web_search_exa` 和 `exa.web_fetch_exa` 读取公众号文章功能正常

Fixes #262