### PR TITLE
chore(scripts): add Twitter/X live-fetch verification script

### DIFF
--- a/docs/plans/2026-06-05-001-chore-agent-reach-setup-plan.md
+++ b/docs/plans/2026-06-05-001-chore-agent-reach-setup-plan.md
@@ -1,0 +1,197 @@
+---
+title: "chore: Set up Agent-Reach with Twitter/X access on Windows"
+type: chore
+status: completed
+date: 2026-06-05
+---
+
+# chore: Set up Agent-Reach with Twitter/X access on Windows
+
+## Summary
+
+Install Agent-Reach into an isolated Python virtual environment on this Windows
+machine (pipx is absent, so a venv is the recommended path), run the auto
+installer to activate the zero-config core channels, install `twitter-cli`,
+configure Twitter/X cookie auth, and leave behind a reusable script that proves
+X/Twitter fetching actually works. Scope is **Twitter/X + core channels** —
+other platforms are deferred and can be added later with one command.
+
+---
+
+## Problem Frame
+
+The user has cloned `github.com/Panniantong/Agent-Reach` and wants their AI agent
+to have internet reach, with Twitter/X as the priority. Agent-Reach is an
+installer + doctor + config tool: after install, the agent calls upstream tools
+(`twitter`, `yt-dlp`, `gh`, Jina Reader, Exa via `mcporter`) directly. The
+machine has Python 3.11, uv, Node 22, npm, gh, git, and ffmpeg, but **no pipx**,
+so the package and `twitter-cli` need a venv. Raw `curl` is sandboxed in this
+tool environment (returns `000`) while `pip` reaches PyPI fine — so runtime
+network parity must be verified, not assumed.
+
+---
+
+## Requirements
+
+### Installation
+
+- R1. Agent-Reach CLI is installed and runnable from an isolated venv on Windows, without modifying system Python.
+- R2. The zero-config core channels are active: Web (Jina Reader), YouTube, GitHub, RSS, Exa search, V2EX, and Bilibili (basic).
+
+### Twitter/X
+
+- R3. `twitter-cli` is installed and the `twitter` command is discoverable on PATH for the agent's invocations.
+- R4. Twitter/X credentials (`auth_token`, `ct0`) are configured from a **dedicated/burner** account, stored locally only.
+- R5. `twitter status` reports authenticated (`ok: true`) and a real fetch (search or read a tweet) returns live data.
+
+### Verification & hygiene
+
+- R6. `agent-reach doctor` runs and its full output is reviewed with the user.
+- R7. A reusable verification script exists that the user or agent can run on demand to confirm X fetching works.
+- R8. No changes are made to Agent-Reach source code or the upstream repo's git history; credentials live only in `~/.agent-reach/config.yaml`.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Virtual environment, not pipx.** pipx is not installed; the user's stated preference is "pipx if available, otherwise a venv." uv is present but a plain `venv` keeps the setup simple and matches both `docs/install.md` (PEP 668 fallback) and `CLAUDE.md`'s `pip install -e .` convention.
+- KTD2. **venv lives outside the clone at `~/.agent-reach-venv`.** `.venv` is *not* in the repo's `.gitignore` (only `.agent-reach/`, `*.egg-info/`, `dist/`, `build/` are), so a repo-local venv would dirty the working tree. An external venv keeps `git status` clean and matches the doc's `~/.agent-reach-venv` convention.
+- KTD3. **Editable install (`pip install -e .`) from the local clone.** Matches `CLAUDE.md`'s dev convention and lets future `git pull`s take effect without reinstalling.
+- KTD4. **Install `twitter-cli` into the same venv via `pip`** (not `uv tool`/pipx). pipx is absent; a same-venv install puts `twitter.exe` in the venv `Scripts\` dir, so `shutil.which("twitter")` resolves it once that dir is on PATH — no reliance on a uv tools bin being on PATH. Pin observed at plan time: `twitter-cli 0.8.5`.
+- KTD5. **Prepend the venv `Scripts\` dir to `PATH` per command; don't rely on activation.** PowerShell activation doesn't persist across separate tool calls, so each invocation explicitly prepends `Scripts\` and sets `PYTHONUTF8=1` for clean emoji/Chinese CLI output.
+- KTD6. **Cookie auth via Cookie-Editor "Header String" (`auth_token` + `ct0`).** Per project rules (Cookie-Editor export only, never QR) and security guidance — use a dedicated account because cookie auth carries ban and credential-exposure risk.
+
+---
+
+## Implementation Units
+
+Setup steps, dependency-ordered. Commands are the deliverable for this runbook
+and are shown explicitly so they can be reviewed before execution. PowerShell is
+the primary shell; `$VENV = "$env:USERPROFILE\.agent-reach-venv"` and
+`$SCRIPTS = "$VENV\Scripts"` are assumed set.
+
+### U1. Create the Python virtual environment
+
+- Goal: An isolated interpreter at `~/.agent-reach-venv` with up-to-date pip.
+- Requirements: R1
+- Dependencies: none
+- Commands:
+  ```powershell
+  $env:PYTHONUTF8 = "1"
+  $VENV = "$env:USERPROFILE\.agent-reach-venv"
+  python -m venv $VENV
+  & "$VENV\Scripts\python.exe" -m pip install --upgrade pip
+  ```
+- Verification: `& "$VENV\Scripts\python.exe" --version` prints 3.11.x; `pip --version` points inside `$VENV`.
+
+### U2. Install Agent-Reach (editable) into the venv
+
+- Goal: `agent-reach` console script available in the venv from the local clone.
+- Requirements: R1
+- Dependencies: U1
+- Files: `C:\dev\Agent-Reach\pyproject.toml` (source of the install; not modified)
+- Commands:
+  ```powershell
+  & "$VENV\Scripts\python.exe" -m pip install -e C:\dev\Agent-Reach
+  ```
+- Verification: `& "$VENV\Scripts\agent-reach.exe" --version` prints `Agent Reach v1.4.0`.
+
+### U3. Run the auto installer
+
+- Goal: Activate zero-config core channels; install/configure mcporter + Exa, gh check, yt-dlp JS runtime; register SKILL.md.
+- Requirements: R2
+- Dependencies: U2
+- Approach: Run with the venv `Scripts\` prepended to PATH so `node`/`npm`/`gh` (already on PATH) and the venv tools are all visible. `--env=auto` will detect "local".
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"; $env:PYTHONUTF8 = "1"
+  agent-reach install --env=auto
+  ```
+- Notes: `mcporter` install (npm global) and Exa registration need network via Node; on a restricted network these may warn — non-blocking for the Twitter goal. No `--channels` passed, so no cookie auto-import is triggered at this step.
+- Verification: Installer prints "Installation complete! N/total channels active" and a report table; core channels (web, youtube, github, rss, v2ex) show ✅.
+
+### U4. Install twitter-cli into the venv
+
+- Goal: `twitter` command present and detectable.
+- Requirements: R3
+- Dependencies: U2
+- Commands:
+  ```powershell
+  & "$VENV\Scripts\python.exe" -m pip install twitter-cli
+  ```
+- Verification: `& "$SCRIPTS\twitter.exe" --help` runs; with `$env:PATH` prepended, `(Get-Command twitter).Source` resolves into `$SCRIPTS`.
+
+### U5. Run doctor and review full output
+
+- Goal: Capture the complete channel-status report and surface anything broken.
+- Requirements: R6
+- Dependencies: U3, U4
+- Commands:
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"; $env:PYTHONUTF8 = "1"
+  agent-reach doctor
+  ```
+- Expected: Twitter shows ⚠️ "installed but not authenticated" until U6 supplies cookies. Core channels green. Any ❌/⚠️ on mcporter/Exa/gh is noted and explained (likely network or auth), not necessarily fixed if outside the Twitter scope.
+- Verification: Full doctor output shown to the user.
+
+### U6. Configure Twitter/X cookies
+
+- Goal: Store `auth_token` + `ct0` and confirm twitter-cli authenticates.
+- Requirements: R4
+- Dependencies: U4
+- **User input required:** From a logged-in **dedicated/burner** X account, export cookies with the Cookie-Editor extension (icon → Export → **Header String**) and paste the string.
+- Commands (the agent runs, given the pasted string):
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"
+  agent-reach configure twitter-cookies "<pasted header string with auth_token=...; ct0=...>"
+  ```
+- Approach: `_cmd_configure` parses `auth_token`/`ct0` out of the header string, writes them to `~/.agent-reach/config.yaml`, sets `TWITTER_AUTH_TOKEN`/`TWITTER_CT0` for a probe subprocess, and runs `twitter status`.
+- Verification: Command prints "✅ Twitter cookies configured!" then "✅ Twitter access works!" (i.e. `twitter status` returned `ok: true`).
+
+### U7. Create and run the X/Twitter verification script
+
+- Goal: A reusable, self-contained script that proves live fetching, independent of the install session.
+- Requirements: R5, R7
+- Dependencies: U6
+- Files: `C:\dev\Agent-Reach\scripts\verify_twitter.ps1` (new, local-only helper)
+- Approach: The script reads `auth_token`/`ct0` from `~/.agent-reach/config.yaml`, exports them as `TWITTER_AUTH_TOKEN`/`TWITTER_CT0` (twitter-cli reads these directly — Agent-Reach is not a wrapper), puts the venv `Scripts\` on PATH, then runs `twitter status` followed by a real `twitter search` (and optionally `twitter tweet <URL>`), printing PASS/FAIL.
+- Test scenarios:
+  - Authenticated status: `twitter status` output contains `ok: true` → PASS.
+  - Live search: `twitter search "openai" -n 3` returns ≥1 tweet → PASS.
+  - Missing/invalid cookies: script reports a clear FAIL with the remediation hint (re-run U6) rather than a raw stack trace.
+  - Network blocked: a fetch error is surfaced as FAIL with a note to retry in the user's own shell via the `! <command>` prefix.
+- Verification: Running `powershell -File scripts\verify_twitter.ps1` prints PASS for status and search and shows sample tweet text.
+
+---
+
+## Risks & Dependencies
+
+- **Runtime network parity.** Raw `curl` is sandboxed here (`000`), though `pip` reaches PyPI. `twitter-cli` is Python and should have pip-level network access, but this is unverified until U7. If Python network is also restricted in this tool sandbox, doctor/twitter will warn — mitigation: have the user run the verification (or the raw `twitter` commands) in their own shell via the `! <command>` prefix.
+- **Cookie validity / account safety.** Cookies expire or get invalidated; scripted access risks account limits. Mitigation: dedicated burner account (KTD6); re-export via Cookie-Editor when `twitter status` stops returning `ok: true`.
+- **mcporter / Exa / gh need network too** (Node fetch / GitHub API). On a restricted network these channels may warn in doctor; non-blocking for the Twitter-focused goal.
+- **Upstream churn.** `twitter-cli` (pinned `0.8.5` at plan time) could change its cookie scheme or CLI surface; the doctor check keys on `twitter status` → `ok: true`.
+- **Blocking dependency:** U6 cannot complete without the user pasting cookies; R4/R5 are gated on it.
+
+---
+
+## Scope Boundaries
+
+### Deferred to follow-up (addable later, no rework)
+
+- Reddit, Weibo, WeChat, XiaoHongShu, Douyin, LinkedIn, Xueqiu, Xiaoyuzhou, full Bilibili — each addable via `agent-reach install --env=auto --channels=<name>` plus its own auth where needed.
+
+### Out of scope
+
+- Residential proxy setup (only needed for server IP blocks; this is a local machine).
+- OpenClaw daily-cron monitoring (`agent-reach watch`).
+- Any modification of Agent-Reach source or a PR to the upstream repo.
+
+---
+
+## Sources / Research
+
+- `docs/install.md` — install flow, channel names, `configure twitter-cookies` usage, Cookie-Editor method.
+- `docs/cookie-export.md` — Cookie-Editor "Header String" export steps for x.com.
+- `agent_reach/cli.py` — `_cmd_install` / `_detect_environment` (install + auto env detect), `_install_twitter_deps` (pipx/uv installer for `twitter-cli`), `_cmd_configure` + `_parse_twitter_cookie_input` (cookie parsing → `config.yaml` + `twitter status` probe).
+- `agent_reach/channels/twitter.py` — `check()` expects `twitter status` to print `ok: true`; reads `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`.
+- `agent_reach/config.py` — config at `~/.agent-reach/config.yaml`; `get()` also resolves the uppercase env-var form of a key.
+- Environment probe (this session): Python 3.11.9, uv 0.11.3, Node 22.13.1, npm 10.9.2, gh 2.87.0, ffmpeg 7.1.1 present; pipx absent; `twitter-cli` latest 0.8.5 on PyPI.

--- a/scripts/verify_twitter.ps1
+++ b/scripts/verify_twitter.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Verify that Agent-Reach's Twitter/X access actually works (live fetch).
+
+.DESCRIPTION
+    Self-contained check, independent of the install session. It:
+      1. Locates the Agent-Reach venv and the 'twitter' CLI.
+      2. Reads twitter_auth_token / twitter_ct0 from ~/.agent-reach/config.yaml
+         (via Agent-Reach's own Config loader, which also honours the uppercase
+         env-var form TWITTER_AUTH_TOKEN / TWITTER_CT0).
+      3. Exports those as TWITTER_AUTH_TOKEN / TWITTER_CT0 -- twitter-cli reads
+         them directly (Agent-Reach is a glue layer, not a wrapper).
+      4. Runs 'twitter status' (auth check) and a live 'twitter search',
+         printing PASS / FAIL for each.
+
+    Exit code: 0 if both checks PASS, 1 otherwise.
+    NOTE: ASCII-only on purpose -- Windows PowerShell 5.1 reads BOM-less UTF-8
+    scripts as ANSI, which mangles non-ASCII characters.
+
+.PARAMETER Query
+    Search term for the live-fetch check. Default: "openai".
+
+.PARAMETER Max
+    Max tweets to fetch for the search check. Default: 3.
+
+.PARAMETER Venv
+    Path to the Agent-Reach venv. Defaults to $env:AGENT_REACH_VENV, then
+    ~/.agent-reach-venv.
+
+.EXAMPLE
+    powershell -File scripts\verify_twitter.ps1
+    powershell -File scripts\verify_twitter.ps1 -Query "claude ai" -Max 5
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Query = "openai",
+    [int]$Max = 3,
+    [string]$Venv = $(if ($env:AGENT_REACH_VENV) { $env:AGENT_REACH_VENV } else { Join-Path $env:USERPROFILE ".agent-reach-venv" })
+)
+
+$env:PYTHONUTF8 = "1"
+try { [Console]::OutputEncoding = [Text.Encoding]::UTF8 } catch { }
+
+function Write-Status($ok, $label, $detail) {
+    $mark = if ($ok) { "PASS" } else { "FAIL" }
+    $color = if ($ok) { "Green" } else { "Red" }
+    Write-Host ("[{0}] {1}" -f $mark, $label) -ForegroundColor $color
+    if ($detail) { Write-Host "       $detail" -ForegroundColor DarkGray }
+}
+
+Write-Host "Agent-Reach -- Twitter/X verification" -ForegroundColor Cyan
+Write-Host ("=" * 40)
+
+# --- Locate venv python + twitter CLI ---------------------------------------
+$pythonExe  = Join-Path $Venv "Scripts\python.exe"
+$twitterExe = Join-Path $Venv "Scripts\twitter.exe"
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Status $false "venv" "Python not found at $pythonExe. Re-run the Agent-Reach install (U1/U2)."
+    exit 1
+}
+if (-not (Test-Path $twitterExe)) {
+    $resolved = (Get-Command twitter -ErrorAction SilentlyContinue).Source
+    if ($resolved) {
+        $twitterExe = $resolved
+    } else {
+        Write-Status $false "twitter-cli" "Not found. Install with: pip install twitter-cli (into the venv)."
+        exit 1
+    }
+}
+$env:PATH = (Join-Path $Venv "Scripts") + ";" + $env:PATH
+
+# --- Read cookies from Agent-Reach config -----------------------------------
+# Parse ~/.agent-reach/config.yaml directly. (Reading via `python -c` is fragile
+# on Windows PowerShell 5.1, which mangles embedded double quotes when passing
+# arguments to native executables.) These are the exact keys that
+# `agent-reach configure twitter-cookies` writes.
+$cfgPath = Join-Path $env:USERPROFILE ".agent-reach\config.yaml"
+$authToken = ""
+$ct0 = ""
+if (Test-Path $cfgPath) {
+    foreach ($line in (Get-Content -LiteralPath $cfgPath)) {
+        if ($line -match '^\s*twitter_auth_token\s*:\s*(.+?)\s*$') {
+            $authToken = $matches[1].Trim().Trim("'").Trim('"')
+        } elseif ($line -match '^\s*twitter_ct0\s*:\s*(.+?)\s*$') {
+            $ct0 = $matches[1].Trim().Trim("'").Trim('"')
+        }
+    }
+}
+# Fall back to twitter-cli's own env-var convention if not stored in the file.
+if (-not $authToken -and $env:TWITTER_AUTH_TOKEN) { $authToken = $env:TWITTER_AUTH_TOKEN }
+if (-not $ct0 -and $env:TWITTER_CT0) { $ct0 = $env:TWITTER_CT0 }
+
+if (-not $authToken -or -not $ct0) {
+    Write-Status $false "cookies" "No twitter_auth_token / twitter_ct0 in ~/.agent-reach/config.yaml."
+    Write-Host  '       Fix: agent-reach configure twitter-cookies "auth_token=...; ct0=..."' -ForegroundColor Yellow
+    Write-Host  "       Export the header string from a dedicated/burner X account via Cookie-Editor." -ForegroundColor Yellow
+    exit 1
+}
+$env:TWITTER_AUTH_TOKEN = $authToken
+$env:TWITTER_CT0        = $ct0
+$authPrev = $authToken.Substring(0, [Math]::Min(6, $authToken.Length))
+$ct0Prev  = $ct0.Substring(0, [Math]::Min(6, $ct0.Length))
+Write-Status $true "cookies" ("loaded auth_token={0}... ct0={1}..." -f $authPrev, $ct0Prev)
+
+$statusOk = $false
+$searchOk = $false
+
+# --- Check 1: authenticated session -----------------------------------------
+try {
+    $statusOut = (& $twitterExe status 2>&1 | Out-String)
+    if ($statusOut -match "ok:\s*true") {
+        $statusOk = $true
+        Write-Status $true "status" "twitter status -> ok: true"
+    } else {
+        Write-Status $false "status" ("twitter status did not report ok: true. Output:`n" + $statusOut.Trim())
+    }
+} catch {
+    Write-Status $false "status" ("twitter status errored: " + $_.Exception.Message)
+}
+
+# --- Check 2: live search fetch ---------------------------------------------
+if ($statusOk) {
+    try {
+        $searchRaw = (& $twitterExe search $Query -n $Max --json 2>&1 | Out-String)
+        $code = $LASTEXITCODE
+        $count = 0
+        $sample = $null
+
+        # Trim any leading log noise before the JSON payload.
+        $jsonStart = $searchRaw.IndexOfAny([char[]]@('[', '{'))
+        $jsonText = if ($jsonStart -ge 0) { $searchRaw.Substring($jsonStart) } else { $searchRaw }
+
+        try {
+            $parsed = $jsonText | ConvertFrom-Json
+            $items = if ($parsed -is [System.Array]) { $parsed }
+                     elseif ($parsed.tweets) { $parsed.tweets }
+                     elseif ($parsed.data)   { $parsed.data }
+                     elseif ($parsed.results) { $parsed.results }
+                     else { @($parsed) }
+            $count = @($items).Count
+            if ($count -gt 0) {
+                $first = @($items)[0]
+                $sample = $first.text
+                if (-not $sample) { $sample = $first.full_text }
+                if (-not $sample) { $sample = $first.content }
+            }
+        } catch {
+            # JSON did not parse -- fall back to exit code + non-empty output.
+            if ($code -eq 0 -and $searchRaw.Trim()) { $count = 1 }
+        }
+
+        if ($count -ge 1) {
+            $searchOk = $true
+            $preview = if ($sample) { ($sample -replace "\s+", " ").Trim() } else { "(no text field; raw output received)" }
+            if ($preview.Length -gt 160) { $preview = $preview.Substring(0, 160) + "..." }
+            Write-Status $true "search" ("'{0}' returned {1} tweet(s). Sample: {2}" -f $Query, $count, $preview)
+        } else {
+            Write-Status $false "search" ("'{0}' returned no tweets. Output:`n{1}" -f $Query, $searchRaw.Trim())
+        }
+    } catch {
+        Write-Status $false "search" ("search errored: " + $_.Exception.Message)
+    }
+} else {
+    Write-Status $false "search" "skipped (status check failed -- fix auth first)"
+}
+
+# --- Summary ----------------------------------------------------------------
+Write-Host ("=" * 40)
+if ($statusOk -and $searchOk) {
+    Write-Host "RESULT: PASS -- Twitter/X fetching works." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "RESULT: FAIL -- see messages above." -ForegroundColor Red
+    Write-Host "If this machine's sandbox blocks network, retry in your own shell:" -ForegroundColor Yellow
+    Write-Host "  ! powershell -File scripts\verify_twitter.ps1" -ForegroundColor Yellow
+    exit 1
+}


### PR DESCRIPTION
## Summary

Adds a standalone Twitter/X live-fetch verification helper so the installed `twitter-cli` + cookie configuration can be sanity-checked end-to-end.

- `scripts/verify_twitter.ps1` — loads cookies from `~/.agent-reach/config.yaml` (the same way `agent-reach configure` writes them), sets `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`, and runs a `twitter` command to confirm fetching works.
- `docs/plans/2026-06-05-001-chore-agent-reach-setup-plan.md` — the setup plan this implements.

## Scope / safety

- Read-only: no posting/liking/following; no Agent-Reach or upstream source modified (glue layer only).
- Credentials are read from local config and passed via env vars — never written anywhere.

## Test

- Verified the script loads config and shells out to `twitter` using the documented cookie-env pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
