### PR TITLE
fix: keep install and doctor non-interactive for cookie channels

### DIFF
--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -8,7 +8,7 @@ session cookie. Run `rdt login` after installation to authenticate.
 
 import json
 import shutil
-import subprocess
+from pathlib import Path
 
 from .base import Channel
 
@@ -39,38 +39,36 @@ class RedditChannel(Channel):
                 "安装后运行 `rdt login` 登录（需先在浏览器登录 reddit.com）"
             )
 
+        # Keep doctor/status non-interactive and fast.
+        cred_path = Path.home() / ".config" / "rdt-cli" / "credential.json"
         try:
-            r = subprocess.run(
-                [rdt, "status", "--json"],
-                capture_output=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=10,
-            )
-            data = json.loads(r.stdout or "{}")
-            authenticated = data.get("data", {}).get("authenticated", False)
-            username = data.get("data", {}).get("username") or ""
+            if cred_path.exists():
+                data = json.loads(cred_path.read_text(encoding="utf-8"))
+                cookies = data.get("cookies") or {}
+                session = cookies.get("reddit_session") or data.get("reddit_session")
+                username = data.get("username") or ""
+                if session:
+                    suffix = f"（已保存账号：{username}）" if username else ""
+                    return "ok", (
+                        f"检测到本地 Reddit 凭证{suffix}。"
+                        "doctor 跳过在线校验，保持非交互"
+                    )
+        except (json.JSONDecodeError, OSError):
+            pass
 
