### PR TITLE
fix(config): update stale comment from bird CLI to twitter-cli

### DIFF
--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -21,7 +21,7 @@ class Config:
     # Feature → required config keys
     FEATURE_REQUIREMENTS = {
         "exa_search": ["exa_api_key"],
-        "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by bird CLI
+        "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
         "groq_whisper": ["groq_api_key"],
         "github_token": ["github_token"],
     }


### PR DESCRIPTION
## Summary / 问题说明

`config.py` line 24 still references `bird CLI` in a comment, but the project has migrated to `twitter-cli`. This is the same class of stale reference as #282, just in code instead of docs.

`config.py` 第 24 行的注释仍然写着 `bird CLI`，但项目已经迁移到 `twitter-cli`。和 #282 是同类问题，只是出现在代码注释里。

## Changes / 改动

```python
# before
"twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by bird CLI

# after
"twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
```

## Test / 测试

All 85 tests pass (`python3 -m pytest tests/ -v`).

## Related / 关联

Related to #282