### PR TITLE
feat(scripts): add X Board — local HTML viewer for fetched X posts

### DIFF
--- a/docs/brainstorms/2026-06-05-x-board-requirements.md
+++ b/docs/brainstorms/2026-06-05-x-board-requirements.md
@@ -1,0 +1,101 @@
+---
+title: "X Board — a simple local frontend to view fetched X posts"
+type: requirements
+status: ready-for-planning
+date: 2026-06-05
+---
+
+# X Board — a simple local frontend to view fetched X posts
+
+## Problem / Context
+
+Agent-Reach's Twitter/X access is now installed and verified, but the only proof
+is CLI output (`scripts/verify_twitter.ps1`, raw `twitter` commands). The user
+wants a **visual** way to (a) confirm fetching is genuinely working and (b) read
+recent posts from a small, hand-picked set of people — in one glance.
+
+Agent-Reach today is a CLI + library + MCP "glue layer" with **no frontend**.
+The fetch path is 100% Python (`twitter-cli` → `curl-cffi` → x.com's own API →
+JSON); no LLM is involved in fetching. This feature is a thin **view** over that
+same Python-fetched data — it must not reimplement fetching or add an LLM.
+
+## Goal
+
+A small, standalone **"X Board"**: one command reads a follow-list, fetches each
+person's recent original posts via the existing `twitter-cli`, and writes a
+self-contained HTML page (auto-opened in the browser) that both **displays the
+posts** and **proves the fetch worked**. Re-running the command refreshes it.
+
+## Users
+
+- **Primary (only):** the repo owner, running locally on their own machine. Single-user, local-only. No auth, no hosting, no sharing in v1.
+
+## Success Criteria
+
+- Running one command produces an HTML page showing recent original posts for every handle in the follow-list, opened in the default browser.
+- The page makes it unambiguous that real data was fetched: a per-account "N posts fetched" badge and a top-level status line (overall OK + account count + timestamp).
+- If a handle fails (suspended / rate-limited / network / bad handle), that is visible per-account as an error card — the rest of the page still renders.
+- No new credentials, no LLM calls, no long-running server. Uses the cookies already stored in `~/.agent-reach/config.yaml`.
+
+## Requirements
+
+### Follow-list
+- **R1.** The set of people is read from a plain-text file the user edits — one `@handle` per line (leading `@` optional). Blank lines and `#` comments ignored.
+- **R2.** Default file location is `~/.agent-reach/follow.txt`, overridable (e.g. a `--file` argument). If the file is missing, the tool prints a clear message and how to create it (with a sample line), and exits non-zero.
+
+### Fetch
+- **R3.** For each handle, fetch that person's recent **original** posts — excluding pure replies and reposts. Default ~10 per person, configurable (e.g. `-n`).
+- **R4.** Fetching goes through the existing `twitter-cli` (e.g. `user-posts`/equivalent with `--json`); cookies are loaded from `~/.agent-reach/config.yaml` and passed via the `TWITTER_AUTH_TOKEN` / `TWITTER_CT0` env vars, mirroring `scripts/verify_twitter.ps1`. No direct HTTP/scraping is written here.
+- **R5.** Reply/repost exclusion is applied client-side from the returned JSON if the CLI does not filter it, so behavior is consistent regardless of CLI flags.
+- **R6.** A per-handle failure (suspended, rate-limited, network error, unknown handle, empty result) is captured and surfaced for that account without aborting the whole run.
+
+### Output / view
+- **R7.** The tool writes a single self-contained HTML file (inline CSS, no external assets/CDN) and opens it in the default browser. Default output path `~/.agent-reach/x-board.html`, overridable.
+- **R8.** Layout is **grouped by account**: one section per handle, each with a header showing the handle, display name if available, and a "N posts fetched" badge. Posts show text, relative time/date, and like/repost counts; a permalink to the post on x.com when available.
+- **R9.** A top status bar shows overall result (✅ all OK / ⚠️ partial — M of N accounts), the account count, and the fetch timestamp.
+- **R10.** The page degrades gracefully: accounts with errors render an error card with the reason and a hint (e.g. "cookies may be stale — re-run `configure twitter-cookies`").
+
+### Delivery / non-functional
+- **R11.** Ships as a standalone script `scripts/x_board.py`, runnable via the Agent-Reach venv on any OS. No new runtime dependencies beyond what the venv already has (`twitter-cli`, plus stdlib for HTML; `rich` optional for console progress).
+- **R12.** Read-only and side-effect-free except for writing the HTML output file. No posting/liking/following; no database; no telemetry; no network beyond `twitter-cli`'s own calls.
+- **R13.** Does not modify Agent-Reach or upstream source; lives only under `scripts/`. Credentials are never written to the output file (no tokens embedded in the HTML).
+
+## Key Decisions
+
+- **Static HTML report over a live web app or TUI.** Smallest form that delivers both "proof" and "reader" value; no server process, near-zero carrying cost. Re-running the command is an acceptable "refresh." (Live web app + Refresh button deferred.)
+- **Editable follow-file over auto-pulling the account's real X following list.** Matches "give it a few people to follow," keeps the user in control, avoids large/noisy lists and an extra fetch. (Auto-pull deferred.)
+- **Original posts only (no replies/reposts).** Cleanest to read; article-announcement posts still appear as normal posts. (Reposts/replies deferred.)
+- **Grouped-by-account layout.** The per-account "N posts fetched" badge is the proof signal; also reads naturally. (Merged chronological feed deferred.)
+- **Files live under `~/.agent-reach/`, not the repo.** Keeps the git clone clean (consistent with how cookies/config are already stored).
+- **Reuse `twitter-cli`, mirror the `verify_twitter.ps1` cookie-loading pattern.** Stays a glue layer; no reimplementation of fetching; no LLM.
+
+## Scope Boundaries
+
+### In scope (v1)
+- Read follow-file → fetch original posts per handle → render grouped HTML with proof badges + status bar → open in browser, with per-account error handling.
+
+### Deferred (easy to add later, no rework)
+- Live local web app with a Refresh button; merged chronological feed; image/video/media thumbnails; auto-refresh or scheduled runs; in-page search/filter; including reposts & replies; pulling the account's real following list; per-person "articles" beyond what appears in the timeline.
+
+### Out of scope
+- Any write actions (post / like / follow / bookmark) — strictly read-only.
+- Persisting a post-history database or caching across runs.
+- Multi-user, hosting, or remote/shared access.
+- Re-implementing X fetching or adding any LLM/AI step to the fetch or render.
+
+## Assumptions / Dependencies
+
+- Twitter/X is already configured and working (`twitter status` → `ok: true`); cookies in `~/.agent-reach/config.yaml`. If cookies are stale, accounts will error and the page will say so.
+- `twitter-cli` can list a user's posts as JSON; exact subcommand/flags and the JSON shape are an **implementation-time detail for `/ce-plan`** (confirm `user-posts` flags and fields). If reply/repost filtering isn't available as a flag, filter client-side (R5).
+- Network access from this machine works for `twitter-cli` (already verified for search).
+
+## Open Questions (non-blocking — sensible default chosen)
+
+- Exact relative-time formatting and whether to show avatars (avatars need image URLs from the JSON; default: text-only, no remote images, to keep the page self-contained). Resolve during planning.
+
+## Handoff
+
+Ready for `/ce-plan` (or `/ce-work` for a direct build). Suggested first
+implementation reference: `scripts/verify_twitter.ps1` (cookie loading + venv
+PATH + `twitter-cli` invocation pattern), `agent_reach/config.py` (config keys),
+`agent_reach/channels/twitter.py` (how Agent-Reach shells out to `twitter`).

