### PR TITLE
docs(skill_en): replace stale `bird` CLI with `twitter`

### DIFF
--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -41,14 +41,17 @@ mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
 ```
 
-## Twitter/X (bird)
+## Twitter/X (twitter-cli)
 
 ```bash
-bird search "query" -n 10                  # search
-bird read URL_OR_ID                        # read tweet (supports /status/ and /article/ URLs)
-bird user-tweets @username -n 20           # user timeline
-bird thread URL_OR_ID                      # full thread
+twitter -c search "query" -n 10            # search (-c = compact JSON, LLM-friendly)
+twitter -c tweet URL_OR_ID                 # read tweet + replies (supports /status/ URLs)
+twitter -c article URL_OR_ID               # read a Twitter Article
+twitter -c user-posts @username -n 20      # user timeline
+twitter -c feed -n 20                      # home timeline
 ```
+
+> Binary is `twitter` (`pipx install twitter-cli`, ≥ 0.8.5). The `bird` name in older docs has been retired. If `search` returns 404, run `pipx upgrade twitter-cli`.
 
 ## YouTube (yt-dlp)
 


### PR DESCRIPTION
## Summary
- The English `SKILL.md` (`agent_reach/skill/SKILL_en.md`) still documented a `bird` CLI for Twitter/X reads. That binary isn't shipped/installed by agent-reach anymore — agents calling `bird read <url>` hit `command not found` and fall back to slower paths (Jina Reader, browser automation).
- The Chinese `SKILL.md` was already migrated to `twitter` (twitter-cli). This PR brings the English doc in line.

## Changes
- `bird search` → `twitter -c search`
- `bird read` → `twitter -c tweet`
- `bird user-tweets` → `twitter -c user-posts`
- Added `twitter -c article` and `twitter -c feed` examples
- Added a hint to run `pipx upgrade twitter-cli` if `search` returns 404 (matches existing guidance in `references/social.md`)

Docs-only; no code changes.

## Test plan
- [x] Confirmed `twitter -c tweet <x.com/status URL>` returns the tweet + replies as JSON on a fresh install (twitter-cli 0.8.5, env from `~/.agent-reach/env.sh`).
- [x] Existing `references/social.md` already uses these exact subcommand names — this aligns the top-level English skill with the reference doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)