### PR TITLE
feat(xiaoyuzhou): Chinese punctuation prompt + optional --polish flag

### DIFF
--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 # 小宇宙播客转文字脚本
-# 用法: bash transcribe.sh <小宇宙链接> [输出文件路径]
+# 用法: bash transcribe.sh [--polish] <小宇宙链接> [输出文件路径]
 # 环境变量: GROQ_API_KEY (必须)
+#
+# --polish: 转录后调用 Groq Llama 3.3 70B 给文稿补中文标点+合理分段
+#           （Whisper 对中文标点支持较弱，开启后阅读体验显著更好）
 
 set -e
 
-URL="${1:?用法: bash transcribe.sh <小宇宙链接> [输出文件路径]}"
+POLISH=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --polish) POLISH=1; shift ;;
+        --) shift; break ;;
+        -h|--help)
+            echo "用法: bash transcribe.sh [--polish] <小宇宙链接> [输出文件路径]"
+            exit 0 ;;
+        --*)
+            echo "未知选项: $1" >&2
+            exit 1 ;;
+        *) break ;;
+    esac
+done
+
+URL="${1:?用法: bash transcribe.sh [--polish] <小宇宙链接> [输出文件路径]}"
 OUTPUT="${2:-/tmp/podcast_transcript.txt}"
 TMPDIR="/tmp/xiaoyuzhou_$$"
 
@@ -99,6 +117,7 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
         -F file="@$TMPDIR/chunk_${i}.mp3" \
         -F model="whisper-large-v3" \
         -F language="zh" \
+        -F prompt="以下是一段中文普通话播客录音，请输出包含完整中文标点（，。？！：；""''）的转写文本。" \
         -F response_format="text")
     
     HTTP_CODE=$(echo "$RESPONSE" | tail -1)
@@ -140,6 +159,81 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
     echo "✅ ($CHARS 字)"
 done
 