--- a/docs/plans/2026-06-05-001-chore-agent-reach-setup-plan.md
+++ b/docs/plans/2026-06-05-001-chore-agent-reach-setup-plan.md
@@ -1,0 +1,197 @@
+---
+title: "chore: Set up Agent-Reach with Twitter/X access on Windows"
+type: chore
+status: completed
+date: 2026-06-05
+---
+
+# chore: Set up Agent-Reach with Twitter/X access on Windows
+
+## Summary
+
+Install Agent-Reach into an isolated Python virtual environment on this Windows
+machine (pipx is absent, so a venv is the recommended path), run the auto
+installer to activate the zero-config core channels, install `twitter-cli`,
+configure Twitter/X cookie auth, and leave behind a reusable script that proves
+X/Twitter fetching actually works. Scope is **Twitter/X + core channels** —
+other platforms are deferred and can be added later with one command.
+
+---
+
+## Problem Frame
+
+The user has cloned `github.com/Panniantong/Agent-Reach` and wants their AI agent
+to have internet reach, with Twitter/X as the priority. Agent-Reach is an
+installer + doctor + config tool: after install, the agent calls upstream tools
+(`twitter`, `yt-dlp`, `gh`, Jina Reader, Exa via `mcporter`) directly. The
+machine has Python 3.11, uv, Node 22, npm, gh, git, and ffmpeg, but **no pipx**,
+so the package and `twitter-cli` need a venv. Raw `curl` is sandboxed in this
+tool environment (returns `000`) while `pip` reaches PyPI fine — so runtime
+network parity must be verified, not assumed.
+
+---
+
+## Requirements
+
+### Installation
+
+- R1. Agent-Reach CLI is installed and runnable from an isolated venv on Windows, without modifying system Python.
+- R2. The zero-config core channels are active: Web (Jina Reader), YouTube, GitHub, RSS, Exa search, V2EX, and Bilibili (basic).
+
+### Twitter/X
+
+- R3. `twitter-cli` is installed and the `twitter` command is discoverable on PATH for the agent's invocations.
+- R4. Twitter/X credentials (`auth_token`, `ct0`) are configured from a **dedicated/burner** account, stored locally only.
+- R5. `twitter status` reports authenticated (`ok: true`) and a real fetch (search or read a tweet) returns live data.
+
+### Verification & hygiene
+
+- R6. `agent-reach doctor` runs and its full output is reviewed with the user.
+- R7. A reusable verification script exists that the user or agent can run on demand to confirm X fetching works.
+- R8. No changes are made to Agent-Reach source code or the upstream repo's git history; credentials live only in `~/.agent-reach/config.yaml`.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Virtual environment, not pipx.** pipx is not installed; the user's stated preference is "pipx if available, otherwise a venv." uv is present but a plain `venv` keeps the setup simple and matches both `docs/install.md` (PEP 668 fallback) and `CLAUDE.md`'s `pip install -e .` convention.
+- KTD2. **venv lives outside the clone at `~/.agent-reach-venv`.** `.venv` is *not* in the repo's `.gitignore` (only `.agent-reach/`, `*.egg-info/`, `dist/`, `build/` are), so a repo-local venv would dirty the working tree. An external venv keeps `git status` clean and matches the doc's `~/.agent-reach-venv` convention.
+- KTD3. **Editable install (`pip install -e .`) from the local clone.** Matches `CLAUDE.md`'s dev convention and lets future `git pull`s take effect without reinstalling.
+- KTD4. **Install `twitter-cli` into the same venv via `pip`** (not `uv tool`/pipx). pipx is absent; a same-venv install puts `twitter.exe` in the venv `Scripts\` dir, so `shutil.which("twitter")` resolves it once that dir is on PATH — no reliance on a uv tools bin being on PATH. Pin observed at plan time: `twitter-cli 0.8.5`.
+- KTD5. **Prepend the venv `Scripts\` dir to `PATH` per command; don't rely on activation.** PowerShell activation doesn't persist across separate tool calls, so each invocation explicitly prepends `Scripts\` and sets `PYTHONUTF8=1` for clean emoji/Chinese CLI output.
+- KTD6. **Cookie auth via Cookie-Editor "Header String" (`auth_token` + `ct0`).** Per project rules (Cookie-Editor export only, never QR) and security guidance — use a dedicated account because cookie auth carries ban and credential-exposure risk.
+
+---
+
+## Implementation Units
+
+Setup steps, dependency-ordered. Commands are the deliverable for this runbook
+and are shown explicitly so they can be reviewed before execution. PowerShell is
+the primary shell; `$VENV = "$env:USERPROFILE\.agent-reach-venv"` and
+`$SCRIPTS = "$VENV\Scripts"` are assumed set.
+
+### U1. Create the Python virtual environment
+
+- Goal: An isolated interpreter at `~/.agent-reach-venv` with up-to-date pip.
+- Requirements: R1
+- Dependencies: none
+- Commands:
+  ```powershell
+  $env:PYTHONUTF8 = "1"
+  $VENV = "$env:USERPROFILE\.agent-reach-venv"
+  python -m venv $VENV
+  & "$VENV\Scripts\python.exe" -m pip install --upgrade pip
+  ```
+- Verification: `& "$VENV\Scripts\python.exe" --version` prints 3.11.x; `pip --version` points inside `$VENV`.
+
+### U2. Install Agent-Reach (editable) into the venv
+
+- Goal: `agent-reach` console script available in the venv from the local clone.
+- Requirements: R1
+- Dependencies: U1
+- Files: `C:\dev\Agent-Reach\pyproject.toml` (source of the install; not modified)
+- Commands:
+  ```powershell
+  & "$VENV\Scripts\python.exe" -m pip install -e C:\dev\Agent-Reach
+  ```
+- Verification: `& "$VENV\Scripts\agent-reach.exe" --version` prints `Agent Reach v1.4.0`.
+
+### U3. Run the auto installer
+
+- Goal: Activate zero-config core channels; install/configure mcporter + Exa, gh check, yt-dlp JS runtime; register SKILL.md.
+- Requirements: R2
+- Dependencies: U2
+- Approach: Run with the venv `Scripts\` prepended to PATH so `node`/`npm`/`gh` (already on PATH) and the venv tools are all visible. `--env=auto` will detect "local".
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"; $env:PYTHONUTF8 = "1"
+  agent-reach install --env=auto
+  ```
+- Notes: `mcporter` install (npm global) and Exa registration need network via Node; on a restricted network these may warn — non-blocking for the Twitter goal. No `--channels` passed, so no cookie auto-import is triggered at this step.
+- Verification: Installer prints "Installation complete! N/total channels active" and a report table; core channels (web, youtube, github, rss, v2ex) show ✅.
+
+### U4. Install twitter-cli into the venv
+
+- Goal: `twitter` command present and detectable.
+- Requirements: R3
+- Dependencies: U2
+- Commands:
+  ```powershell
+  & "$VENV\Scripts\python.exe" -m pip install twitter-cli
+  ```
+- Verification: `& "$SCRIPTS\twitter.exe" --help` runs; with `$env:PATH` prepended, `(Get-Command twitter).Source` resolves into `$SCRIPTS`.
+
+### U5. Run doctor and review full output
+
+- Goal: Capture the complete channel-status report and surface anything broken.
+- Requirements: R6
+- Dependencies: U3, U4
+- Commands:
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"; $env:PYTHONUTF8 = "1"
+  agent-reach doctor
+  ```
+- Expected: Twitter shows ⚠️ "installed but not authenticated" until U6 supplies cookies. Core channels green. Any ❌/⚠️ on mcporter/Exa/gh is noted and explained (likely network or auth), not necessarily fixed if outside the Twitter scope.
+- Verification: Full doctor output shown to the user.
+
+### U6. Configure Twitter/X cookies
+
+- Goal: Store `auth_token` + `ct0` and confirm twitter-cli authenticates.
+- Requirements: R4
+- Dependencies: U4
+- **User input required:** From a logged-in **dedicated/burner** X account, export cookies with the Cookie-Editor extension (icon → Export → **Header String**) and paste the string.
+- Commands (the agent runs, given the pasted string):
+  ```powershell
+  $env:PATH = "$SCRIPTS;$env:PATH"
+  agent-reach configure twitter-cookies "<pasted header string with auth_token=...; ct0=...>"
+  ```
+- Approach: `_cmd_configure` parses `auth_token`/`ct0` out of the header string, writes them to `~/.agent-reach/config.yaml`, sets `TWITTER_AUTH_TOKEN`/`TWITTER_CT0` for a probe subprocess, and runs `twitter status`.
+- Verification: Command prints "✅ Twitter cookies configured!" then "✅ Twitter access works!" (i.e. `twitter status` returned `ok: true`).
+
+### U7. Create and run the X/Twitter verification script
+
+- Goal: A reusable, self-contained script that proves live fetching, independent of the install session.
+- Requirements: R5, R7
+- Dependencies: U6
+- Files: `C:\dev\Agent-Reach\scripts\verify_twitter.ps1` (new, local-only helper)
+- Approach: The script reads `auth_token`/`ct0` from `~/.agent-reach/config.yaml`, exports them as `TWITTER_AUTH_TOKEN`/`TWITTER_CT0` (twitter-cli reads these directly — Agent-Reach is not a wrapper), puts the venv `Scripts\` on PATH, then runs `twitter status` followed by a real `twitter search` (and optionally `twitter tweet <URL>`), printing PASS/FAIL.
+- Test scenarios:
+  - Authenticated status: `twitter status` output contains `ok: true` → PASS.
+  - Live search: `twitter search "openai" -n 3` returns ≥1 tweet → PASS.
+  - Missing/invalid cookies: script reports a clear FAIL with the remediation hint (re-run U6) rather than a raw stack trace.
+  - Network blocked: a fetch error is surfaced as FAIL with a note to retry in the user's own shell via the `! <command>` prefix.
+- Verification: Running `powershell -File scripts\verify_twitter.ps1` prints PASS for status and search and shows sample tweet text.
+
+---
+
+## Risks & Dependencies
+
+- **Runtime network parity.** Raw `curl` is sandboxed here (`000`), though `pip` reaches PyPI. `twitter-cli` is Python and should have pip-level network access, but this is unverified until U7. If Python network is also restricted in this tool sandbox, doctor/twitter will warn — mitigation: have the user run the verification (or the raw `twitter` commands) in their own shell via the `! <command>` prefix.
+- **Cookie validity / account safety.** Cookies expire or get invalidated; scripted access risks account limits. Mitigation: dedicated burner account (KTD6); re-export via Cookie-Editor when `twitter status` stops returning `ok: true`.
+- **mcporter / Exa / gh need network too** (Node fetch / GitHub API). On a restricted network these channels may warn in doctor; non-blocking for the Twitter-focused goal.
+- **Upstream churn.** `twitter-cli` (pinned `0.8.5` at plan time) could change its cookie scheme or CLI surface; the doctor check keys on `twitter status` → `ok: true`.
+- **Blocking dependency:** U6 cannot complete without the user pasting cookies; R4/R5 are gated on it.
+
+---
+
+## Scope Boundaries
+
+### Deferred to follow-up (addable later, no rework)
+
+- Reddit, Weibo, WeChat, XiaoHongShu, Douyin, LinkedIn, Xueqiu, Xiaoyuzhou, full Bilibili — each addable via `agent-reach install --env=auto --channels=<name>` plus its own auth where needed.
+
+### Out of scope
+
+- Residential proxy setup (only needed for server IP blocks; this is a local machine).
+- OpenClaw daily-cron monitoring (`agent-reach watch`).
+- Any modification of Agent-Reach source or a PR to the upstream repo.
+
+---
+
+## Sources / Research
+
+- `docs/install.md` — install flow, channel names, `configure twitter-cookies` usage, Cookie-Editor method.
+- `docs/cookie-export.md` — Cookie-Editor "Header String" export steps for x.com.
+- `agent_reach/cli.py` — `_cmd_install` / `_detect_environment` (install + auto env detect), `_install_twitter_deps` (pipx/uv installer for `twitter-cli`), `_cmd_configure` + `_parse_twitter_cookie_input` (cookie parsing → `config.yaml` + `twitter status` probe).
+- `agent_reach/channels/twitter.py` — `check()` expects `twitter status` to print `ok: true`; reads `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`.
+- `agent_reach/config.py` — config at `~/.agent-reach/config.yaml`; `get()` also resolves the uppercase env-var form of a key.
+- Environment probe (this session): Python 3.11.9, uv 0.11.3, Node 22.13.1, npm 10.9.2, gh 2.87.0, ffmpeg 7.1.1 present; pipx absent; `twitter-cli` latest 0.8.5 on PyPI.

--- a/docs/plans/2026-06-05-002-feat-x-board-html-viewer-plan.md
+++ b/docs/plans/2026-06-05-002-feat-x-board-html-viewer-plan.md
@@ -1,0 +1,215 @@
+---
+title: "feat: X Board — local HTML viewer for fetched X posts"
+type: feat
+status: completed
+date: 2026-06-05
+origin: docs/brainstorms/2026-06-05-x-board-requirements.md
+---
+
+# feat: X Board — local HTML viewer for fetched X posts
+
+## Summary
+
+Build `scripts/x_board.py`: a standalone, read-only helper that reads a
+user-edited follow-list, fetches each person's recent **original** posts through
+the already-installed `twitter-cli`, and writes a self-contained, grouped-by-
+account HTML page (auto-opened in the browser) with per-account "N posts fetched"
+proof badges and a status bar. Pure Python, no LLM, no new runtime dependencies,
+and **no changes to `agent_reach/` source** — it stays a glue-layer helper that
+shells out to `twitter`, mirroring the cookie-loading pattern already proven in
+`scripts/verify_twitter.ps1`.
+
+---
+
+## Problem Frame
+
+Twitter/X access is installed and verified, but the only proof is CLI output. The
+user wants a **visual** dashboard that (a) confirms fetching genuinely works and
+(b) reads recent posts from a small, hand-picked set of people — in one glance.
+Agent-Reach has no frontend today; the fetch path is 100% Python
+(`twitter-cli` → `curl-cffi` → x.com API → JSON). This feature is a thin **view**
+over that same Python-fetched data; it must not reimplement fetching or introduce
+an LLM (see origin: `docs/brainstorms/2026-06-05-x-board-requirements.md`).
+
+---
+
+## Requirements
+
+Traced to the origin requirements doc (R1–R13).
+
+- **R1/R2 — Follow-list:** read handles from a user-edited text file (one `@handle` per line; `@` optional; blank lines and `#` comments ignored). Default `~/.agent-reach/follow.txt`, overridable; missing file → clear message + non-zero exit.
+- **R3 — Count:** ~10 recent posts per person, configurable.
+- **R4 — Fetch via twitter-cli:** cookies loaded from `~/.agent-reach/config.yaml`, passed via `TWITTER_AUTH_TOKEN` / `TWITTER_CT0` env vars; no direct HTTP/scraping.
+- **R5 — Original-posts filter:** exclude replies and reposts; applied client-side from JSON (no CLI flag exists — confirmed).
+- **R6 — Per-handle resilience:** a failing handle (suspended / rate-limited / network / unknown / empty) surfaces per-account without aborting the run.
+- **R7 — Output:** one self-contained HTML file (inline CSS, no external assets), opened in the default browser; default `~/.agent-reach/x-board.html`, overridable.
+- **R8 — Layout:** grouped by account; header shows handle + display name + "N posts fetched" badge; posts show text, relative time, like/repost counts, permalink.
+- **R9 — Status bar:** overall result (✅ all OK / ⚠️ partial M of N), account count, fetch timestamp.
+- **R10 — Graceful degradation:** error accounts render an error card with reason + remediation hint.
+- **R11 — Delivery:** standalone `scripts/x_board.py`, runnable via the venv on any OS; no new runtime deps beyond what the venv has.
+- **R12 — Read-only:** no write actions, no DB, no telemetry; only side effect is writing the HTML file.
+- **R13 — No source/credential leakage:** lives only under `scripts/`; no tokens embedded in output HTML.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1. Standalone Python script with importable pure functions behind a thin CLI.** Keeps it a glue-layer helper (honors "never modify Agent-Reach/upstream source"), is cross-platform (unlike the PowerShell verify script), and makes the parse/filter/render logic unit-testable.
+- **KTD2. Load cookies by importing `agent_reach.config.Config` directly.** The script runs under the venv where `agent_reach` is installed, so `Config().get("twitter_auth_token")` reads exactly what `configure` wrote and also resolves the uppercase env-var fallback for free — avoiding the brittle YAML/quoting issues that bit the PowerShell script. (See origin assumption; pattern in `agent_reach/config.py`.)
+- **KTD3. Fetch through `twitter-cli` subprocess, one call per handle.** `twitter user-posts <handle> -n <N> --json` (flags confirmed). Display name is read from the author object embedded in that same response — no separate `twitter user` call, halving requests and rate-limit exposure.
+- **KTD4. Client-side original-posts filter.** `user-posts` has no exclude flag, so drop replies (reply markers present) and reposts (`retweeted_status` present / `RT @` prefix) from the JSON. Fetch a buffer (> N) before filtering, then trim to N.
+- **KTD5. Zero new dependencies — stdlib only for rendering.** `html.escape` + string templating for HTML, `webbrowser` to open, `argparse`, `pathlib`, `subprocess`, `json`. `rich` (already installed) optional for console progress only.
+- **KTD6. Files live under `~/.agent-reach/`.** Follow-list and output HTML default outside the repo so the git clone stays clean, consistent with where cookies/config already live.
+- **KTD7. Exit codes encode the proof.** `0` all accounts OK, `1` partial (some errors — page still written/opened), `2` setup error (no cookies / no follow file). Makes the board both human-glanceable and scriptable.
+
+---
+
+## High-Level Technical Design
+
+Linear fetch-render pipeline; per-handle errors branch into the same render step
+as error cards rather than aborting.
+
+```mermaid
+flowchart TD
+    A["follow.txt"] --> B["parse_follow_list()"]
+    C["~/.agent-reach/config.yaml"] --> D["load_cookies() -> env"]
+    B --> E{"for each handle"}
+    D --> E
+    E --> F["twitter user-posts --json (subprocess)"]
+    F --> G["filter_original_posts() + normalize_post()"]
+    F -. "error / timeout / empty" .-> H["AccountResult(error=...)"]
+    G --> I["AccountResult(posts=[...])"]
+    H --> J["render_html()"]
+    I --> J
+    J --> K["~/.agent-reach/x-board.html"]
+    K --> L["webbrowser.open()"]
+```
+
+---
+
+## Implementation Units
+
+### U1. Input layer — cookie loading + follow-list parsing
+
+- **Goal:** Load Twitter cookies from config and parse the follow-list file into a clean, ordered, de-duplicated list of handles.
+- **Requirements:** R1, R2, R4 (cookie-load portion)
+- **Dependencies:** none
+- **Files:** `scripts/x_board.py` (new), `tests/test_x_board.py` (new)
+- **Approach:**
+  - `load_cookies()` → uses `agent_reach.config.Config` to return `(auth_token, ct0)`; raises a clear `XBoardError` with a `configure twitter-cookies` hint when either is absent (Config already falls back to `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`).
+  - `parse_follow_list(path)` → reads the file; trims whitespace; skips blank lines and `#` comments; strips a leading `@`; de-dupes preserving first-seen order. Missing file raises `XBoardError` naming the path and pointing to `scripts/follow.sample.txt`.
+- **Patterns to follow:** `agent_reach/config.py` (`Config.get`, keys `twitter_auth_token` / `twitter_ct0`); cookie-loading concept from `scripts/verify_twitter.ps1`.
+- **Test scenarios:**
+  - `parse_follow_list`: strips `@`; ignores blanks and `#` comments; de-dupes (order preserved); trims surrounding whitespace; preserves case. Empty file → `[]`.
+  - `parse_follow_list` missing file → raises `XBoardError` whose message names the path and the sample file.
+  - `load_cookies`: returns the pair when set in config; resolves from env-var fallback; raises `XBoardError` with remediation when neither is present.
+- **Verification:** Given a sample follow-file, `parse_follow_list` returns the expected ordered handles; `load_cookies` returns the configured token pair or a clear error.
+
+### U2. Fetch layer — per-handle twitter-cli call, normalize, filter, error capture
+
+- **Goal:** For each handle, fetch posts via `twitter-cli`, parse JSON, filter to original posts, normalize to a small post model, and capture per-handle failures without aborting.
+- **Requirements:** R3, R4, R5, R6
+- **Dependencies:** U1
+- **Files:** `scripts/x_board.py`, `tests/test_x_board.py`
+- **Execution note:** `filter_original_posts` and `normalize_post` are pure and well-specified — write their tests first.
+- **Approach:**
+  - `fetch_handle(handle, count, env, timeout)` → runs `twitter user-posts <handle> -n <buffer> --json` via `subprocess.run` with `env` carrying the cookie vars; trims any leading non-JSON noise before `json.loads`. Non-zero exit / timeout / parse failure / empty result → returns `AccountResult` with `error` set (human reason), never raises out.
+  - `filter_original_posts(items)` → drops replies (reply markers such as `in_reply_to_status_id_str` / `in_reply_to_screen_name`) and reposts (`retweeted_status` present or `RT @` prefix). Exact field names confirmed at implementation time from one sample `--json` response (directional list above).
+  - `normalize_post(item, handle)` → extracts text (`full_text` else `text`), `created_at`, like count (`favorite_count`), repost count (`retweet_count`), permalink `https://x.com/<handle>/status/<id_str>`; tolerant of missing fields (counts default 0).
+  - `extract_display_name(items, handle)` → reads the embedded author/user object if present, else falls back to `@handle`.
+  - Returns `AccountResult(handle, display_name, posts, error, fetched_count)`; buffer-fetch (> count) then trim to `count` after filtering.
+- **Patterns to follow:** `agent_reach/channels/twitter.py` (subprocess invocation of `twitter`, reading stdout, env handling); `scripts/verify_twitter.ps1` (env passing + leading-noise-trim before JSON parse).
+- **Test scenarios:**
+  - `filter_original_posts`: drops replies; drops reposts (`retweeted_status` and `RT @`); keeps originals; empty input → empty.
+  - `normalize_post`: maps fields; builds correct permalink; prefers `full_text` over `text`; missing like/repost counts default to 0.
+  - `fetch_handle` (mocked subprocess): success → normalized original posts trimmed to count; non-zero exit → `error` set; timeout → `error`; invalid JSON → `error`; empty list → flagged; asserts cookie env vars were passed. (Covers R6.)
+- **Verification:** With a mocked `twitter-cli`, `fetch_handle` returns normalized original posts trimmed to count; every failure mode surfaces as `AccountResult.error` and never propagates as an exception.
+
+### U3. Render layer — self-contained HTML
+
+- **Goal:** Render `AccountResult`s into one self-contained HTML page: status bar, per-account sections with proof badges and post cards, error cards. Everything HTML-escaped; no external assets; no credentials in output.
+- **Requirements:** R7 (HTML structure), R8, R9, R10, R13
+- **Dependencies:** U2 (consumes the `AccountResult` model)
+- **Files:** `scripts/x_board.py`, `tests/test_x_board.py`
+- **Approach:**
+  - `render_html(results, generated_at)` → returns a complete HTML document string with an inline `<style>`. Top status bar: overall ✅/⚠️ (partial when any account errored), `M ok / N total`, timestamp. One `<section>` per account: header (display name, `@handle`, "N posts fetched" badge or error label); each post: escaped text (line breaks preserved), relative time with absolute date as `title`, like/repost counts, permalink (`target=_blank rel=noopener`). Error accounts: error card with reason + hint ("cookies may be stale — re-run `agent-reach configure twitter-cookies`").
+  - `format_relative_time(created_at, now)` → `"2h"`, `"5h"`, `"3d"`; falls back to an absolute date for old/unparseable values. Pure.
+  - All dynamic values pass through `html.escape`; cookie/token values are never interpolated into output (R13).
+  - Self-contained: inline CSS only; no CDN, web fonts, or remote images (text-only, no avatars by default — see Open Questions).
+- **Patterns to follow:** stdlib `html.escape`; minimal, legible inline styling.
+- **Test scenarios:**
+  - `render_html`: output is one string containing the status bar, one section per account, the "N posts fetched" badge with the correct count, and post text. (Covers R8, R9.)
+  - `render_html` escaping: a post containing `<script>` / `&` / quotes is escaped; a malicious handle/display name is escaped. (Covers R13.)
+  - `render_html` partial failure: an errored account renders an error card with reason + remediation hint, and the status bar shows ⚠️ `M of N`. (Covers R10.)
+  - `render_html` credential safety: given a context that includes token values, no `auth_token`/`ct0` value appears anywhere in the output. (Covers R13.)
+  - `format_relative_time`: minute/hour/day boundaries; very old → absolute date; missing/unparseable `created_at` → graceful fallback.
+- **Verification:** Given fixture `AccountResult`s (mix of success + error), `render_html` returns valid self-contained HTML with badges, escaped content, and a partial-status bar; opening the file shows the board.
+
+### U4. CLI orchestration + packaging
+
+- **Goal:** Wire the layers behind a CLI: parse args, run the pipeline, write the HTML, open it in the browser, set exit codes; ship a sample follow-list.
+- **Requirements:** R7 (write + open + default paths), R11, R12, plus the end-to-end success criteria
+- **Dependencies:** U1, U2, U3
+- **Files:** `scripts/x_board.py`, `scripts/follow.sample.txt` (new), `tests/test_x_board.py`
+- **Approach:**
+  - `main(argv)` with `argparse`: `--file` (default `~/.agent-reach/follow.txt`), `-n/--count` (default 10), `--out` (default `~/.agent-reach/x-board.html`), `--no-open` (default: open).
+  - Flow: `load_cookies()` (missing → exit 2 with configure hint) → `parse_follow_list()` (missing file → exit 2, point to `scripts/follow.sample.txt`) → build env → fetch each handle sequentially (print simple per-handle progress) → `render_html()` → write to `--out` (UTF-8) → `webbrowser.open()` unless `--no-open`.
+  - Exit codes per KTD7: 0 all-OK, 1 partial, 2 setup error.
+  - Cross-platform via `pathlib` + `webbrowser`; no new deps. The script's module docstring documents usage.
+  - `scripts/follow.sample.txt`: a few example handles + a comment explaining the format.
+  - **Test import path:** `scripts/` is not an importable package (the suite imports `agent_reach`). Make `scripts/x_board.py` importable from `tests/test_x_board.py` via a `conftest.py` that adds `scripts/` to `sys.path` (or `importlib.util.spec_from_file_location`) — decided at implementation time; both are stdlib-only and avoid touching `pyproject.toml` / `agent_reach`.
+- **Patterns to follow:** `argparse` structure in `agent_reach/cli.py`; stdlib `webbrowser`.
+- **Test scenarios:**
+  - `main` happy path (monkeypatched fetch, tmp paths): writes the out file, returns 0, calls `webbrowser.open` unless `--no-open`.
+  - `main` partial: some handles error → returns 1, file still written and complete.
+  - `main` missing follow file → returns 2 with a message pointing to the sample; missing cookies → returns 2 with the configure hint.
+  - Flags: `--no-open` suppresses the browser; `--out` / `--file` / `-n` are respected.
+  - Integration: end-to-end with a mocked subprocess returning fixture JSON → produced HTML contains the expected accounts and posts (no mocks for the render/filter chain). (Covers success criteria.)
+- **Verification:** Running the script against a sample follow-list writes `~/.agent-reach/x-board.html`, opens it, and the exit code reflects all-OK vs partial vs setup-error.
+
+---
+
+## Risks & Dependencies
+
+- **twitter-cli JSON field names unverified at plan time.** `user-posts -n --json` is confirmed, but exact field keys (`full_text`/`text`, reply/repost markers, `id_str`, count fields) are confirmed at implementation time from one sample response. Mitigation: `normalize_post` / `filter_original_posts` written defensively with fallbacks; U2 tests use fixtures matching the confirmed shape.
+- **Rate limiting across many handles.** Sequential one-call-per-handle keeps volume low; large lists could still hit limits. Mitigation: keep lists small; rate-limit errors surface per-account as error cards (R6/R10), not a crash.
+- **Cookie staleness.** Expired cookies → all accounts error. Mitigation: error cards carry the re-`configure` hint; exit code 1.
+- **Repost/reply detection is heuristic.** Field-based detection plus `RT @` fallback is best-effort; an occasional misclassification is acceptable for a personal reader.
+- **`created_at` format parsing.** Twitter's timestamp format must be parsed in `format_relative_time`; unparseable values fall back to a raw/absolute display.
+- **Dependency:** Twitter/X already configured and working (`twitter status` → `ok: true`); `twitter` on PATH via the venv.
+
+---
+
+## Scope Boundaries
+
+### Deferred to follow-up (addable later, no rework)
+
+Carried from origin: live local web app with a Refresh button; merged
+chronological feed; image/video/media thumbnails; auto-refresh or scheduled runs;
+in-page search/filter; including reposts & replies; pulling the account's real
+following list; per-person long-form "Articles" beyond what appears in the
+timeline.
+
+### Out of scope
+
+Carried from origin: any write actions (post / like / follow / bookmark);
+persisting a post-history database or cross-run cache; multi-user, hosting, or
+remote access; re-implementing X fetching or adding any LLM/AI step to fetch or
+render.
+
+---
+
+## Open Questions (non-blocking — default chosen)
+
+- **Relative-time detail & avatars.** Default: text-only, no remote images, to keep the page self-contained (R7); `format_relative_time` granularity (`2h`/`3d` then absolute date) resolved during implementation. Revisit only if the board feels too sparse.
+
+---
+
+## Sources / Research
+
+- Origin: `docs/brainstorms/2026-06-05-x-board-requirements.md` (problem frame, R1–R13, scope, decisions).
+- `scripts/verify_twitter.ps1` — cookie load → env → `twitter-cli` invocation + JSON-noise-trim pattern (in-session precedent).
+- `agent_reach/config.py` — `Config.get`, keys `twitter_auth_token` / `twitter_ct0`, uppercase env fallback.
+- `agent_reach/channels/twitter.py` — how Agent-Reach shells out to `twitter` (subprocess, env, stdout parsing).
+- `agent_reach/cli.py` — `argparse` conventions.
+- twitter-cli 0.8.5 help (in-session): `twitter user-posts SCREEN_NAME -n N --json` confirmed; no reply/repost exclude flag (→ client-side filter); `user-posts` returns author info inline (→ no separate `user` call).

