### PR TITLE
fix(xiaoyuzhou): macOS BSD grep compat — replace grep -oP with perl -ne

### DIFF
--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -35,8 +35,8 @@ echo "===================="
 # Step 1: 提取音频 URL 和标题
 echo "🔍 正在解析页面..."
 PAGE=$(curl -s "$URL")
-AUDIO_URL=$(echo "$PAGE" | grep -oP 'https://media\.xyzcdn\.net/[^"]*\.(m4a|mp3)' | head -1)
-TITLE=$(echo "$PAGE" | grep -oP '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"//')
+AUDIO_URL=$(echo "$PAGE" | perl -ne 'while (/(https:\/\/media\.xyzcdn\.net\/[^"]*\.(?:m4a|mp3))/g) { print "$1\n" }' | head -1)
+TITLE=$(echo "$PAGE" | perl -ne 'if (/"title":"([^"]*)"/) { print "$1\n"; last }' | head -1)
 
 if [ -z "$AUDIO_URL" ]; then
     echo "❌ 无法从页面提取音频链接"
@@ -111,7 +111,7 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
         # 如果是速率限制，等待后重试
         if [ "$HTTP_CODE" = "429" ]; then
             # 从错误信息中提取等待时间，默认 120 秒
-            WAIT_SEC=$(echo "$BODY" | grep -oP 'in \K[0-9]+m' | sed 's/m//' | head -1)
+            WAIT_SEC=$(echo "$BODY" | perl -ne 'if (/in (\d+)m/) { print "$1\n"; exit }')
             WAIT_SEC=${WAIT_SEC:-2}
             WAIT_SEC=$((WAIT_SEC * 60 + 30))
             echo "   ⏳ 速率限制，等待 ${WAIT_SEC} 秒后重试..."


### PR DESCRIPTION
## Summary

- Fixes `transcribe_xiaoyuzhou.sh` failing on every macOS install with `grep: invalid option -- P`
- Root cause: `grep -oP` (PCRE) is a GNU extension and is not available in BSD grep that ships with macOS
- Replaces the three affected sites with `perl -ne` — macOS ships perl by default, so no new dependency, and works identically on Linux

Closes #289

## What changed

`agent_reach/scripts/transcribe_xiaoyuzhou.sh`, lines 38, 39, 114:

```diff
-AUDIO_URL=$(echo "$PAGE" | grep -oP 'https://media\.xyzcdn\.net/[^"]*\.(m4a|mp3)' | head -1)
-TITLE=$(echo "$PAGE" | grep -oP '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"//')
+AUDIO_URL=$(echo "$PAGE" | perl -ne 'while (/(https:\/\/media\.xyzcdn\.net\/[^"]*\.(?:m4a|mp3))/g) { print "$1\n" }' | head -1)
+TITLE=$(echo "$PAGE" | perl -ne 'if (/"title":"([^"]*)"/) { print "$1\n"; last }' | head -1)
```

```diff
-WAIT_SEC=$(echo "$BODY" | grep -oP 'in \K[0-9]+m' | sed 's/m//' | head -1)
+WAIT_SEC=$(echo "$BODY" | perl -ne 'if (/in (\d+)m/) { print "$1\n"; exit }')
```

Net change: 3 insertions, 3 deletions. No behavior change on Linux; fixes the macOS path entirely.

## Test plan

- [x] Lint: shell still parses (`bash -n agent_reach/scripts/transcribe_xiaoyuzhou.sh`)
- [x] End-to-end on macOS 14 (Apple Silicon, bash 3.2, BSD grep, ffmpeg 8.1, Python 3.14, agent-reach 1.4.0): full transcription of `https://www.xiaoyuzhoufm.com/episode/69f2d432bb3ffa11e59cc5b0` (9:05, 8.4MB → 4MB mono mp3 → 1 chunk → Groq Whisper large-v3 → 2561 字 markdown). Sample run:

  ```
  📻 小宇宙播客转文字
  🔍 正在解析页面...
  📝 标题: 五一前夜，5A景区集体翻车背后
  🔗 音频: https://media.xyzcdn.net/.../xxx.m4a
  ⬇️  正在下载音频...
  📦 文件大小: 8.4M
  ⏱️  时长: 9分5秒
  🔄 正在转码...
  📦 转码后: 4MB
  📎 无需切片
  🎙️  正在转录 (Groq Whisper large-v3)...
     段 1/1... ✅ (2561 字)
  ✅ 完成！
  ```
- [ ] Linux smoke (any maintainer with a Linux box): same command should still work — `perl` regexes are equivalent to the prior PCRE patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)