+# Step 6.5 (可选): 用 Llama 3.3 70B 给文稿补标点+分段
+if [ "$POLISH" = "1" ]; then
+    echo "✨ 正在润色（Llama 3.3 70B 加标点+分段）..."
+    for i in $(seq 0 $((NUM_CHUNKS - 1))); do
+        echo -n "   段 $((i+1))/$NUM_CHUNKS... "
+        IN_FILE="$TMPDIR/transcript_${i}.txt" \
+        OUT_FILE="$TMPDIR/polished_${i}.txt" \
+        GROQ_API_KEY="$GROQ_API_KEY" \
+        python3 <<'PY'
+import json, os, sys, urllib.request, urllib.error
+
+KEY = os.environ["GROQ_API_KEY"]
+IN = os.environ["IN_FILE"]
+OUT = os.environ["OUT_FILE"]
+
+MODEL = "llama-3.3-70b-versatile"
+MAX_DEPTH = 3
+PROMPT_TMPL = (
+    "以下是一段中文普通话播客的语音转写片段，由于 Whisper 对中文标点支持较弱，"
+    "整段几乎没有标点。请你**只做一件事**：在合适位置补充中文标点（，。！？：；），"
+    "可以适度分段。\n\n"
+    "**严格要求**：\n"
+    "- 不得修改、删除、增加任何汉字或英文/数字\n"
+    "- 不得改写、润色、总结\n"
+    "- 不得添加任何解释、前言、后记\n"
+    "- 直接输出加好标点+合理分段后的全文\n\n"
+    "原文：\n{}"
+)
+
+def call_groq(text):
+    body = json.dumps({
+        "model": MODEL,
+        "temperature": 0.2,
+        "max_completion_tokens": 8192,
+        "messages": [{"role": "user", "content": PROMPT_TMPL.format(text)}],
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.groq.com/openai/v1/chat/completions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {KEY}",
+            "Content-Type": "application/json",
+            "User-Agent": "agent-reach-xiaoyuzhou/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=180) as r:
+        resp = json.load(r)
+    return (
+        resp["choices"][0]["message"]["content"].strip(),
+        resp["choices"][0].get("finish_reason"),
+    )
+
+def polish(text, depth=0):
+    try:
+        out, fr = call_groq(text)
+    except urllib.error.HTTPError as e:
+        sys.stderr.write(f"polish HTTP {e.code}: {e.read().decode(errors='replace')[:200]}\n")
+        return text  # fallback to raw
+    except Exception as e:
+        sys.stderr.write(f"polish error: {e}\n")
+        return text
+    if fr != "length" or depth >= MAX_DEPTH:
+        return out
+    # 输出被截断：从中点切两半递归处理
+    mid = len(text) // 2
+    return polish(text[:mid], depth + 1) + polish(text[mid:], depth + 1)
+
+content = open(IN, encoding="utf-8").read().strip()
+result = polish(content)
+open(OUT, "w", encoding="utf-8").write(result + "\n")
+print(f"✅ ({len(result)} 字)")
+PY
+    done
+fi
+
 # Step 7: 合并输出
 echo "📄 正在合并文字稿..."
 
@@ -149,12 +243,19 @@ echo "📄 正在合并文字稿..."
     echo "来源: $URL"
     echo "时长: ${DURATION_MIN}分${DURATION_SEC}秒"
     echo "转录时间: $(date '+%Y-%m-%d %H:%M')"
+    if [ "$POLISH" = "1" ]; then
+        echo "润色: Groq Llama 3.3 70B"
+    fi
     echo ""
     echo "---"
     echo ""
-    
+
     for i in $(seq 0 $((NUM_CHUNKS - 1))); do
-        cat "$TMPDIR/transcript_${i}.txt"
+        if [ "$POLISH" = "1" ] && [ -f "$TMPDIR/polished_${i}.txt" ]; then
+            cat "$TMPDIR/polished_${i}.txt"
+        else
+            cat "$TMPDIR/transcript_${i}.txt"
+        fi
         echo ""
     done
 } > "$OUTPUT"

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -117,7 +117,7 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
         -F file="@$TMPDIR/chunk_${i}.mp3" \
         -F model="whisper-large-v3" \
         -F language="zh" \
-        -F prompt="以下是一段中文普通话播客录音，请输出包含完整中文标点（，。？！：；""''）的转写文本。" \
+        -F prompt="以下是一段中文普通话播客录音，请输出包含完整中文标点（，。？！：；“”‘’）的转写文本。" \
         -F response_format="text")
     
     HTTP_CODE=$(echo "$RESPONSE" | tail -1)
@@ -141,6 +141,7 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
                 -F file="@$TMPDIR/chunk_${i}.mp3" \
                 -F model="whisper-large-v3" \
                 -F language="zh" \
+                -F prompt="以下是一段中文普通话播客录音，请输出包含完整中文标点（，。？！：；“”‘’）的转写文本。" \
                 -F response_format="text")
             HTTP_CODE=$(echo "$RESPONSE" | tail -1)
             BODY=$(echo "$RESPONSE" | sed '$d')

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -71,12 +71,14 @@ bili rank -n 10
 
 ## 小宇宙播客 / Xiaoyuzhou Podcast
 
-### 转录单集播客
+### 转录单集播客（推荐带 --polish 自动加标点）
 
 ```bash
-# 输出 Markdown 文件到 /tmp/
-~/.agent-reach/tools/xiaoyuzhou/transcribe.sh "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
+# 输出 Markdown 文件到 /tmp/。--polish 让 Llama 3.3 70B 给文稿补中文标点+合理分段
+~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
 ```
+
+> Whisper 对中文标点支持较弱，**推荐默认使用 `--polish`**。润色调用 Groq 上免费的 Llama 3.3 70B，9 分钟播客只增加 ~7 秒处理时间。如果只想要原始（无标点）转录，去掉 `--polish` 即可。
 
 ### 前置要求
 

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -71,14 +71,14 @@ bili rank -n 10
 
 ## 小宇宙播客 / Xiaoyuzhou Podcast
 