-            if authenticated:
-                suffix = f"（已登录：{username}）" if username else ""
-                return "ok", (f"rdt-cli 可用{suffix}（搜索帖子、阅读全文、查看评论）")
-
-            return "warn", (
-                "rdt-cli 已安装但未登录。Reddit 自 2024 年起要求认证，"
-                "未登录时所有请求均返回 403。\n\n"
-                "方法一（自动）：运行 `rdt login`\n"
-                "  先在浏览器登录 reddit.com，再运行此命令自动提取 Cookie。\n\n"
-                "方法二（手动，适用于 Chrome/Edge 127+ 无法自动提取时）：\n"
-                "  1. Chrome 应用商店安装 Cookie-Editor 扩展：\n"
-                "     https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm\n"
-                "  2. 在浏览器打开 reddit.com（确保已登录）\n"
-                "  3. 点击 Cookie-Editor 图标，找到 `reddit_session`，复制其 Value\n"
-                f"  4. 将以下内容写入 {_CREDENTIAL_FILE}：\n"
-                '     {"cookies": {"reddit_session": "<粘贴 Value>"}, '
-                '"source": "manual", "username": "<你的用户名>", '
-                '"modhash": null, "saved_at": 0, "last_verified_at": null}\n\n'
-                "验证：`rdt status --json` 确认 authenticated: true"
-            )
-
-        except (json.JSONDecodeError, FileNotFoundError, subprocess.TimeoutExpired):
-            return "warn", "rdt-cli 已安装但状态检查失败，运行 `rdt status` 查看详情"
+        return "warn", (
+            "rdt-cli 已安装，但当前未检测到本地凭证。Reddit 自 2024 年起要求认证，"
+            "未登录时所有请求均返回 403。\n\n"
+            "方法一（自动）：运行 `rdt login`\n"
+            "  先在浏览器登录 reddit.com，再运行此命令自动提取 Cookie。\n\n"
+            "方法二（手动，适用于 Chrome/Edge 127+ 无法自动提取时）：\n"
+            "  1. Chrome 应用商店安装 Cookie-Editor 扩展：\n"
+            "     https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm\n"
+            "  2. 在浏览器打开 reddit.com（确保已登录）\n"
+            "  3. 点击 Cookie-Editor 图标，找到 `reddit_session`，复制其 Value\n"
+            f"  4. 将以下内容写入 {_CREDENTIAL_FILE}：\n"
+            '     {"cookies": {"reddit_session": "<粘贴 Value>"}, '
+            '"source": "manual", "username": "<你的用户名>", '
+            '"modhash": null, "saved_at": 0, "last_verified_at": null}\n\n'
+            "验证：`rdt status --json` 确认 authenticated: true"
+        )

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Twitter/X — check if twitter-cli or bird CLI is available."""
 
+import json
 import shutil
-import subprocess
+from pathlib import Path
 from .base import Channel
 
 
@@ -22,10 +23,24 @@ class TwitterChannel(Channel):
         twitter = shutil.which("twitter")
         bird = shutil.which("bird") or shutil.which("birdx")
 
-        if twitter:
-            return self._check_twitter_cli(twitter)
-        elif bird:
-            return self._check_bird(bird)
+        if twitter or bird:
+            creds = self._find_local_credentials(config)
+            if creds:
+                return "ok", (
+                    f"检测到本地凭证（{creds}）。"
+                    "doctor 跳过在线校验，保持非交互"
+                )
+            if twitter:
+                return "warn", (
+                    "twitter-cli 已安装，但当前未检测到本地凭证。配置方式：\n"
+                    "  agent-reach configure twitter-cookies AUTH_TOKEN CT0\n"
+                    "或：\n"
+                    "  agent-reach configure twitter-cookies \"auth_token=xxx; ct0=yyy; ...\""
+                )
+            return "warn", (
+                "bird CLI 已安装，但当前未检测到本地凭证。"
+                "设置环境变量文件：~/.config/bird/credentials.env"
+            )
         else:
             return "warn", (
                 "Twitter CLI 未安装。安装方式：\n"
@@ -34,49 +49,32 @@ class TwitterChannel(Channel):
                 "  uv tool install twitter-cli"
             )
 
-    def _check_twitter_cli(self, binary: str):
+    def _find_local_credentials(self, config=None):
         try:
-            r = subprocess.run(
-                [binary, "status"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=10
-            )
-            output = (r.stdout or "") + (r.stderr or "")
-            if r.returncode == 0 and "ok: true" in output:
-                return "ok", (
-                    "twitter-cli 完整可用（搜索、读推文、时间线、长文/Article、"
-                    "用户查询、Thread）"
-                )
-            if "not_authenticated" in output:
-                return "warn", (
-                    "twitter-cli 已安装但未认证。设置方式：\n"
-                    "  export TWITTER_AUTH_TOKEN=\"xxx\"\n"
-                    "  export TWITTER_CT0=\"yyy\"\n"
-                    "或确保已在浏览器中登录 x.com"
-                )
-            return "warn", (
-                "twitter-cli 已安装但认证检查失败。运行：\n"
-                "  twitter -v status 查看详细信息"
-            )
+            if config:
+                auth = (config.get("twitter_auth_token") or "").strip()
+                ct0 = (config.get("twitter_ct0") or "").strip()
+                if auth and ct0:
+                    return "~/.agent-reach/config.yaml"
         except Exception:
-            return "warn", "twitter-cli 已安装但连接失败"
+            pass
 
-    def _check_bird(self, binary: str):
+        session_path = Path.home() / ".config" / "xfetch" / "session.json"
         try:
-            r = subprocess.run(
-                [binary, "check"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=10
-            )
-            output = (r.stdout or "") + (r.stderr or "")
-            if r.returncode == 0:
-                return "ok", "bird CLI 可用（读取、搜索推文，含长文/X Article）"
-            if "Missing credentials" in output or "missing" in output.lower():
-                return "warn", (
-                    "bird CLI 已安装但未配置认证。设置环境变量：\n"
-                    "  export AUTH_TOKEN=\"xxx\"\n"
-                    "  export CT0=\"yyy\""
-                )
-            return "warn", (
-                "bird CLI 已安装但认证检查失败。"
-            )
+            if session_path.exists():
+                data = json.loads(session_path.read_text(encoding="utf-8"))
+                if data.get("authToken") and data.get("ct0"):
+                    return str(session_path)
         except Exception:
-            return "warn", "bird CLI 已安装但连接失败"
+            pass
+
+        bird_env = Path.home() / ".config" / "bird" / "credentials.env"
+        try:
+            if bird_env.exists():
+                text = bird_env.read_text(encoding="utf-8")
+                if "AUTH_TOKEN=" in text and "CT0=" in text:
+                    return str(bird_env)
+        except Exception:
+            pass
+
+        return None

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -2,7 +2,7 @@
 """XiaoHongShu — check if xhs-cli (xiaohongshu-cli) is available."""
 
 import shutil
-import subprocess
+from pathlib import Path
 from .base import Channel
 
 
@@ -137,26 +137,41 @@ class XiaoHongShuChannel(Channel):
                 "安装后运行 `xhs login` 登录"
             )
 
-        try:
-            r = subprocess.run(
-                [xhs, "status"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=10,
-            )
-            output = (r.stdout or "") + (r.stderr or "")
-            if r.returncode == 0 and "ok: true" in output:
-                return "ok", (
-                    "完整可用（搜索、阅读、评论、发帖、热门、"
-                    "收藏、关注、用户查询）"
-                )
-            if "not_authenticated" in output or "expired" in output:
-                return "warn", (
-                    "xhs-cli 已安装但未登录。运行：\n"
-                    "  xhs login\n"
-                    "（自动从浏览器提取 Cookie，或扫码登录）"
-                )
-            return "warn", (
-                "xhs-cli 已安装但状态异常。运行：\n"
-                "  xhs -v status 查看详细信息"
-            )
-        except Exception:
-            return "warn", "xhs-cli 已安装但连接失败"
+        # Keep doctor/status fully non-interactive.
+        #
+        # xhs-cli status may scan multiple browsers for cookies, which can
+        # trigger repeated macOS Keychain prompts. A passive health check should
+        # never open browser-cookie access or login flows.
+        if config:
+            try:
+                cookie_str = (config.get("xhs_cookie") or "").strip()
+                if cookie_str:
+                    n_cookies = len([p for p in cookie_str.split(";") if "=" in p])
+                    return "ok", (
+                        f"检测到本地 Cookie 配置（{n_cookies} 项）。"
+                        "doctor 跳过在线校验，保持非交互"
+                    )
+            except Exception:
+                pass
+
+        cookie_files = [
+            Path.home() / ".xiaohongshu-cli" / "cookies.json",
+            Path.home() / ".agent-reach" / "xhs-cookies.json",
+        ]
+        for path in cookie_files:
+            try:
+                if path.exists() and path.stat().st_size > 10:
+                    return "ok", (
+                        f"检测到本地登录状态：{path}。"
+                        "doctor 跳过在线校验，保持非交互"
+                    )
+            except OSError:
+                pass
+
+        return "warn", (
+            "xhs-cli 已安装，但当前未检测到本地 Cookie。"
+            "需要时手动配置：\n"
+            "  xhs login\n"
+            "或：\n"
+            "  agent-reach configure xhs-cookies '<cookie header 或 JSON>'"
+        )

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -248,34 +248,48 @@ def _cmd_install(args):
         print()
         print(f"[dry-run] Would install optional channels: {', '.join(sorted(requested_channels))}")
 
-    # ── Auto-import cookies (only if cookie-needing channels are requested) ──
+    # ── Cookie import policy ──
+    #
+    # Keep install non-interactive by default.
+    # Automatic browser scans can trigger repeated macOS Keychain prompts
+    # across multiple browsers and platforms. Make this an explicit opt-in.
     needs_cookies = bool(requested_channels & COOKIE_CHANNELS)
+    auto_cookie_import = os.environ.get("AGENT_REACH_AUTO_IMPORT_COOKIES", "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
     if env == "local" and needs_cookies and not safe_mode and not dry_run:
         print()
-        print("Importing cookies from browser...")
-        print("  (macOS may ask for your login password to access the Keychain — this is normal,")
-        print("   it only happens once during install. Enter your password or click 'Allow'.)")
-        try:
-            from agent_reach.cookie_extract import configure_from_browser
-            results = configure_from_browser("chrome", config)
-            found = False
-            for platform, success, message in results:
-                if success:
-                    print(f"  ✅ {platform}: {message}")
-                    found = True
-            if not found:
-                results = configure_from_browser("firefox", config)
+        if auto_cookie_import:
+            print("Importing cookies from browser...")
+            print("  Opt-in enabled via AGENT_REACH_AUTO_IMPORT_COOKIES=1")
+            try:
+                from agent_reach.cookie_extract import configure_from_browser
+                results = configure_from_browser("chrome", config)
+                found = False
                 for platform, success, message in results:
                     if success:
                         print(f"  ✅ {platform}: {message}")
                         found = True
-            if not found:
-                print("  -- No cookies found (normal if you haven't logged into these sites)")
-        except Exception:
-            print("  -- Could not read browser cookies (browser might be open or password was denied)")
+                if not found:
+                    results = configure_from_browser("firefox", config)
+                    for platform, success, message in results:
+                        if success:
+                            print(f"  ✅ {platform}: {message}")
+                            found = True
+                if not found:
+                    print("  -- No cookies found (normal if you haven't logged into these sites)")
+            except Exception:
+                print("  -- Could not read browser cookies (browser might be open or password was denied)")
+        else:
+            print("Skipping automatic browser cookie import to keep install non-interactive.")
+            print("  Configure auth only when you explicitly need it:")
+            print("    agent-reach configure --from-browser chrome")
+            print("    agent-reach configure twitter-cookies AUTH_TOKEN CT0")
+            print("    agent-reach configure xhs-cookies '<cookie header 或 JSON>'")
     elif env == "local" and needs_cookies and dry_run:
         print()
-        print("[dry-run] Would try to import cookies from Chrome/Firefox")
+        print("[dry-run] Would keep install non-interactive by default")
+        print("[dry-run] Set AGENT_REACH_AUTO_IMPORT_COOKIES=1 to opt into browser cookie import")
 
     # Environment-specific advice
     if env == "server":

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,6 +130,8 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 > 4. 把导出的字符串发给 Agent
 >
 > **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。
+>
+> `agent-reach install` 默认保持非交互，不会自动扫描浏览器 Cookie。只有你明确执行 `configure --from-browser`，或显式设置 `AGENT_REACH_AUTO_IMPORT_COOKIES=1` 时，才会触发浏览器 Cookie 导入。
 
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -4,6 +4,7 @@
 import json
 import shutil
 import subprocess
+from pathlib import Path
 from urllib.error import URLError
 
 from agent_reach.channels import get_all_channels, get_channel
@@ -655,35 +656,28 @@ class TestRedditChannel:
         assert "rdt-cli" in msg
         assert "public-clis/rdt-cli" in msg
 
-    def test_reports_ok_when_authenticated(self, monkeypatch):
+    def test_reports_ok_when_saved_credential_exists(self, monkeypatch, tmp_path):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-        fake_output = json.dumps({
-            "ok": True,
-            "schema_version": "1",
-            "data": {"authenticated": True, "username": "testuser", "cookie_count": 1},
-        })
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cred = tmp_path / ".config" / "rdt-cli" / "credential.json"
+        cred.parent.mkdir(parents=True)
+        cred.write_text(
+            json.dumps({
+                "cookies": {"reddit_session": "abc"},
+                "username": "testuser",
+            }),
+            encoding="utf-8",
+        )
 
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, fake_output, "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.reddit import RedditChannel
         status, msg = RedditChannel().check()
         assert status == "ok"
         assert "testuser" in msg
+        assert "非交互" in msg
 
-    def test_reports_warn_when_not_authenticated(self, monkeypatch):
+    def test_reports_warn_when_not_authenticated(self, monkeypatch, tmp_path):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-        fake_output = json.dumps({
-            "ok": True,
-            "schema_version": "1",
-            "data": {"authenticated": False, "username": None, "cookie_count": 0},
-        })
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, fake_output, "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         from agent_reach.channels.reddit import RedditChannel
         status, msg = RedditChannel().check()
         assert status == "warn"
@@ -692,16 +686,13 @@ class TestRedditChannel:
         assert "Cookie-Editor" in msg
         assert "chromewebstore.google.com" in msg
 
-    def test_reports_warn_when_status_check_fails(self, monkeypatch):
+    def test_reports_warn_when_status_check_fails(self, monkeypatch, tmp_path):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "not valid json{{{", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         from agent_reach.channels.reddit import RedditChannel
         status, msg = RedditChannel().check()
         assert status == "warn"
+        assert "rdt login" in msg
 
     def test_can_handle_reddit_urls(self):
         from agent_reach.channels.reddit import RedditChannel
@@ -713,27 +704,36 @@ class TestRedditChannel:
 
 
 class TestXiaoHongShuChannel:
-    def test_reports_ok_when_cli_authenticated(self, monkeypatch):
+    class _Config:
+        def __init__(self, cookie=""):
+            self.cookie = cookie
+
+        def get(self, key):
+            if key == "xhs_cookie":
+                return self.cookie
+            return None
+
+    def test_reports_ok_when_saved_cookie_in_config(self, monkeypatch):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "ok: true\nusername: testuser\n", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-
-        status, msg = XiaoHongShuChannel().check()
+        status, msg = XiaoHongShuChannel().check(self._Config("a1=123; web_session=456"))
         assert status == "ok"
-        assert "完整可用" in msg
+        assert "非交互" in msg
 
-    def test_reports_warn_when_not_authenticated(self, monkeypatch):
+    def test_reports_ok_when_saved_cookie_file_exists(self, monkeypatch, tmp_path):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cookie_file = tmp_path / ".xiaohongshu-cli" / "cookies.json"
+        cookie_file.parent.mkdir(parents=True)
+        cookie_file.write_text('{"a1":"abc"}', encoding="utf-8")
 
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "", "ok: false\nerror:\n  code: not_authenticated\n")
+        status, msg = XiaoHongShuChannel().check(self._Config())
+        assert status == "ok"
+        assert "cookies.json" in msg
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
-
-        status, msg = XiaoHongShuChannel().check()
+    def test_reports_warn_when_not_authenticated(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        status, msg = XiaoHongShuChannel().check(self._Config())
         assert status == "warn"
         assert "xhs login" in msg
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,17 @@ class TestCLI:
         assert auth_token == "token123"
         assert ct0 == "ct0abc"
 
+    def test_install_dry_run_keeps_cookie_import_non_interactive(self, capsys):
+        with patch("agent_reach.cli._detect_environment", return_value="local"):
+            with patch(
+                "sys.argv",
+                ["agent-reach", "install", "--dry-run", "--channels=twitter,xiaohongshu"],
+            ):
+                main()
+        captured = capsys.readouterr()
+        assert "non-interactive" in captured.out
+        assert "AGENT_REACH_AUTO_IMPORT_COOKIES=1" in captured.out
+
 
 class TestCheckUpdateRetry:
     def test_retry_timeout_classification(self):

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -1,108 +1,77 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, Mock
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 from agent_reach.channels.twitter import TwitterChannel
 
 
-def _cp(stdout="", stderr="", returncode=0):
-    m = Mock()
-    m.stdout = stdout
-    m.stderr = stderr
-    m.returncode = returncode
-    return m
+def _config(auth="", ct0=""):
+    cfg = Mock()
+    cfg.get.side_effect = lambda key: {
+        "twitter_auth_token": auth,
+        "twitter_ct0": ct0,
+    }.get(key)
+    return cfg
 
 
-# --- twitter-cli tests ---
-
-def test_check_twitter_cli_found_and_auth_ok():
-    """twitter-cli found + twitter status ok → ok."""
+def test_check_twitter_with_agent_reach_config():
     channel = TwitterChannel()
-    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="ok: true\nusername: testuser\n", returncode=0),
-    ):
-        status, message = channel.check()
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None):
+        status, message = channel.check(_config("token123", "ct0abc"))
     assert status == "ok"
-    assert "twitter-cli" in message
-    assert "完整可用" in message
+    assert "非交互" in message
+    assert "config.yaml" in message
 
 
-def test_check_twitter_cli_found_auth_missing():
-    """twitter-cli found + not_authenticated → warn about auth."""
+def test_check_twitter_warns_when_binary_present_but_no_credentials(tmp_path, monkeypatch):
     channel = TwitterChannel()
-    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None), patch(
-        "subprocess.run",
-        return_value=_cp(
-            stderr="ok: false\nerror:\n  code: not_authenticated\n",
-            returncode=1,
-        ),
-    ):
-        status, message = channel.check()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None):
+        status, message = channel.check(_config())
     assert status == "warn"
-    assert "未认证" in message
+    assert "twitter-cookies" in message
 
 
-# --- bird CLI fallback tests ---
-
-def test_check_bird_fallback_auth_ok():
-    """No twitter-cli, but bird found + bird check ok → ok."""
+def test_check_bird_uses_saved_env_credentials(tmp_path, monkeypatch):
     channel = TwitterChannel()
+    bird_dir = tmp_path / ".config" / "bird"
+    bird_dir.mkdir(parents=True)
+    (bird_dir / "credentials.env").write_text('AUTH_TOKEN="aaa"\nCT0="bbb"\n', encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
     def which_side_effect(name):
         if name == "bird":
             return "/usr/local/bin/bird"
         return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="Authenticated as @user\n", returncode=0),
-    ):
-        status, message = channel.check()
+
+    with patch("shutil.which", side_effect=which_side_effect):
+        status, message = channel.check(_config())
     assert status == "ok"
-    assert "bird" in message
+    assert "非交互" in message
+    assert "credentials.env" in message
 
 
-def test_check_bird_fallback_auth_missing():
-    """No twitter-cli, bird found but Missing credentials → warn."""
+def test_check_twitter_uses_xfetch_session(tmp_path, monkeypatch):
     channel = TwitterChannel()
-    def which_side_effect(name):
-        if name == "bird":
-            return "/usr/local/bin/bird"
-        return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stderr="Missing credentials\n", returncode=1),
-    ):
-        status, message = channel.check()
-    assert status == "warn"
-    assert "未配置认证" in message
+    xfetch_dir = tmp_path / ".config" / "xfetch"
+    xfetch_dir.mkdir(parents=True)
+    (xfetch_dir / "session.json").write_text(
+        json.dumps({"authToken": "aaa", "ct0": "bbb"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None):
+        status, message = channel.check(_config())
+    assert status == "ok"
+    assert "session.json" in message
 
-# --- neither installed ---
 
 def test_check_nothing_installed():
-    """Neither twitter-cli nor bird → warn with install hint."""
     channel = TwitterChannel()
     with patch("shutil.which", return_value=None):
         status, message = channel.check()
     assert status == "warn"
-    assert "twitter-cli" in message
-
-
-# --- twitter-cli preferred over bird ---
-
-def test_twitter_cli_preferred_over_bird():
-    """When both are installed, twitter-cli is used."""
-    channel = TwitterChannel()
-    def which_side_effect(name):
-        if name == "twitter":
-            return "/usr/local/bin/twitter"
-        if name == "bird":
-            return "/usr/local/bin/bird"
-        return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="ok: true\n", returncode=0),
-    ):
-        status, message = channel.check()
-    assert status == "ok"
     assert "twitter-cli" in message


### PR DESCRIPTION
## Summary

Keep `install` and cookie-backed channel health checks non-interactive by default.

## Problem

On macOS, `agent-reach install` and `agent-reach doctor` can route into browser-cookie scanning or interactive status commands for cookie-backed channels.

In practice this can trigger repeated Keychain / password prompts when the underlying CLI scans multiple browsers for cookies. It also makes passive health checks hang or retry in places where the user only asked for install or doctor output.

## Changes

- `install`
  - keep automatic browser cookie import disabled by default
  - add explicit opt-in via `AGENT_REACH_AUTO_IMPORT_COOKIES=1`
  - keep `--dry-run` messaging aligned with the non-interactive default
- `twitter`
  - detect saved local credentials from Agent Reach config, `~/.config/xfetch/session.json`, or `~/.config/bird/credentials.env`
  - skip `twitter status` / `bird check` during doctor-style checks
- `xiaohongshu`
  - detect saved cookies from Agent Reach config or common local cookie files
  - skip `xhs status` during doctor-style checks
- `reddit`
  - detect saved credentials from `~/.config/rdt-cli/credential.json`
  - skip `rdt status --json` during doctor-style checks
- docs
  - document the new install behavior
- tests
  - update channel tests to validate passive local-credential detection
  - add CLI coverage for the non-interactive install messaging

## Why this shape

`install` and `doctor` are passive flows. They work better when they only inspect local state and leave login / browser-cookie import to explicit configuration steps.

That keeps health checks fast, avoids repeated Keychain prompts, and still preserves the existing explicit login/configure workflows.

## Validation

- `python3 -m py_compile agent_reach/channels/twitter.py agent_reach/channels/xiaohongshu.py agent_reach/channels/reddit.py agent_reach/cli.py`
- `.venv/bin/pytest tests/test_twitter_channel.py tests/test_channels.py tests/test_cli.py -q`
- `.venv/bin/pytest tests/test_doctor.py -q`
- `.venv/bin/pytest -q`

Full test run result: `86 passed in 18.83s`