--- a/scripts/follow.sample.txt
+++ b/scripts/follow.sample.txt
@@ -1,0 +1,16 @@
+# X Board follow-list — one X/Twitter @handle per line.
+#
+# How to use:
+#   1. Copy this file to ~/.agent-reach/follow.txt
+#        (or pass --file <path> to scripts/x_board.py)
+#   2. Replace the examples below with the people you want to follow.
+#   3. Run:  python scripts/x_board.py
+#
+# Rules:
+#   - The leading @ is optional ("OpenAI" and "@OpenAI" are the same).
+#   - Blank lines and lines starting with # are ignored.
+#   - Duplicates are removed automatically.
+
+@OpenAI
+@AnthropicAI
+sama

--- a/scripts/verify_twitter.ps1
+++ b/scripts/verify_twitter.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Verify that Agent-Reach's Twitter/X access actually works (live fetch).
+
+.DESCRIPTION
+    Self-contained check, independent of the install session. It:
+      1. Locates the Agent-Reach venv and the 'twitter' CLI.
+      2. Reads twitter_auth_token / twitter_ct0 from ~/.agent-reach/config.yaml
+         (via Agent-Reach's own Config loader, which also honours the uppercase
+         env-var form TWITTER_AUTH_TOKEN / TWITTER_CT0).
+      3. Exports those as TWITTER_AUTH_TOKEN / TWITTER_CT0 -- twitter-cli reads
+         them directly (Agent-Reach is a glue layer, not a wrapper).
+      4. Runs 'twitter status' (auth check) and a live 'twitter search',
+         printing PASS / FAIL for each.
+
+    Exit code: 0 if both checks PASS, 1 otherwise.
+    NOTE: ASCII-only on purpose -- Windows PowerShell 5.1 reads BOM-less UTF-8
+    scripts as ANSI, which mangles non-ASCII characters.
+
+.PARAMETER Query
+    Search term for the live-fetch check. Default: "openai".
+
+.PARAMETER Max
+    Max tweets to fetch for the search check. Default: 3.
+
+.PARAMETER Venv
+    Path to the Agent-Reach venv. Defaults to $env:AGENT_REACH_VENV, then
+    ~/.agent-reach-venv.
+
+.EXAMPLE
+    powershell -File scripts\verify_twitter.ps1
+    powershell -File scripts\verify_twitter.ps1 -Query "claude ai" -Max 5
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Query = "openai",
+    [int]$Max = 3,
+    [string]$Venv = $(if ($env:AGENT_REACH_VENV) { $env:AGENT_REACH_VENV } else { Join-Path $env:USERPROFILE ".agent-reach-venv" })
+)
+
+$env:PYTHONUTF8 = "1"
+try { [Console]::OutputEncoding = [Text.Encoding]::UTF8 } catch { }
+
+function Write-Status($ok, $label, $detail) {
+    $mark = if ($ok) { "PASS" } else { "FAIL" }
+    $color = if ($ok) { "Green" } else { "Red" }
+    Write-Host ("[{0}] {1}" -f $mark, $label) -ForegroundColor $color
+    if ($detail) { Write-Host "       $detail" -ForegroundColor DarkGray }
+}
+
+Write-Host "Agent-Reach -- Twitter/X verification" -ForegroundColor Cyan
+Write-Host ("=" * 40)
+
+# --- Locate venv python + twitter CLI ---------------------------------------
+$pythonExe  = Join-Path $Venv "Scripts\python.exe"
+$twitterExe = Join-Path $Venv "Scripts\twitter.exe"
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Status $false "venv" "Python not found at $pythonExe. Re-run the Agent-Reach install (U1/U2)."
+    exit 1
+}
+if (-not (Test-Path $twitterExe)) {
+    $resolved = (Get-Command twitter -ErrorAction SilentlyContinue).Source
+    if ($resolved) {
+        $twitterExe = $resolved
+    } else {
+        Write-Status $false "twitter-cli" "Not found. Install with: pip install twitter-cli (into the venv)."
+        exit 1
+    }
+}
+$env:PATH = (Join-Path $Venv "Scripts") + ";" + $env:PATH
+
+# --- Read cookies from Agent-Reach config -----------------------------------
+# Parse ~/.agent-reach/config.yaml directly. (Reading via `python -c` is fragile
+# on Windows PowerShell 5.1, which mangles embedded double quotes when passing
+# arguments to native executables.) These are the exact keys that
+# `agent-reach configure twitter-cookies` writes.
+$cfgPath = Join-Path $env:USERPROFILE ".agent-reach\config.yaml"
+$authToken = ""
+$ct0 = ""
+if (Test-Path $cfgPath) {
+    foreach ($line in (Get-Content -LiteralPath $cfgPath)) {
+        if ($line -match '^\s*twitter_auth_token\s*:\s*(.+?)\s*$') {
+            $authToken = $matches[1].Trim().Trim("'").Trim('"')
+        } elseif ($line -match '^\s*twitter_ct0\s*:\s*(.+?)\s*$') {
+            $ct0 = $matches[1].Trim().Trim("'").Trim('"')
+        }
+    }
+}
+# Fall back to twitter-cli's own env-var convention if not stored in the file.
+if (-not $authToken -and $env:TWITTER_AUTH_TOKEN) { $authToken = $env:TWITTER_AUTH_TOKEN }
+if (-not $ct0 -and $env:TWITTER_CT0) { $ct0 = $env:TWITTER_CT0 }
+
+if (-not $authToken -or -not $ct0) {
+    Write-Status $false "cookies" "No twitter_auth_token / twitter_ct0 in ~/.agent-reach/config.yaml."
+    Write-Host  '       Fix: agent-reach configure twitter-cookies "auth_token=...; ct0=..."' -ForegroundColor Yellow
+    Write-Host  "       Export the header string from a dedicated/burner X account via Cookie-Editor." -ForegroundColor Yellow
+    exit 1
+}
+$env:TWITTER_AUTH_TOKEN = $authToken
+$env:TWITTER_CT0        = $ct0
+$authPrev = $authToken.Substring(0, [Math]::Min(6, $authToken.Length))
+$ct0Prev  = $ct0.Substring(0, [Math]::Min(6, $ct0.Length))
+Write-Status $true "cookies" ("loaded auth_token={0}... ct0={1}..." -f $authPrev, $ct0Prev)
+
+$statusOk = $false
+$searchOk = $false
+
+# --- Check 1: authenticated session -----------------------------------------
+try {
+    $statusOut = (& $twitterExe status 2>&1 | Out-String)
+    if ($statusOut -match "ok:\s*true") {
+        $statusOk = $true
+        Write-Status $true "status" "twitter status -> ok: true"
+    } else {
+        Write-Status $false "status" ("twitter status did not report ok: true. Output:`n" + $statusOut.Trim())
+    }
+} catch {
+    Write-Status $false "status" ("twitter status errored: " + $_.Exception.Message)
+}
+
+# --- Check 2: live search fetch ---------------------------------------------
+if ($statusOk) {
+    try {
+        $searchRaw = (& $twitterExe search $Query -n $Max --json 2>&1 | Out-String)
+        $code = $LASTEXITCODE
+        $count = 0
+        $sample = $null
+
+        # Trim any leading log noise before the JSON payload.
+        $jsonStart = $searchRaw.IndexOfAny([char[]]@('[', '{'))
+        $jsonText = if ($jsonStart -ge 0) { $searchRaw.Substring($jsonStart) } else { $searchRaw }
+
+        try {
+            $parsed = $jsonText | ConvertFrom-Json
+            $items = if ($parsed -is [System.Array]) { $parsed }
+                     elseif ($parsed.tweets) { $parsed.tweets }
+                     elseif ($parsed.data)   { $parsed.data }
+                     elseif ($parsed.results) { $parsed.results }
+                     else { @($parsed) }
+            $count = @($items).Count
+            if ($count -gt 0) {
+                $first = @($items)[0]
+                $sample = $first.text
+                if (-not $sample) { $sample = $first.full_text }
+                if (-not $sample) { $sample = $first.content }
+            }
+        } catch {
+            # JSON did not parse -- fall back to exit code + non-empty output.
+            if ($code -eq 0 -and $searchRaw.Trim()) { $count = 1 }
+        }
+
+        if ($count -ge 1) {
+            $searchOk = $true
+            $preview = if ($sample) { ($sample -replace "\s+", " ").Trim() } else { "(no text field; raw output received)" }
+            if ($preview.Length -gt 160) { $preview = $preview.Substring(0, 160) + "..." }
+            Write-Status $true "search" ("'{0}' returned {1} tweet(s). Sample: {2}" -f $Query, $count, $preview)
+        } else {
+            Write-Status $false "search" ("'{0}' returned no tweets. Output:`n{1}" -f $Query, $searchRaw.Trim())
+        }
+    } catch {
+        Write-Status $false "search" ("search errored: " + $_.Exception.Message)
+    }
+} else {
+    Write-Status $false "search" "skipped (status check failed -- fix auth first)"
+}
+
+# --- Summary ----------------------------------------------------------------
+Write-Host ("=" * 40)
+if ($statusOk -and $searchOk) {
+    Write-Host "RESULT: PASS -- Twitter/X fetching works." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "RESULT: FAIL -- see messages above." -ForegroundColor Red
+    Write-Host "If this machine's sandbox blocks network, retry in your own shell:" -ForegroundColor Yellow
+    Write-Host "  ! powershell -File scripts\verify_twitter.ps1" -ForegroundColor Yellow
+    exit 1
+}