-### 转录单集播客（推荐带 --polish 自动加标点）
+### 转录单集播客（可选 --polish 增强标点）
 
 ```bash
 # 输出 Markdown 文件到 /tmp/。--polish 让 Llama 3.3 70B 给文稿补中文标点+合理分段
 ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
 ```
 
-> Whisper 对中文标点支持较弱，**推荐默认使用 `--polish`**。润色调用 Groq 上免费的 Llama 3.3 70B，9 分钟播客只增加 ~7 秒处理时间。如果只想要原始（无标点）转录，去掉 `--polish` 即可。
+> 转写 prompt 已要求 Whisper 输出中文标点；若标点效果仍不理想，可加 `--polish` 用 Groq 上免费的 Llama 3.3 70B 补标点+合理分段（9 分钟播客约多 ~7 秒）。每次转写多一轮 LLM 调用，按需使用。
 
 ### 前置要求
 


### PR DESCRIPTION
## Summary

Whisper-large-v3 leaves Chinese transcripts almost punctuation-free, which makes the small-yu-zhou (小宇宙) podcast output very hard to read. This PR adds two improvements:

1. **Pass a Chinese-context `prompt` to every Whisper call** (initial + 429 retry). No extra round-trip, no extra cost. Biases Whisper itself to emit punctuation.
2. **New `--polish` flag** — after transcription, runs each chunk through Groq's free `llama-3.3-70b-versatile` with a strict "only add punctuation, do not change wording" prompt. Final markdown prefers polished output when present.

No new dependency (python3 + curl already required).

Stacked on / related to #290 (PR fixing the BSD `grep -oP` bug). This PR's changes are independent of those lines, so it can be merged in either order — but on macOS, #290 is required for this script to run at all.

## Why this matters

Original Whisper output for a 9-min Chinese podcast (one continuous run-on paragraph, very hard to skim):

> 五一前夜5A景区集体翻车背后本文来自微信公众号旅界作者Sildor西少授权虎秀APP发布五一前我注意到文旅部集中点名批评了一大批5A景区...

After `--polish`:

> 五一前夜，5A景区集体翻车背后。本文来自微信公众号旅界，作者Sildor西少授权虎秀APP发布。五一前，我注意到文旅部集中点名批评了一大批5A景区。在刚召开不久的第一季度例行新闻发布会上...

(Plus paragraph breaks every few sentences — see the test artifacts.)

## How --polish handles long audio

The script already chunks audio at 20 MB (~40 min) so each Whisper transcript stays small. Polish reuses the same chunk boundaries, so each polish call sends ≤ ~7K input tokens / ≤ ~7K output tokens — comfortably under Groq's 8192-token completion cap.

If a single polish call still hits `finish_reason == "length"` (very long, dense speech), the helper bisects the chunk and recurses up to depth 3, then concatenates. On any HTTP / network error it falls back to the raw transcript for that chunk, so polish failures never lose data.

## Test plan

- [x] `bash -n` syntax check
- [x] End-to-end on macOS 14, 9-min Chinese podcast (`https://www.xiaoyuzhoufm.com/episode/69f2d432bb3ffa11e59cc5b0`):
  - **Without `--polish`** (just the new Whisper prompt): 2757 字 (was 2561 字 before this PR — Whisper itself now emits more punctuation)
  - **With `--polish`**: 2768 字 with full punctuation + 8 reasonable paragraph breaks
  - Polish step adds ~7s to total runtime
- [x] Verified `--polish` falls back to raw transcript on simulated HTTP error (manually edited the helper to raise; final markdown still complete)
- [ ] Linux smoke (any maintainer): same `--polish` behavior expected — no platform-specific code

## Cost

Free. `llama-3.3-70b-versatile` on Groq has a free tier; a 9-min podcast consumes ~5K total tokens, comfortably inside daily TPD limits even for heavy users.

## CLI

```bash
# unchanged default behavior
~/.agent-reach/tools/xiaoyuzhou/transcribe.sh URL

# new: add punctuation + paragraph breaks
~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish URL [output.md]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)