### PR TITLE
fix(cli): validate groq-key prefix before saving (refs #271)

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1117,8 +1117,20 @@ def _cmd_configure(args):
         print(f"✅ GitHub token configured!")
 
     elif args.key == "groq-key":
-        config.set("groq_api_key", value)
+        cleaned = value.strip()
+        if not _looks_like_groq_key(cleaned):
+            print("[X] Groq API keys start with 'gsk_'. The value you provided does not.")
+            print("   Tip: Groq Console (https://console.groq.com) issues keys prefixed 'gsk_'.")
+            print("   If you pasted a key from OpenAI (sk-...) or another vendor, it won't work")
+            print("   against Groq's Whisper endpoint used for Xiaoyuzhou transcription.")
+            return
+        config.set("groq_api_key", cleaned)
         print(f"✅ Groq key configured!")
+
+
+def _looks_like_groq_key(value: str) -> bool:
+    """Best-effort check that ``value`` looks like a Groq console API key."""
+    return bool(value) and value.startswith("gsk_")
 
 
 def _parse_twitter_cookie_input(value: str):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,59 @@ class TestCLI:
         assert ct0 == "ct0abc"
 
 
+class TestGroqKeyValidation:
+    def test_looks_like_groq_key_accepts_gsk_prefix(self):
+        assert cli._looks_like_groq_key("gsk_abc123")
+
+    def test_looks_like_groq_key_rejects_openai_prefix(self):
+        assert not cli._looks_like_groq_key("sk-abc123")
+
+    def test_looks_like_groq_key_rejects_empty(self):
+        assert not cli._looks_like_groq_key("")
+
+    def test_configure_groq_key_rejects_bad_prefix(self, capsys):
+        saved = {}
+
+        class _FakeConfig:
+            def set(self, key, value):
+                saved[key] = value
+
+        fake = _FakeConfig()
+        args = type(
+            "Args",
+            (),
+            {"key": "groq-key", "value": ["sk-not-a-groq-key"], "from_browser": None},
+        )()
+
+        with patch("agent_reach.config.Config", return_value=fake):
+            cli._cmd_configure(args)
+
+        out = capsys.readouterr().out
+        assert "gsk_" in out
+        assert "groq_api_key" not in saved  # key must not be persisted
+
+    def test_configure_groq_key_accepts_good_prefix(self, capsys):
+        saved = {}
+
+        class _FakeConfig:
+            def set(self, key, value):
+                saved[key] = value
+
+        fake = _FakeConfig()
+        args = type(
+            "Args",
+            (),
+            {"key": "groq-key", "value": ["gsk_looksfine"], "from_browser": None},
+        )()
+
+        with patch("agent_reach.config.Config", return_value=fake):
+            cli._cmd_configure(args)
+
+        out = capsys.readouterr().out
+        assert "✅ Groq key configured" in out
+        assert saved["groq_api_key"] == "gsk_looksfine"
+
+
 class TestCheckUpdateRetry:
     def test_retry_timeout_classification(self):
         sleeps = []


### PR DESCRIPTION
## Summary

`agent-reach configure groq-key <value>` now rejects values that do not start with `gsk_` before persisting them to `~/.agent-reach/config.yaml`. If the prefix is wrong the command prints a short explanation pointing the user to the Groq Console and reminding them that OpenAI (`sk-...`) or other vendor keys will not work against `api.groq.com`, then returns without writing config.

## Motivation

Issue #271 reports a user who pasted a non-Groq key (confusing grok.com with groq.com) and saw silent failures during Xiaoyuzhou podcast transcription. The CLI previously accepted any string, so the mistake only surfaced later when `curl` against `api.groq.com/openai/v1/audio/transcriptions` returned 401 — far from the point of input.

The fix catches the wrong key format at the point of entry with an actionable error.

## Changes

- `agent_reach/cli.py`: add `_looks_like_groq_key()` helper; `_cmd_configure` now validates Groq keys, trims whitespace, and only persists values that pass the check.
- `tests/test_cli.py`: new `TestGroqKeyValidation` class — 5 cases covering the helper and the configure branch (accept/reject paths, no-persist on reject).

## Test plan

- [x] `pytest -q` — 90 passed (new tests included)
- [x] manual: `agent-reach configure groq-key sk-foo` → prints help message, nothing saved
- [x] manual: `agent-reach configure groq-key gsk_real_looking_key` → stores the key, prints success

Refs #271.