### PR TITLE
fix(skill): update Twitter commands from bird to twitter-cli in SKILL_en.md

### DIFF
--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -41,13 +41,13 @@ mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
 ```
 
-## Twitter/X (bird)
+## Twitter/X (twitter-cli)
 
 ```bash
-bird search "query" -n 10                  # search
-bird read URL_OR_ID                        # read tweet (supports /status/ and /article/ URLs)
-bird user-tweets @username -n 20           # user timeline
-bird thread URL_OR_ID                      # full thread
+twitter search "query" -n 10                  # search
+twitter read URL_OR_ID                        # read tweet (supports /status/ and /article/ URLs)
+twitter user-tweets @username -n 20           # user timeline
+twitter thread URL_OR_ID                      # full thread
 ```
 
 ## YouTube (yt-dlp)


### PR DESCRIPTION
## Summary / 问题说明

`SKILL_en.md` was using the legacy `bird` command for Twitter operations, but the installed CLI is `twitter` (twitter-cli). Agents following the English skill file hit `bird: command not found` on every Twitter call.

`SKILL_en.md` 中 Twitter 部分使用的是旧命令 `bird`，但实际安装的 CLI 是 `twitter`（twitter-cli）。按英文版操作的 Agent 每次调用 Twitter 都会报 `bird: command not found`。

## Changes / 改动

- Updated `SKILL_en.md` Twitter section: `bird ...` → `twitter ...`
- Updated section heading: `Twitter/X (bird)` → `Twitter/X (twitter-cli)`
- The Chinese `SKILL.md` already uses `twitter` correctly — this brings the English version in sync.

## Related / 关联

Closes #282