--- a/scripts/x_board.py
+++ b/scripts/x_board.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""X Board — a local, self-contained HTML viewer for fetched X (Twitter) posts.
+
+Reads a user-edited follow-list (one @handle per line), fetches each person's
+recent *original* posts through the already-installed ``twitter-cli``, and writes
+a single self-contained HTML page (auto-opened in the browser). The page both
+displays the posts and proves the fetch worked: each account gets an
+"N posts fetched" badge and the page header shows an overall status line.
+
+This is a read-only glue-layer helper. It does NOT modify Agent-Reach or any
+upstream source, adds no new runtime dependencies (stdlib only for parsing and
+rendering), and involves no LLM. Cookies are loaded from
+``~/.agent-reach/config.yaml`` exactly as ``agent-reach configure`` wrote them,
+mirroring the pattern in ``scripts/verify_twitter.ps1``. Credentials are never
+written into the output HTML.
+
+Usage (run with the Agent-Reach venv interpreter so ``twitter`` is on PATH):
+
+    python scripts/x_board.py
+    python scripts/x_board.py --file ~/.agent-reach/follow.txt -n 10
+    python scripts/x_board.py --out ~/.agent-reach/x-board.html --no-open
+
+Exit codes:
+    0  all accounts fetched OK
+    1  partial — some (or all) accounts errored; the page is still written/opened
+    2  setup error — no cookies configured, or the follow-list is missing/empty
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import shutil
+import subprocess
+import sys
+import webbrowser
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+# Defaults live under ~/.agent-reach/ so the git clone stays clean (KTD6).
+DEFAULT_FOLLOW_FILE = Path.home() / ".agent-reach" / "follow.txt"
+DEFAULT_OUTPUT_FILE = Path.home() / ".agent-reach" / "x-board.html"
+# Repo-relative pointer shown in error messages (not used to read at runtime).
+SAMPLE_FOLLOW_FILE = "scripts/follow.sample.txt"
+
+
+class XBoardError(Exception):
+    """A setup/precondition failure (missing cookies or follow-list).
+
+    Raised only for whole-run problems that should stop before fetching. Per-handle
+    fetch failures are captured on :class:`AccountResult`, never raised.
+    """
+
+
+# ── Input layer (U1) ────────────────────────────────────────────────────────
+
+
+def load_cookies(config: Any = None) -> Tuple[str, str]:
+    """Return ``(auth_token, ct0)`` from Agent-Reach config.
+
+    Uses ``agent_reach.config.Config`` so it reads exactly what
+    ``agent-reach configure twitter-cookies`` wrote, and inherits Config's
+    uppercase env-var fallback (``TWITTER_AUTH_TOKEN`` / ``TWITTER_CT0``).
+
+    Raises :class:`XBoardError` with a remediation hint when either is absent.
+    """
+    if config is None:
+        try:
+            from agent_reach.config import Config
+        except ImportError as exc:  # pragma: no cover - environment guard
+            raise XBoardError(
+                "Could not import agent_reach. Run X Board with the Agent-Reach "
+                "venv interpreter (e.g. ~/.agent-reach-venv/Scripts/python.exe)."
+            ) from exc
+        config = Config()
+
+    auth_token = config.get("twitter_auth_token")
+    ct0 = config.get("twitter_ct0")
+    if not auth_token or not ct0:
+        raise XBoardError(
+            "No Twitter/X cookies found in ~/.agent-reach/config.yaml.\n"
+            '  Fix: agent-reach configure twitter-cookies "auth_token=...; ct0=..."\n'
+            "  Export the header string from a dedicated/burner X account via Cookie-Editor."
+        )
+    return str(auth_token), str(ct0)
+
+
+def parse_follow_list(path: Any) -> List[str]:
+    """Parse a follow-list file into a clean, ordered, de-duplicated handle list.
+
+    One handle per line; a leading ``@`` is optional. Blank lines and lines
+    starting with ``#`` are ignored. Surrounding whitespace is trimmed. Handles
+    are de-duplicated case-insensitively (X screen names are case-insensitive),
+    keeping the first-seen spelling. Original case is otherwise preserved.
+
+    Raises :class:`XBoardError` naming the path and the sample file if missing.
+    """
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise XBoardError(
+            f"Follow-list not found: {p}\n"
+            "  Create it with one @handle per line (blank lines and # comments are ignored).\n"
+            f"  See {SAMPLE_FOLLOW_FILE} for an example you can copy."
+        )
+
+    handles: List[str] = []
+    seen: set = set()
+    for raw_line in p.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        handle = line.lstrip("@").strip()
+        if not handle:
+            continue
+        key = handle.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        handles.append(handle)
+    return handles
+
+
+# ── Data model ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Post:
+    """A single normalized, display-ready original post."""
+
+    text: str
+    created_at: str
+    likes: int
+    retweets: int
+    permalink: str
+
+
+@dataclass
+class AccountResult:
+    """The fetch outcome for one handle — either posts or a human error reason."""
+
+    handle: str
+    display_name: str
+    posts: List[Post] = field(default_factory=list)
+    error: Optional[str] = None
+    fetched_count: int = 0
+
+
+# ── Fetch layer (U2) ─────────────────────────────────────────────────────────
+
+
+def resolve_twitter_exe() -> Optional[str]:
+    """Locate the ``twitter`` executable.
+
+    Prefers the binary next to the running interpreter (the venv's Scripts/bin
+    dir, where ``pip install twitter-cli`` puts it) so the script works even when
+    the venv isn't "activated"; falls back to PATH.
+    """
+    exe_dir = Path(sys.executable).parent
+    for name in ("twitter.exe", "twitter"):
+        candidate = exe_dir / name
+        if candidate.exists():
+            return str(candidate)
+    return shutil.which("twitter")
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    """Coerce a value to int, tolerating None and bad types."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _short(text: Optional[str], limit: int = 200) -> str:
+    """Collapse whitespace and truncate a (possibly multi-line) message."""
+    collapsed = " ".join((text or "").split())
+    if len(collapsed) > limit:
+        return collapsed[:limit] + "..."
+    return collapsed
+
+
+def _extract_json(raw: str) -> Any:
+    """Parse JSON from CLI output, trimming any leading non-JSON noise.
+
+    Returns the parsed object, or ``None`` if nothing parseable is found.
+    """
+    if not raw:
+        return None
+    starts = [i for i in (raw.find("["), raw.find("{")) if i >= 0]
+    if not starts:
+        return None
+    try:
+        return json.loads(raw[min(starts):])
+    except ValueError:
+        return None
+
+
+def _items_from_payload(data: Any) -> List[dict]:
+    """Pull the list of tweet dicts out of twitter-cli's response envelope.
+
+    twitter-cli wraps success as ``{"ok": true, "schema_version": "1",
+    "data": [...]}``; tolerate a few alternative shapes and a bare list.
+    """
+    if isinstance(data, dict):
+        if isinstance(data.get("data"), list):
+            return data["data"]
+        for key in ("tweets", "results", "posts"):
+            if isinstance(data.get(key), list):
+                return data[key]
+        return []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _post_text(item: dict) -> str:
+    """Best available post text. twitter-cli emits ``text``; ``full_text`` is the
+    raw x.com field — prefer it when present (defensive)."""
+    return item.get("full_text") or item.get("text") or ""
+
+
+def _is_repost(item: dict) -> bool:
+    """True if the item is a retweet/repost (not an original)."""
+    if item.get("isRetweet") is True or item.get("is_retweet") is True:
+        return True
+    if item.get("retweetedBy") or item.get("retweeted_by"):
+        return True
+    if item.get("retweeted_status") or item.get("retweeted_status_result"):
+        return True
+    return _post_text(item).lstrip().startswith("RT @")
+
+
+def _is_reply(item: dict) -> bool:
+    """True if the item is a reply.
+
+    twitter-cli's ``user-posts`` (the "Posts" tab) already excludes replies to
+    others server-side and *discards* the raw ``in_reply_to_*`` fields. We still
+    check those defensively (in case of a raw/alternate shape) and fall back to
+    the leading-``@`` mention heuristic for anything that slips through.
+    """
+    if (
+        item.get("in_reply_to_status_id_str")
+        or item.get("in_reply_to_screen_name")
+        or item.get("in_reply_to_user_id_str")
+    ):
+        return True
+    return _post_text(item).lstrip().startswith("@")
+
+
+def filter_original_posts(items: List[dict]) -> List[dict]:
+    """Keep only original posts — drop replies and reposts. Pure."""
+    originals = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if _is_repost(item) or _is_reply(item):
+            continue
+        originals.append(item)
+    return originals
+
+
+def normalize_post(item: dict, handle: str) -> Post:
+    """Map a twitter-cli tweet dict to the small :class:`Post` model. Pure.
+
+    Tolerant of missing fields and of both the twitter-cli camelCase shape and a
+    raw snake_case shape (counts default to 0).
+    """
+    metrics = item.get("metrics") if isinstance(item.get("metrics"), dict) else {}
+    likes = _to_int(metrics.get("likes", item.get("favorite_count", item.get("favoriteCount"))))
+    retweets = _to_int(metrics.get("retweets", item.get("retweet_count", item.get("retweetCount"))))
+    created_at = item.get("createdAtISO") or item.get("createdAt") or item.get("created_at") or ""
+    tweet_id = str(item.get("id") or item.get("id_str") or "")
+    permalink = f"https://x.com/{handle}/status/{tweet_id}" if tweet_id else f"https://x.com/{handle}"
+    return Post(
+        text=_post_text(item),
+        created_at=created_at,
+        likes=likes,
+        retweets=retweets,
+        permalink=permalink,
+    )
+
+
+def extract_display_name(items: List[dict], handle: str) -> str:
+    """Read the author display name from the embedded author object; else @handle."""
+    for item in items:
+        if isinstance(item, dict):
+            author = item.get("author")
+            if isinstance(author, dict):
+                name = author.get("name") or author.get("screenName") or author.get("screen_name")
+                if name:
+                    return str(name)
+    return "@" + handle
+
+
+def fetch_handle(
+    handle: str,
+    count: int,
+    env: dict,
+    timeout: int = 60,
+    twitter_exe: Optional[str] = None,
+) -> AccountResult:
+    """Fetch one handle's recent original posts via twitter-cli.
+
+    Every failure mode (missing CLI, non-zero exit, timeout, unparseable output,
+    API error envelope, empty result) is captured as ``AccountResult.error`` —
+    this never raises so one bad handle can't abort the whole board (R6).
+    """
+    fallback_name = "@" + handle
+    exe = twitter_exe or resolve_twitter_exe()
+    if not exe:
+        return AccountResult(
+            handle, fallback_name, [],
+            "twitter CLI not found. Run X Board with the Agent-Reach venv, "
+            "or install it with: pip install twitter-cli",
+            0,
+        )
+
+    # Over-fetch so client-side filtering still leaves enough originals.
+    buffer = max(count * 2, count + 10)
+    cmd = [exe, "user-posts", handle, "-n", str(buffer), "--json"]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, encoding="utf-8", errors="replace",
+            env=env, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return AccountResult(handle, fallback_name, [], f"Timed out after {timeout}s.", 0)
+    except Exception as exc:  # pragma: no cover - defensive
+        return AccountResult(handle, fallback_name, [], f"Failed to run twitter CLI: {exc}", 0)
+
+    data = _extract_json(proc.stdout or "")
+    # Structured error envelope: {"ok": false, "error": {"code","message"}}
+    if isinstance(data, dict) and data.get("ok") is False:
+        err = data.get("error") or {}
+        message = err.get("message") or err.get("code") or "Unknown API error."
+        return AccountResult(handle, fallback_name, [], _short(message), 0)
+    if data is None:
+        message = _short(proc.stderr or proc.stdout) or f"twitter CLI exited with code {proc.returncode}."
+        return AccountResult(handle, fallback_name, [], message, 0)
+
+    items = _items_from_payload(data)
+    if not items:
+        return AccountResult(
+            handle, fallback_name, [],
+            "No posts returned (the account may be empty, protected, or suspended).",
+            0,
+        )
+
+    display_name = extract_display_name(items, handle)
+    originals = filter_original_posts(items)
+    posts = [normalize_post(item, handle) for item in originals][:count]
+    return AccountResult(handle, display_name, posts, None, len(posts))
+
+
+# ── Render layer (U3) ────────────────────────────────────────────────────────
+
+
+def _parse_dt(value: str) -> Optional[datetime]:
+    """Parse an ISO-8601 or Twitter-native timestamp; ``None`` if unparseable."""
+    if not value:
+        return None
+    text = value.strip()
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+    try:
+        return datetime.strptime(text, "%a %b %d %H:%M:%S %z %Y")
+    except ValueError:
+        return None
+
+
+def format_relative_time(created_at: str, now: Optional[datetime] = None) -> str:
+    """Compact relative age (``now``/``30m``/``3h``/``2d``); absolute date if old
+    (>= 7 days); the raw string if it can't be parsed. Pure (pass ``now``)."""
+    dt = _parse_dt(created_at)
+    if dt is None:
+        return created_at or ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if now is None:  # pragma: no cover - exercised via tests with explicit now
+        now = datetime.now(timezone.utc)
+    seconds = max((now - dt).total_seconds(), 0)
+    if seconds < 60:
+        return "now"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h"
+    if seconds < 7 * 86400:
+        return f"{int(seconds // 86400)}d"
+    return dt.astimezone(timezone.utc).strftime("%b %d, %Y")
+
+
+def format_absolute_time(created_at: str) -> str:
+    """Absolute UTC timestamp for hover titles; raw string if unparseable."""
+    dt = _parse_dt(created_at)
+    if dt is None:
+        return created_at or ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+_CSS = """
+* { box-sizing: border-box; }
+body { margin: 0; background: #f5f7fa; color: #14171a; line-height: 1.5;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+.statusbar { position: sticky; top: 0; z-index: 10; display: flex; flex-wrap: wrap;
+  justify-content: space-between; align-items: center; gap: 8px; padding: 14px 20px;
+  color: #fff; font-weight: 600; box-shadow: 0 1px 4px rgba(0,0,0,.15); }
+.statusbar.ok { background: #17a673; }
+.statusbar.warn { background: #d9822b; }
+.statusbar .mark { margin-right: 6px; }
+.status-meta { font-weight: 400; font-size: .85rem; opacity: .95; }
+main { max-width: 720px; margin: 0 auto; padding: 20px 16px 60px; }
+.account { background: #fff; border: 1px solid #e1e8ed; border-radius: 12px;
+  margin-bottom: 22px; overflow: hidden; }
+.acct-head { display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+  padding: 14px 16px; border-bottom: 1px solid #eef3f6; }
+.acct-head .name { font-weight: 700; }
+.acct-head .handle { color: #657786; text-decoration: none; }
+.acct-head .handle:hover { text-decoration: underline; }
+.badge { margin-left: auto; font-size: .8rem; font-weight: 600;
+  padding: 3px 10px; border-radius: 999px; }
+.badge.ok { background: #e3f6ee; color: #0f7a52; }
+.badge.err { background: #fdecea; color: #b3261e; }
+.post { padding: 14px 16px; border-bottom: 1px solid #f2f5f7; }
+.post:last-child { border-bottom: none; }
+.post-text { word-wrap: break-word; margin-bottom: 8px; }
+.post-meta { display: flex; align-items: center; gap: 16px; font-size: .85rem; color: #657786; }
+.post-meta .permalink { margin-left: auto; color: #1d9bf0; text-decoration: none; }
+.post-meta .permalink:hover { text-decoration: underline; }
+.error-card { padding: 14px 16px; background: #fdf6f5; }
+.error-reason { color: #b3261e; font-weight: 600; margin-bottom: 6px; }
+.hint { color: #657786; font-size: .85rem; }
+.hint code { background: #eef3f6; padding: 1px 5px; border-radius: 4px; }
+.empty { padding: 14px 16px; color: #657786; font-style: italic; }
+footer { text-align: center; color: #8a99a8; font-size: .8rem; padding: 20px; }
+""".strip()
+
+
+def _render_post(post: Post, now: datetime) -> str:
+    text = html.escape(post.text).replace("\n", "<br>")
+    rel = html.escape(format_relative_time(post.created_at, now))
+    absolute = html.escape(format_absolute_time(post.created_at))
+    permalink = html.escape(post.permalink, quote=True)
+    return (
+        '    <article class="post">\n'
+        f'      <div class="post-text">{text}</div>\n'
+        '      <div class="post-meta">\n'
+        f'        <span class="time" title="{absolute}">{rel}</span>\n'
+        f'        <span class="stat">&#9829; {post.likes}</span>\n'
+        f'        <span class="stat">&#8646; {post.retweets}</span>\n'
+        f'        <a class="permalink" href="{permalink}" target="_blank" rel="noopener">open &#8599;</a>\n'
+        '      </div>\n'
+        '    </article>'
+    )
+
+
+def _render_account(result: AccountResult, now: datetime) -> str:
+    name = html.escape(result.display_name or ("@" + result.handle))
+    handle = html.escape(result.handle)
+    if result.error:
+        badge = '<span class="badge err">fetch failed</span>'
+        inner = (
+            '    <div class="error-card">\n'
+            f'      <div class="error-reason">{html.escape(result.error)}</div>\n'
+            '      <div class="hint">If this keeps happening, your cookies may be stale — '
+            're-run <code>agent-reach configure twitter-cookies</code>.</div>\n'
+            '    </div>'
+        )
+    else:
+        badge = f'<span class="badge ok">{result.fetched_count} posts fetched</span>'
+        if result.posts:
+            inner = "\n".join(_render_post(p, now) for p in result.posts)
+        else:
+            inner = '    <div class="empty">No original posts in the fetched window.</div>'
+    return (
+        '  <section class="account">\n'
+        '    <div class="acct-head">\n'
+        f'      <span class="name">{name}</span>\n'
+        f'      <a class="handle" href="https://x.com/{handle}" target="_blank" rel="noopener">@{handle}</a>\n'
+        f'      {badge}\n'
+        '    </div>\n'
+        f'{inner}\n'
+        '  </section>'
+    )
+
+
+def render_html(results: List[AccountResult], generated_at: datetime) -> str:
+    """Render account results into one self-contained HTML document string.
+
+    Inline CSS only — no external assets, fonts, or remote images. Every dynamic
+    value is HTML-escaped. The renderer only ever receives display data, never
+    cookies, so credentials cannot leak into the output (R13).
+    """
+    if isinstance(generated_at, datetime):
+        now = generated_at if generated_at.tzinfo else generated_at.replace(tzinfo=timezone.utc)
+        stamp = now.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    else:  # pragma: no cover - defensive; callers pass a datetime
+        now = datetime.now(timezone.utc)
+        stamp = str(generated_at)
+
+    total = len(results)
+    ok_count = sum(1 for r in results if not r.error)
+    plural = "s" if total != 1 else ""
+    if total and ok_count == total:
+        status_class, mark = "ok", "&#9989;"  # ✅
+        status_text = f"All {total} account{plural} OK"
+    else:
+        status_class, mark = "warn", "&#9888;"  # ⚠
+        status_text = f"{ok_count} of {total} accounts OK"
+
+    body = "\n".join(_render_account(r, now) for r in results)
+
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>X Board</title>\n"
+        f"<style>{_CSS}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        f'<header class="statusbar {status_class}">\n'
+        f'  <div class="status-main"><span class="mark">{mark}</span> {html.escape(status_text)}</div>\n'
+        f'  <div class="status-meta">{total} account{plural} &middot; fetched {html.escape(stamp)}</div>\n'
+        "</header>\n"
+        "<main>\n"
+        f"{body}\n"
+        "</main>\n"
+        '<footer>Generated by X Board &middot; a read-only viewer over twitter-cli. '
+        "No login details are stored in this file.</footer>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+# ── CLI orchestration (U4) ───────────────────────────────────────────────────
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Parse args, run the fetch→render pipeline, write+open the board.
+
+    Returns an exit code: 0 all OK, 1 partial/all-failed (page still written),
+    2 setup error (no cookies / missing or empty follow-list).
+    """
+    argv = sys.argv[1:] if argv is None else list(argv)
+    parser = argparse.ArgumentParser(
+        prog="x_board",
+        description="Build a local HTML board of recent original X posts for a follow-list.",
+    )
+    parser.add_argument("--file", default=str(DEFAULT_FOLLOW_FILE),
+                        help=f"Follow-list path (default: {DEFAULT_FOLLOW_FILE}).")
+    parser.add_argument("-n", "--count", type=int, default=10,
+                        help="Original posts to show per account (default: 10).")
+    parser.add_argument("--out", default=str(DEFAULT_OUTPUT_FILE),
+                        help=f"Output HTML path (default: {DEFAULT_OUTPUT_FILE}).")
+    parser.add_argument("--no-open", action="store_true",
+                        help="Do not open the page in a browser after writing it.")
+    parser.add_argument("--timeout", type=int, default=60,
+                        help="Per-account fetch timeout in seconds (default: 60).")
+    args = parser.parse_args(argv)
+
+    try:
+        auth_token, ct0 = load_cookies()
+    except XBoardError as exc:
+        print(f"[setup] {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        handles = parse_follow_list(args.file)
+    except XBoardError as exc:
+        print(f"[setup] {exc}", file=sys.stderr)
+        return 2
+    if not handles:
+        print(
+            f"[setup] No handles found in {args.file}. Add one @handle per line "
+            f"(see {SAMPLE_FOLLOW_FILE}).",
+            file=sys.stderr,
+        )
+        return 2
+
+    env = dict(os.environ)
+    env["TWITTER_AUTH_TOKEN"] = auth_token
+    env["TWITTER_CT0"] = ct0
+    env["PYTHONUTF8"] = "1"
+
+    twitter_exe = resolve_twitter_exe()
+    results: List[AccountResult] = []
+    for handle in handles:
+        print(f"  fetching @{handle} ...", file=sys.stderr)
+        results.append(
+            fetch_handle(handle, args.count, env, timeout=args.timeout, twitter_exe=twitter_exe)
+        )
+
+    document = render_html(results, datetime.now(timezone.utc))
+    out_path = Path(args.out).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(document, encoding="utf-8")
+    print(f"Wrote {out_path}", file=sys.stderr)
+
+    if not args.no_open:
+        try:
+            webbrowser.open(out_path.resolve().as_uri())
+        except Exception:  # pragma: no cover - browser env dependent
+            print("  (could not open a browser automatically; open the file manually)", file=sys.stderr)
+
+    ok_count = sum(1 for r in results if not r.error)
+    return 0 if ok_count == len(results) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/scripts/x_board.py
+++ b/scripts/x_board.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
+from urllib.parse import quote as _urlquote
 
 # Defaults live under ~/.agent-reach/ so the git clone stays clean (KTD6).
 DEFAULT_FOLLOW_FILE = Path.home() / ".agent-reach" / "follow.txt"
@@ -277,7 +278,10 @@ def normalize_post(item: dict, handle: str) -> Post:
     retweets = _to_int(metrics.get("retweets", item.get("retweet_count", item.get("retweetCount"))))
     created_at = item.get("createdAtISO") or item.get("createdAt") or item.get("created_at") or ""
     tweet_id = str(item.get("id") or item.get("id_str") or "")
-    permalink = f"https://x.com/{handle}/status/{tweet_id}" if tweet_id else f"https://x.com/{handle}"
+    # URL-encode the handle for the path segment so an unusual follow-list entry
+    # can't produce a malformed link (handles are normally [A-Za-z0-9_] only).
+    handle_path = _urlquote(handle, safe="")
+    permalink = f"https://x.com/{handle_path}/status/{tweet_id}" if tweet_id else f"https://x.com/{handle_path}"
     return Post(
         text=_post_text(item),
         created_at=created_at,
@@ -341,6 +345,13 @@ def fetch_handle(
         err = data.get("error") or {}
         message = err.get("message") or err.get("code") or "Unknown API error."
         return AccountResult(handle, fallback_name, [], _short(message), 0)
+    # A non-zero exit is a failure unless twitter-cli explicitly reported success
+    # (ok: true). This catches the case where the CLI exits non-zero but still
+    # emitted parseable-but-non-success JSON on stdout (R6/R10).
+    succeeded = isinstance(data, dict) and data.get("ok") is True
+    if proc.returncode != 0 and not succeeded:
+        message = _short(proc.stderr or proc.stdout) or f"twitter CLI exited with code {proc.returncode}."
+        return AccountResult(handle, fallback_name, [], message, 0)
     if data is None:
         message = _short(proc.stderr or proc.stdout) or f"twitter CLI exited with code {proc.returncode}."
         return AccountResult(handle, fallback_name, [], message, 0)
@@ -468,6 +479,8 @@ def _render_post(post: Post, now: datetime) -> str:
 def _render_account(result: AccountResult, now: datetime) -> str:
     name = html.escape(result.display_name or ("@" + result.handle))
     handle = html.escape(result.handle)
+    # URL-encode for the href path; html.escape (quote=True) the display text.
+    handle_url = html.escape(_urlquote(result.handle, safe=""))
     if result.error:
         badge = '<span class="badge err">fetch failed</span>'
         inner = (
@@ -487,7 +500,7 @@ def _render_account(result: AccountResult, now: datetime) -> str:
         '  <section class="account">\n'
         '    <div class="acct-head">\n'
         f'      <span class="name">{name}</span>\n'
-        f'      <a class="handle" href="https://x.com/{handle}" target="_blank" rel="noopener">@{handle}</a>\n'
+        f'      <a class="handle" href="https://x.com/{handle_url}" target="_blank" rel="noopener">@{handle}</a>\n'
         f'      {badge}\n'
         '    </div>\n'
         f'{inner}\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Pytest configuration for Agent Reach tests.
+
+Adds the repo-root ``scripts/`` directory to ``sys.path`` so standalone helper
+scripts (e.g. ``x_board.py``) are importable from the test suite. ``scripts/`` is
+not an installable package, so this is the lightweight, stdlib-only way to test
+it without touching ``pyproject.toml`` or ``agent_reach``.
+"""
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/tests/test_x_board.py
+++ b/tests/test_x_board.py
@@ -193,6 +193,11 @@ class TestNormalizePost:
         post = normalize_post(_tweet(created="2026-06-05T10:00:00+00:00"), "x")
         assert post.created_at == "2026-06-05T10:00:00+00:00"
 
