### PR TITLE
docs(skill): replace stale bird commands with twitter-cli in SKILL_en.md

### DIFF
--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -41,13 +41,13 @@ mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
 ```
 
-## Twitter/X (bird)
+## Twitter/X (twitter-cli)
 
 ```bash
-bird search "query" -n 10                  # search
-bird read URL_OR_ID                        # read tweet (supports /status/ and /article/ URLs)
-bird user-tweets @username -n 20           # user timeline
-bird thread URL_OR_ID                      # full thread
+twitter search "query" --limit 10         # search
+twitter tweet URL_OR_ID                   # read tweet
+twitter article URL_OR_ID                 # read X Article / long-form
+twitter user-posts @username -n 20        # user timeline
 ```
 
 ## YouTube (yt-dlp)


### PR DESCRIPTION
## Summary

Commit `c5a304d` migrated the Twitter/X channel from the `bird` CLI to `twitter-cli` across the codebase, but `agent_reach/skill/SKILL_en.md` was missed. English-locale agents following this file get `bird: command not found` on every Twitter/X operation.

### Changes

- Updated section heading from `## Twitter/X (bird)` to `## Twitter/X (twitter-cli)`
- Replaced all `bird` commands with their `twitter-cli` equivalents:
  - `bird search "query" -n 10` → `twitter search "query" --limit 10`
  - `bird read URL_OR_ID` (tweets) → `twitter tweet URL_OR_ID`
  - `bird read URL_OR_ID` (articles) → `twitter article URL_OR_ID` (twitter-cli splits these into separate subcommands)
  - `bird user-tweets @username -n 20` → `twitter user-posts @username -n 20`
  - `bird thread URL_OR_ID` — omitted; no direct equivalent in twitter-cli
- Format matches `agent_reach/skill/references/social.md` and the Chinese `SKILL.md`

Closes #282