+    def test_url_encodes_handle_in_permalink(self):
+        # An unusual follow-list entry must not produce a malformed link.
+        post = normalize_post(_tweet(tid="9"), "weird name/with#chars")
+        assert post.permalink == "https://x.com/weird%20name%2Fwith%23chars/status/9"
+
 
 class TestExtractDisplayName:
     def test_from_author(self):
@@ -254,6 +259,16 @@ class TestFetchHandle:
         monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
         res = fetch_handle("x", 5, {}, twitter_exe="twitter")
         assert "rate limited" in res.error
+
+    def test_nonzero_exit_with_parseable_json_sets_error(self, monkeypatch):
+        # CLI exits non-zero but stdout is parseable, non-success JSON (a bare
+        # list, no ok:true envelope). Must be treated as a failure, not success.
+        proc = _FakeProc(stdout=__import__("json").dumps([_tweet()]), stderr="warn", returncode=1)
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter")
+        assert res.error is not None
+        assert res.posts == []
+        assert res.fetched_count == 0
 
     def test_timeout_sets_error(self, monkeypatch):
         def boom(*a, **k):

--- a/tests/test_x_board.py
+++ b/tests/test_x_board.py
@@ -1,0 +1,502 @@
+# -*- coding: utf-8 -*-
+"""Tests for the standalone X Board helper (scripts/x_board.py).
+
+``scripts/`` is placed on sys.path by tests/conftest.py, so ``x_board`` imports
+as a top-level module here.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import x_board
+from x_board import (
+    AccountResult,
+    Post,
+    XBoardError,
+    extract_display_name,
+    fetch_handle,
+    filter_original_posts,
+    format_relative_time,
+    load_cookies,
+    main,
+    normalize_post,
+    parse_follow_list,
+    render_html,
+)
+
+from agent_reach.config import Config
+
+# ── Helpers / fixtures ───────────────────────────────────────────────────────
+
+
+def _tweet(
+    tid="111",
+    text="hello world",
+    name="Display Name",
+    screen="someone",
+    likes=5,
+    retweets=2,
+    created="2026-06-05T10:00:00+00:00",
+    **extra,
+):
+    """Build a twitter-cli-shaped (camelCase) tweet dict."""
+    d = {
+        "id": tid,
+        "text": text,
+        "author": {"id": "1", "name": name, "screenName": screen, "verified": False},
+        "metrics": {"likes": likes, "retweets": retweets, "replies": 0, "quotes": 0},
+        "createdAt": "Fri Jun 05 10:00:00 +0000 2026",
+        "createdAtISO": created,
+        "isRetweet": False,
+        "retweetedBy": None,
+        "lang": "en",
+    }
+    d.update(extra)
+    return d
+
+
+def _envelope(items):
+    """Wrap items in the twitter-cli success envelope."""
+    return {"ok": True, "schema_version": "1", "data": items}
+
+
+class _FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+# ── U1: parse_follow_list ────────────────────────────────────────────────────
+
+
+class TestParseFollowList:
+    def test_strips_at_ignores_blanks_and_comments(self, tmp_path):
+        f = tmp_path / "follow.txt"
+        f.write_text(
+            "@OpenAI\n"
+            "\n"
+            "# a comment\n"
+            "  AnthropicAI  \n"
+            "@sama\n",
+            encoding="utf-8",
+        )
+        assert parse_follow_list(f) == ["OpenAI", "AnthropicAI", "sama"]
+
+    def test_dedupes_case_insensitive_preserving_first_spelling(self, tmp_path):
+        f = tmp_path / "follow.txt"
+        f.write_text("OpenAI\n@openai\nSama\nsama\n", encoding="utf-8")
+        assert parse_follow_list(f) == ["OpenAI", "Sama"]
+
+    def test_preserves_case(self, tmp_path):
+        f = tmp_path / "follow.txt"
+        f.write_text("@CamelCaseHandle\n", encoding="utf-8")
+        assert parse_follow_list(f) == ["CamelCaseHandle"]
+
+    def test_empty_file_returns_empty_list(self, tmp_path):
+        f = tmp_path / "follow.txt"
+        f.write_text("\n#only comments\n  \n", encoding="utf-8")
+        assert parse_follow_list(f) == []
+
+    def test_missing_file_raises_with_path_and_sample(self, tmp_path):
+        missing = tmp_path / "nope.txt"
+        with pytest.raises(XBoardError) as exc:
+            parse_follow_list(missing)
+        msg = str(exc.value)
+        assert str(missing) in msg
+        assert "follow.sample.txt" in msg
+
+
+# ── U1: load_cookies ─────────────────────────────────────────────────────────
+
+
+class TestLoadCookies:
+    def test_returns_pair_from_config(self, tmp_path):
+        cfg = Config(config_path=tmp_path / "config.yaml")
+        cfg.set("twitter_auth_token", "AUTHVALUE")
+        cfg.set("twitter_ct0", "CT0VALUE")
+        assert load_cookies(cfg) == ("AUTHVALUE", "CT0VALUE")
+
+    def test_env_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TWITTER_AUTH_TOKEN", "env_auth")
+        monkeypatch.setenv("TWITTER_CT0", "env_ct0")
+        cfg = Config(config_path=tmp_path / "config.yaml")  # empty file
+        assert load_cookies(cfg) == ("env_auth", "env_ct0")
+
+    def test_missing_raises_with_hint(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TWITTER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("TWITTER_CT0", raising=False)
+        cfg = Config(config_path=tmp_path / "config.yaml")
+        with pytest.raises(XBoardError) as exc:
+            load_cookies(cfg)
+        assert "configure twitter-cookies" in str(exc.value)
+
+
+# ── U2: filter_original_posts ────────────────────────────────────────────────
+
+
+class TestFilterOriginalPosts:
+    def test_keeps_originals(self):
+        items = [_tweet(tid="1", text="an original post")]
+        assert filter_original_posts(items) == items
+
+    def test_drops_isretweet_flag(self):
+        items = [_tweet(tid="1"), _tweet(tid="2", isRetweet=True)]
+        out = filter_original_posts(items)
+        assert [i["id"] for i in out] == ["1"]
+
+    def test_drops_retweeted_by(self):
+        items = [_tweet(tid="1"), _tweet(tid="2", retweetedBy="someoneelse")]
+        assert [i["id"] for i in filter_original_posts(items)] == ["1"]
+
+    def test_drops_rt_text_prefix(self):
+        items = [_tweet(tid="2", text="RT @other: look at this")]
+        assert filter_original_posts(items) == []
+
+    def test_drops_replies_via_raw_markers(self):
+        # Defensive: raw x.com legacy shape (twitter-cli discards these, but be safe).
+        items = [_tweet(tid="2", in_reply_to_status_id_str="999")]
+        assert filter_original_posts(items) == []
+
+    def test_drops_replies_via_leading_mention(self):
+        items = [_tweet(tid="2", text="@friend totally agree")]
+        assert filter_original_posts(items) == []
+
+    def test_empty_input(self):
+        assert filter_original_posts([]) == []
+
+
+# ── U2: normalize_post ───────────────────────────────────────────────────────
+
+
+class TestNormalizePost:
+    def test_maps_fields_and_permalink(self):
+        post = normalize_post(_tweet(tid="12345", text="hi", likes=7, retweets=3), "OpenAI")
+        assert isinstance(post, Post)
+        assert post.text == "hi"
+        assert post.likes == 7
+        assert post.retweets == 3
+        assert post.permalink == "https://x.com/OpenAI/status/12345"
+
+    def test_prefers_full_text_over_text(self):
+        item = _tweet(text="short")
+        item["full_text"] = "the longer canonical text"
+        assert normalize_post(item, "x").text == "the longer canonical text"
+
+    def test_missing_counts_default_zero(self):
+        item = {"id": "1", "text": "no metrics here"}
+        post = normalize_post(item, "x")
+        assert post.likes == 0
+        assert post.retweets == 0
+
+    def test_uses_iso_created_at_when_present(self):
+        post = normalize_post(_tweet(created="2026-06-05T10:00:00+00:00"), "x")
+        assert post.created_at == "2026-06-05T10:00:00+00:00"
+
+
+class TestExtractDisplayName:
+    def test_from_author(self):
+        items = [_tweet(name="Sam A", screen="sama")]
+        assert extract_display_name(items, "sama") == "Sam A"
+
+    def test_fallback_to_handle(self):
+        assert extract_display_name([], "ghost") == "@ghost"
+
+
+# ── U2: fetch_handle (mocked subprocess) ─────────────────────────────────────
+
+
+class TestFetchHandle:
+    def test_success_normalizes_and_trims(self, monkeypatch):
+        items = [_tweet(tid=str(i), text=f"post {i}") for i in range(12)]
+        proc = _FakeProc(stdout=__import__("json").dumps(_envelope(items)))
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("OpenAI", 5, {"TWITTER_AUTH_TOKEN": "a", "TWITTER_CT0": "b"}, twitter_exe="twitter")
+        assert res.error is None
+        assert len(res.posts) == 5
+        assert res.fetched_count == 5
+        assert res.display_name == "Display Name"
+
+    def test_filters_reposts_before_trim(self, monkeypatch):
+        items = [_tweet(tid="1", text="orig")] + [_tweet(tid=str(i), isRetweet=True) for i in range(2, 8)]
+        proc = _FakeProc(stdout=__import__("json").dumps(_envelope(items)))
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 10, {}, twitter_exe="twitter")
+        assert [p.text for p in res.posts] == ["orig"]
+
+    def test_passes_cookie_env(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            return _FakeProc(stdout=__import__("json").dumps(_envelope([_tweet()])))
+
+        monkeypatch.setattr(x_board.subprocess, "run", fake_run)
+        env = {"TWITTER_AUTH_TOKEN": "secret-auth", "TWITTER_CT0": "secret-ct0"}
+        fetch_handle("OpenAI", 3, env, twitter_exe="twitter")
+        assert captured["env"]["TWITTER_AUTH_TOKEN"] == "secret-auth"
+        assert captured["env"]["TWITTER_CT0"] == "secret-ct0"
+        assert "user-posts" in captured["cmd"]
+        assert "OpenAI" in captured["cmd"]
+        assert "--json" in captured["cmd"]
+
+    def test_nonzero_exit_sets_error(self, monkeypatch):
+        proc = _FakeProc(stdout="", stderr="boom", returncode=1)
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter")
+        assert res.error is not None
+        assert res.posts == []
+
+    def test_api_error_envelope_sets_error(self, monkeypatch):
+        env_err = {"ok": False, "schema_version": "1", "error": {"code": "api_error", "message": "rate limited"}}
+        proc = _FakeProc(stdout=__import__("json").dumps(env_err), returncode=1)
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter")
+        assert "rate limited" in res.error
+
+    def test_timeout_sets_error(self, monkeypatch):
+        def boom(*a, **k):
+            raise x_board.subprocess.TimeoutExpired(cmd="twitter", timeout=60)
+
+        monkeypatch.setattr(x_board.subprocess, "run", boom)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter", timeout=60)
+        assert res.error is not None
+        assert "time" in res.error.lower()
+
+    def test_invalid_json_sets_error(self, monkeypatch):
+        proc = _FakeProc(stdout="not json at all", returncode=0)
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter")
+        assert res.error is not None
+
+    def test_empty_list_flagged(self, monkeypatch):
+        proc = _FakeProc(stdout=__import__("json").dumps(_envelope([])))
+        monkeypatch.setattr(x_board.subprocess, "run", lambda *a, **k: proc)
+        res = fetch_handle("x", 5, {}, twitter_exe="twitter")
+        assert res.error is not None
+        assert res.posts == []
+
+    def test_missing_twitter_exe(self, monkeypatch):
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: None)
+        res = fetch_handle("x", 5, {}, twitter_exe=None)
+        assert res.error is not None
+        assert "twitter" in res.error.lower()
+
+
+# ── U3: format_relative_time ─────────────────────────────────────────────────
+
+
+class TestFormatRelativeTime:
+    NOW = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_seconds_to_now(self):
+        dt = "2026-06-05T11:59:30+00:00"
+        assert format_relative_time(dt, self.NOW) == "now"
+
+    def test_minutes(self):
+        assert format_relative_time("2026-06-05T11:30:00+00:00", self.NOW) == "30m"
+
+    def test_hours(self):
+        assert format_relative_time("2026-06-05T09:00:00+00:00", self.NOW) == "3h"
+
+    def test_days(self):
+        assert format_relative_time("2026-06-03T12:00:00+00:00", self.NOW) == "2d"
+
+    def test_old_returns_absolute_date(self):
+        out = format_relative_time("2026-01-01T12:00:00+00:00", self.NOW)
+        assert "2026" in out and out not in ("now",) and "d" != out[-1:]
+
+    def test_twitter_native_format(self):
+        out = format_relative_time("Fri Jun 05 09:00:00 +0000 2026", self.NOW)
+        assert out == "3h"
+
+    def test_unparseable_falls_back_to_raw(self):
+        assert format_relative_time("garbage-timestamp", self.NOW) == "garbage-timestamp"
+
+    def test_empty_returns_empty(self):
+        assert format_relative_time("", self.NOW) == ""
+
+
+# ── U3: render_html ──────────────────────────────────────────────────────────
+
+
+def _result(handle="OpenAI", name="OpenAI", posts=None, error=None):
+    posts = posts or []
+    return AccountResult(
+        handle=handle,
+        display_name=name,
+        posts=posts,
+        error=error,
+        fetched_count=len(posts),
+    )
+
+
+GEN_AT = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestRenderHtml:
+    def test_structure_and_badge(self):
+        post = Post(text="hello board", created_at="2026-06-05T11:00:00+00:00",
+                    likes=10, retweets=2, permalink="https://x.com/OpenAI/status/1")
+        html_doc = render_html([_result(posts=[post])], GEN_AT)
+        assert "<!DOCTYPE html>" in html_doc
+        assert "@OpenAI" in html_doc
+        assert "1 posts fetched" in html_doc
+        assert "hello board" in html_doc
+        assert "https://x.com/OpenAI/status/1" in html_doc
+
+    def test_escapes_dangerous_content(self):
+        post = Post(text="<script>alert(1)</script> & \"quotes\"",
+                    created_at="2026-06-05T11:00:00+00:00", likes=0, retweets=0,
+                    permalink="https://x.com/x/status/1")
+        html_doc = render_html([_result(handle="ev<il", name="<b>boom</b>", posts=[post])], GEN_AT)
+        assert "<script>alert(1)</script>" not in html_doc
+        assert "&lt;script&gt;" in html_doc
+        assert "<b>boom</b>" not in html_doc
+
+    def test_partial_failure_status_and_error_card(self):
+        ok = _result(handle="OpenAI", posts=[Post("hi", "2026-06-05T11:00:00+00:00", 1, 1, "https://x.com/OpenAI/status/1")])
+        bad = _result(handle="ghost", name="@ghost", error="rate limited")
+        html_doc = render_html([ok, bad], GEN_AT)
+        assert "rate limited" in html_doc
+        assert "configure twitter-cookies" in html_doc  # remediation hint
+        assert "1 of 2" in html_doc  # M of N
+
+    def test_all_ok_status(self):
+        ok = _result(posts=[Post("hi", "2026-06-05T11:00:00+00:00", 1, 1, "https://x.com/OpenAI/status/1")])
+        html_doc = render_html([ok], GEN_AT)
+        assert "All 1" in html_doc or "All accounts OK" in html_doc
+
+    def test_no_credentials_in_output(self):
+        # render_html only ever receives AccountResult — never cookies. Even if a
+        # token-like value lived in a post, it would be escaped, but structurally
+        # the renderer cannot leak cookies. Assert the known token sentinel is absent.
+        ok = _result(posts=[Post("normal post", "2026-06-05T11:00:00+00:00", 0, 0, "https://x.com/OpenAI/status/1")])
+        html_doc = render_html([ok], GEN_AT)
+        assert "auth_token" not in html_doc
+        assert "ct0" not in html_doc
+
+
+# ── U4: main / CLI orchestration ─────────────────────────────────────────────
+
+
+class TestMain:
+    def _setup_follow(self, tmp_path, handles=("OpenAI", "AnthropicAI")):
+        f = tmp_path / "follow.txt"
+        f.write_text("\n".join(handles) + "\n", encoding="utf-8")
+        return f
+
+    def test_happy_path_writes_and_opens(self, tmp_path, monkeypatch):
+        follow = self._setup_follow(tmp_path)
+        out = tmp_path / "board.html"
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: "twitter")
+        monkeypatch.setattr(
+            x_board, "fetch_handle",
+            lambda h, *a, **k: _result(handle=h, posts=[Post("hi", "2026-06-05T11:00:00+00:00", 1, 1, f"https://x.com/{h}/status/1")]),
+        )
+        opened = {}
+        monkeypatch.setattr(x_board.webbrowser, "open", lambda url: opened.setdefault("url", url))
+        rc = main(["--file", str(follow), "--out", str(out)])
+        assert rc == 0
+        assert out.exists()
+        assert "OpenAI" in out.read_text(encoding="utf-8")
+        assert "url" in opened
+
+    def test_no_open_suppresses_browser(self, tmp_path, monkeypatch):
+        follow = self._setup_follow(tmp_path)
+        out = tmp_path / "board.html"
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: "twitter")
+        monkeypatch.setattr(x_board, "fetch_handle", lambda h, *a, **k: _result(handle=h, posts=[Post("hi", "2026-06-05T11:00:00+00:00", 0, 0, "https://x.com/x/status/1")]))
+        called = {"n": 0}
+        monkeypatch.setattr(x_board.webbrowser, "open", lambda url: called.__setitem__("n", called["n"] + 1))
+        rc = main(["--file", str(follow), "--out", str(out), "--no-open"])
+        assert rc == 0
+        assert called["n"] == 0
+
+    def test_partial_returns_1(self, tmp_path, monkeypatch):
+        follow = self._setup_follow(tmp_path, handles=("good", "bad"))
+        out = tmp_path / "board.html"
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: "twitter")
+
+        def fake_fetch(h, *a, **k):
+            if h == "bad":
+                return _result(handle=h, name="@bad", error="boom")
+            return _result(handle=h, posts=[Post("hi", "2026-06-05T11:00:00+00:00", 0, 0, "https://x.com/good/status/1")])
+
+        monkeypatch.setattr(x_board, "fetch_handle", fake_fetch)
+        monkeypatch.setattr(x_board.webbrowser, "open", lambda url: None)
+        rc = main(["--file", str(follow), "--out", str(out), "--no-open"])
+        assert rc == 1
+        assert out.exists()
+
+    def test_missing_follow_file_returns_2(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        rc = main(["--file", str(tmp_path / "nope.txt"), "--out", str(tmp_path / "o.html"), "--no-open"])
+        assert rc == 2
+
+    def test_missing_cookies_returns_2(self, tmp_path, monkeypatch):
+        follow = self._setup_follow(tmp_path)
+
+        def boom(*a, **k):
+            raise XBoardError("No Twitter/X cookies found")
+
+        monkeypatch.setattr(x_board, "load_cookies", boom)
+        rc = main(["--file", str(follow), "--out", str(tmp_path / "o.html"), "--no-open"])
+        assert rc == 2
+
+    def test_empty_follow_file_returns_2(self, tmp_path, monkeypatch):
+        follow = tmp_path / "follow.txt"
+        follow.write_text("# only comments\n\n", encoding="utf-8")
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        rc = main(["--file", str(follow), "--out", str(tmp_path / "o.html"), "--no-open"])
+        assert rc == 2
+
+    def test_respects_count_argument(self, tmp_path, monkeypatch):
+        follow = self._setup_follow(tmp_path, handles=("OpenAI",))
+        out = tmp_path / "board.html"
+        seen = {}
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: "twitter")
+
+        def fake_fetch(h, count, env, **k):
+            seen["count"] = count
+            return _result(handle=h, posts=[])
+
+        monkeypatch.setattr(x_board, "fetch_handle", fake_fetch)
+        monkeypatch.setattr(x_board.webbrowser, "open", lambda url: None)
+        main(["--file", str(follow), "--out", str(out), "-n", "3", "--no-open"])
+        assert seen["count"] == 3
+
+
+class TestIntegration:
+    def test_end_to_end_with_mocked_subprocess(self, tmp_path, monkeypatch):
+        """No mocks on the filter/normalize/render chain — only the subprocess."""
+        follow = tmp_path / "follow.txt"
+        follow.write_text("OpenAI\nAnthropicAI\n", encoding="utf-8")
+        out = tmp_path / "board.html"
+
+        def fake_run(cmd, **kwargs):
+            # cmd is [exe, "user-posts", handle, "-n", N, "--json"]
+            handle = cmd[2]
+            items = [
+                _tweet(tid="1", text=f"{handle} original post", name=handle, screen=handle),
+                _tweet(tid="2", text="RT @x: a repost", isRetweet=True),
+            ]
+            return _FakeProc(stdout=__import__("json").dumps(_envelope(items)))
+
+        monkeypatch.setattr(x_board, "load_cookies", lambda *a, **k: ("a", "b"))
+        monkeypatch.setattr(x_board, "resolve_twitter_exe", lambda: "twitter")
+        monkeypatch.setattr(x_board.subprocess, "run", fake_run)
+        monkeypatch.setattr(x_board.webbrowser, "open", lambda url: None)
+
+        rc = main(["--file", str(follow), "--out", str(out), "--no-open"])
+        doc = out.read_text(encoding="utf-8")
+        assert rc == 0
+        assert "OpenAI original post" in doc
+        assert "AnthropicAI original post" in doc
+        assert "a repost" not in doc  # repost filtered out
+        assert "1 posts fetched" in doc


### PR DESCRIPTION
## Summary

Adds **X Board** — a standalone, read-only helper that reads a follow-list, fetches each handle's recent **original** X/Twitter posts via the installed `twitter-cli`, and writes a single self-contained HTML page (auto-opened in the browser) that both displays the posts and **proves the fetch worked**.

- `scripts/x_board.py` — the helper (stdlib-only rendering; no new runtime deps; no LLM).
- `scripts/follow.sample.txt` — example follow-list.
- `tests/test_x_board.py` + `tests/conftest.py` — 53 tests (parse, cookie-load, filter, normalize, fetch with mocked subprocess, relative-time, HTML render/escaping/badges, CLI `main`, integration).
- `docs/brainstorms/2026-06-05-x-board-requirements.md`, `docs/plans/2026-06-05-002-feat-x-board-html-viewer-plan.md` — origin docs.

## How it works

```
python scripts/x_board.py                 # default ~/.agent-reach/follow.txt, -n 10
python scripts/x_board.py --file ... -n 5 --out ... --no-open
```

- Cookies load from `~/.agent-reach/config.yaml` and pass via `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`, mirroring `scripts/verify_twitter.ps1`.
- Per-account "N posts fetched" badge + a top status bar (✅ all OK / ⚠ M of N) + fetch timestamp.
- Replies and reposts are filtered client-side so the board shows originals only.
- Per-handle failures (suspended / rate-limited / network / bad handle / empty) render as an isolated error card — the rest of the page still renders.

## Safety

- Read-only and side-effect-free except for writing the HTML output file. No write actions, no DB, no telemetry, no server.
- Does not modify Agent-Reach or upstream source — lives only under `scripts/`.
- **Credentials are never embedded in the output HTML** (R13) — verified by a render test that asserts no token leaks.

## Requirements

Implements R1–R13 from the linked plan. Exit codes: `0` all OK · `1` partial/all-failed (page still written) · `2` setup error (no cookies / missing-or-empty follow-list).

## Tests

`53 passed`, `ruff` clean (`tests/test_x_board.py`). The 3 pre-existing `test_skill_command.py` failures on Windows (cp1252 decode) are unrelated to this change.

## Notes for the reviewer

- **Stacked on #309.** This branch includes the setup commit from #309, so until #309 merges into `main` this PR's diff shows that commit too; afterwards it shows only the 3 X Board commits. If #309 is squash-merged, this branch will need a rebase.
- **Live successful-fetch wasn't verified in CI/sandbox** (network/SSL is blocked there). Please confirm a real fetch in your own shell: `python scripts/x_board.py` with cookies configured. Error-path, filtering, rendering, and credential-safety are fully covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
