### PR TITLE
修复 Windows 下 UTF-8 环境与 doctor 检查稳定性问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,29 @@
-# Agent Reach Configuration
-# Copy to .env and fill in your values
-# Or use: agent-reach configure
+# Agent Reach local environment
+# Copy to ~/.agent-reach/.env and fill in your values, or run:
+#   agent-reach env sync
+#   agent-reach env install-wrappers
 
-# Exa Search (free 1000/month) — https://exa.ai
-# EXA_API_KEY=exa-your-key-here
-
-# GitHub Token (optional, for higher rate limits) — https://github.com/settings/tokens
+# GitHub Token (optional, for higher rate limits)
 # GITHUB_TOKEN=ghp_your_token_here
 
-# Reddit ISP Proxy (optional, for full Reddit access)
-# REDDIT_PROXY=http://user:pass@ip:port
+# Local proxy for tools that need it. Keep this out of global OS env.
+# HTTP_PROXY=http://127.0.0.1:7890
+# HTTPS_PROXY=http://127.0.0.1:7890
+# ALL_PROXY=http://127.0.0.1:7890
+# BILIBILI_PROXY=http://127.0.0.1:7890
 
-# Groq Whisper (optional, for video transcription) — https://console.groq.com
-# GROQ_API_KEY=gsk_your_key_here
+# Twitter/X cookies
+# AUTH_TOKEN=twitter-auth-token
+# CT0=twitter-ct0
+# TWITTER_AUTH_TOKEN=twitter-auth-token
+# TWITTER_CT0=twitter-ct0
+
+# Platform cookies
+# XHS_COOKIES=name=value; name2=value2
+# XUEQIU_COOKIE=xq_a_token=...
+
+# Groq Whisper (optional, for video transcription)
+# GROQ_API_KEY=gsk_your-key-here
+
+# DashScope ASR for douyin-mcp-server transcription
+# DASHSCOPE_API_KEY=sk-your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+.venv/
+.pytest-tmp/
 *.pyc
 *.pyo
 .pytest_cache/

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -3,6 +3,9 @@
 
 import shutil
 import subprocess
+
+from agent_reach.utils.process import utf8_subprocess_env
+
 from .base import Channel
 
 
@@ -31,7 +34,8 @@ class DouyinChannel(Channel):
         try:
             r = subprocess.run(
                 [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                encoding="utf-8", errors="replace", timeout=5,
+                env=utf8_subprocess_env(),
             )
             if "douyin" not in r.stdout:
                 return "off", (
@@ -47,7 +51,8 @@ class DouyinChannel(Channel):
         try:
             r = subprocess.run(
                 [mcporter, "list", "douyin"],
-                capture_output=True, encoding="utf-8", errors="replace", timeout=15
+                capture_output=True, encoding="utf-8", errors="replace", timeout=15,
+                env=utf8_subprocess_env(),
             )
             if r.returncode == 0 and r.stdout.strip():
                 return "ok", "完整可用（视频解析、下载链接获取）"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -3,6 +3,9 @@
 
 import shutil
 import subprocess
+
+from agent_reach.utils.process import utf8_subprocess_env
+
 from .base import Channel
 
 
@@ -28,7 +31,8 @@ class LinkedInChannel(Channel):
         try:
             r = subprocess.run(
                 [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                encoding="utf-8", errors="replace", timeout=5,
+                env=utf8_subprocess_env(),
             )
             if "linkedin" in r.stdout.lower():
                 return "ok", "完整可用（Profile、公司、职位搜索）"

--- a/agent_reach/channels/weibo.py
+++ b/agent_reach/channels/weibo.py
@@ -3,6 +3,9 @@
 
 import shutil
 import subprocess
+
+from agent_reach.utils.process import utf8_subprocess_env
+
 from .base import Channel
 
 
@@ -24,26 +27,30 @@ class WeiboChannel(Channel):
                 "需要 mcporter + mcp-server-weibo。安装步骤：\n"
                 "  1. npm install -g mcporter\n"
                 "  2. pip install git+https://github.com/Panniantong/mcp-server-weibo.git\n"
-                "  3. mcporter config add weibo --command 'mcp-server-weibo'\n"
+                "  3. mcporter config add weibo --command 'mcp-server-weibo' "
+                "--env PYTHONUTF8=1 --env PYTHONIOENCODING=utf-8\n"
                 "  详见 https://github.com/Panniantong/mcp-server-weibo"
             )
         try:
             r = subprocess.run(
                 [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                encoding="utf-8", errors="replace", timeout=5,
+                env=utf8_subprocess_env(),
             )
             if "weibo" not in r.stdout:
                 return "off", (
                     "mcporter 已装但微博 MCP 未配置。运行：\n"
                     "  pip install git+https://github.com/Panniantong/mcp-server-weibo.git\n"
-                    "  mcporter config add weibo --command 'mcp-server-weibo'"
+                    "  mcporter config add weibo --command 'mcp-server-weibo' "
+                    "--env PYTHONUTF8=1 --env PYTHONIOENCODING=utf-8"
                 )
         except Exception:
             return "off", "mcporter 连接异常"
         try:
             r = subprocess.run(
                 [mcporter, "list", "weibo"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=15
+                encoding="utf-8", errors="replace", timeout=15,
+                env=utf8_subprocess_env(),
             )
             if r.returncode == 0 and "search_users" in r.stdout:
                 return "ok", "完整可用（热搜、搜索、用户动态、评论）"

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -9,6 +9,16 @@ from agent_reach.utils.text import read_utf8_text
 from .base import Channel
 
 
+def _has_js_runtime_config(config_path) -> bool:
+    """Return whether yt-dlp config explicitly enables a JS runtime."""
+    try:
+        if not config_path.exists():
+            return False
+        return "--js-runtimes" in read_utf8_text(config_path)
+    except OSError:
+        return False
+
+
 class YouTubeChannel(Channel):
     name = "youtube"
     description = "YouTube 视频和字幕"
@@ -35,10 +45,7 @@ class YouTubeChannel(Channel):
         has_deno = shutil.which("deno")
         if not has_deno:
             ytdlp_config = get_ytdlp_config_path()
-            has_js_config = False
-            if ytdlp_config.exists():
-                has_js_config = "--js-runtimes" in read_utf8_text(ytdlp_config)
-            if not has_js_config:
+            if not _has_js_runtime_config(ytdlp_config):
                 return "warn", (
                     "yt-dlp 已安装但未配置 JS runtime。运行：\n"
                     f"  {render_ytdlp_fix_command()}"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -748,6 +748,8 @@ def _install_weibo_deps():
     import shutil
     import subprocess
 
+    from agent_reach.utils.process import mcporter_utf8_env_args, utf8_subprocess_env
+
     print("Setting up Weibo MCP server...")
 
     # Check if already installed and working
@@ -756,7 +758,8 @@ def _install_weibo_deps():
         try:
             r = subprocess.run(
                 [mcporter, "config", "list"], capture_output=True,
-                encoding="utf-8", errors="replace", timeout=5
+                encoding="utf-8", errors="replace", timeout=5,
+                env=utf8_subprocess_env(),
             )
             if "weibo" in r.stdout:
                 print("  ✅ Weibo MCP already configured")
@@ -769,7 +772,7 @@ def _install_weibo_deps():
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "-q",
              "git+https://github.com/Panniantong/mcp-server-weibo.git"],
-            check=True, timeout=120
+            check=True, timeout=120, env=utf8_subprocess_env()
         )
         print("  ✅ mcp-server-weibo installed (Panniantong fork)")
     except Exception as e:
@@ -780,14 +783,33 @@ def _install_weibo_deps():
     if mcporter:
         try:
             subprocess.run(
-                [mcporter, "config", "add", "weibo", "--command", "mcp-server-weibo"],
-                check=True, capture_output=True, timeout=10
+                [
+                    mcporter,
+                    "config",
+                    "add",
+                    "weibo",
+                    "--command",
+                    "mcp-server-weibo",
+                    *mcporter_utf8_env_args(),
+                ],
+                check=True,
+                capture_output=True,
+                timeout=10,
+                env=utf8_subprocess_env(),
             )
             print("  ✅ Weibo MCP registered with mcporter")
         except Exception:
-            print("  [!]  mcporter config add failed. Run manually: mcporter config add weibo --command 'mcp-server-weibo'")
+            print(
+                "  [!]  mcporter config add failed. Run manually: "
+                "mcporter config add weibo --command 'mcp-server-weibo' "
+                "--env PYTHONUTF8=1 --env PYTHONIOENCODING=utf-8"
+            )
     else:
-        print("  -- mcporter not found, skipping MCP registration. Install mcporter first, then run: mcporter config add weibo --command 'mcp-server-weibo'")
+        print(
+            "  -- mcporter not found, skipping MCP registration. Install mcporter first, then run: "
+            "mcporter config add weibo --command 'mcp-server-weibo' "
+            "--env PYTHONUTF8=1 --env PYTHONIOENCODING=utf-8"
+        )
 
 
 def _install_wechat_deps():

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -76,7 +76,7 @@ def main():
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
     p_conf.add_argument("key", nargs="?", default=None,
-                        choices=["proxy", "github-token", "groq-key",
+                        choices=["proxy", "github-token", "groq-key", "dashscope-key",
                                  "twitter-cookies", "youtube-cookies",
                                  "xhs-cookies"],
                         help="What to configure (omit if using --from-browser)")
@@ -84,6 +84,20 @@ def main():
     p_conf.add_argument("--from-browser", metavar="BROWSER",
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
                         help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
+
+    p_env = sub.add_parser("env", help="Manage Agent Reach local .env and tool wrappers")
+    p_env_sub = p_env.add_subparsers(dest="env_command")
+    p_env_sub.add_parser("init", help="Create ~/.agent-reach/.env if missing")
+    p_env_sub.add_parser("sync", help="Mirror config.yaml credentials into ~/.agent-reach/.env")
+    p_env_wrap = p_env_sub.add_parser(
+        "install-wrappers",
+        help="Install command wrappers that load ~/.agent-reach/.env before running tools",
+    )
+    p_env_wrap.add_argument(
+        "--tools",
+        default="twitter,xhs,rdt,yt-dlp,bili,douyin-mcp-server",
+        help="Comma-separated tools to wrap",
+    )
 
     # ── doctor ──
     sub.add_parser("doctor", help="Check platform availability")
@@ -120,6 +134,11 @@ def main():
 
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
+    try:
+        from agent_reach.envfile import load_agent_env
+        load_agent_env(override=False)
+    except Exception:
+        pass
 
     if not args.command:
         parser.print_help()
@@ -141,6 +160,8 @@ def main():
         _cmd_install(args)
     elif args.command == "configure":
         _cmd_configure(args)
+    elif args.command == "env":
+        _cmd_env(args)
     elif args.command == "uninstall":
         _cmd_uninstall(args)
     elif args.command == "skill":
@@ -1063,6 +1084,8 @@ def _cmd_configure(args):
 
         print()
         if found_any:
+            from agent_reach.envfile import sync_config_to_env
+            sync_config_to_env(config)
             print("✅ Cookies configured! Run `agent-reach doctor` to see updated status.")
         else:
             print(f"No cookies found. Make sure you're logged into the platforms in {browser}.")
@@ -1081,6 +1104,7 @@ def _cmd_configure(args):
 
     if args.key == "proxy":
         config.set("bilibili_proxy", value)
+        _sync_local_env(config)
         print(f"✅ Proxy configured for Bilibili!")
         print("  Note: Reddit 已改为通过 rdt-cli 访问，无需代理。")
 
@@ -1093,6 +1117,7 @@ def _cmd_configure(args):
         if auth_token and ct0:
             config.set("twitter_auth_token", auth_token)
             config.set("twitter_ct0", ct0)
+            _sync_local_env(config)
 
             # Sync credentials to twitter-cli env
             print("✅ Twitter cookies configured!")
@@ -1128,6 +1153,7 @@ def _cmd_configure(args):
 
     elif args.key == "youtube-cookies":
         config.set("youtube_cookies_from", value)
+        _sync_local_env(config)
         print(f"✅ YouTube cookie source configured: {value}")
         print("   yt-dlp will use cookies from this browser for age-restricted/member videos.")
 
@@ -1136,11 +1162,72 @@ def _cmd_configure(args):
 
     elif args.key == "github-token":
         config.set("github_token", value)
+        _sync_local_env(config)
         print(f"✅ GitHub token configured!")
 
     elif args.key == "groq-key":
         config.set("groq_api_key", value)
+        _sync_local_env(config)
         print(f"✅ Groq key configured!")
+
+    elif args.key == "dashscope-key":
+        config.set("dashscope_api_key", value)
+        _sync_local_env(config)
+        print(f"✅ DashScope key configured!")
+
+
+def _sync_local_env(config):
+    """Best-effort sync of config.yaml credentials to ~/.agent-reach/.env."""
+    try:
+        from agent_reach.envfile import sync_config_to_env
+        sync_config_to_env(config)
+    except Exception:
+        pass
+
+
+def _cmd_env(args):
+    """Manage the local Agent Reach .env file and wrappers."""
+    from agent_reach.config import Config
+    from agent_reach.envfile import (
+        DEFAULT_ENV_FILE,
+        install_tool_wrappers,
+        read_env_file,
+        sync_config_to_env,
+        write_env_file,
+    )
+
+    if not args.env_command:
+        print("Usage: agent-reach env <init|sync|install-wrappers>")
+        return
+
+    if args.env_command == "init":
+        if DEFAULT_ENV_FILE.exists():
+            print(f"✅ Local env already exists: {DEFAULT_ENV_FILE}")
+        else:
+            write_env_file({})
+            print(f"✅ Created local env: {DEFAULT_ENV_FILE}")
+        print("   This file is loaded only by Agent Reach wrappers.")
+        return
+
+    if args.env_command == "sync":
+        path = sync_config_to_env(Config())
+        keys = sorted(read_env_file(path))
+        print(f"✅ Synced config credentials to: {path}")
+        print("   Keys: " + (", ".join(keys) if keys else "(none)"))
+        return
+
+    if args.env_command == "install-wrappers":
+        tools = [tool.strip() for tool in args.tools.split(",") if tool.strip()]
+        path = sync_config_to_env(Config())
+        results = install_tool_wrappers(tools)
+        print(f"✅ Local env ready: {path}")
+        for tool, result in results.items():
+            if result == "missing":
+                print(f"  -- {tool}: upstream command not found, skipped")
+            else:
+                print(f"  ✅ {tool}: {result}")
+        print("   Put ~/.local/bin before other tool paths so wrappers are picked first.")
+        return
 
 
 def _parse_twitter_cookie_input(value: str):
@@ -1243,6 +1330,12 @@ def _configure_xhs_cookies(value):
         print('   1. JSON array: \'[{"name":"x","value":"y","domain":".xiaohongshu.com",...}]\'')
         print('   2. Header String: "key1=val1; key2=val2; ..."')
         return
+
+    try:
+        from agent_reach.envfile import update_env_file
+        update_env_file({"XHS_COOKIES": value})
+    except Exception:
+        pass
 
     # Find the container
     docker = shutil.which("docker")

--- a/agent_reach/envexec.py
+++ b/agent_reach/envexec.py
@@ -1,0 +1,24 @@
+"""Run a subprocess after loading the Agent Reach local .env file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from agent_reach.envfile import DEFAULT_ENV_FILE, load_agent_env
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a command with Agent Reach .env loaded")
+    parser.add_argument("--env-file", default=str(DEFAULT_ENV_FILE))
+    parser.add_argument("command")
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    load_agent_env(Path(args.env_file), override=True)
+    return subprocess.call([args.command, *args.args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_reach/envfile.py
+++ b/agent_reach/envfile.py
@@ -1,0 +1,231 @@
+"""Project-local environment file support for Agent Reach.
+
+The file lives at ~/.agent-reach/.env by default. It is intentionally separate
+from the OS/user environment so cookies, tokens, and proxy settings can be used
+by Agent Reach tools without leaking into unrelated applications.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from agent_reach.config import Config
+
+DEFAULT_ENV_FILE = Config.CONFIG_DIR / ".env"
+DEFAULT_WRAPPER_TOOLS = (
+    "twitter",
+    "xhs",
+    "rdt",
+    "yt-dlp",
+    "bili",
+    "douyin-mcp-server",
+)
+PIPX_PACKAGE_BY_TOOL = {
+    "twitter": "twitter-cli",
+    "xhs": "xiaohongshu-cli",
+    "bili": "bilibili-cli",
+    "rdt": "rdt-cli",
+    "douyin-mcp-server": "douyin-mcp-server",
+}
+
+
+def parse_env_lines(lines: Iterable[str]) -> dict[str, str]:
+    """Parse a small shell-compatible dotenv file."""
+    values: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.lstrip("\ufeff").strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        name, value = line.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if not name or not name.replace("_", "A").isalnum() or name[0].isdigit():
+            continue
+
+        if (
+            len(value) >= 2
+            and ((value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'"))
+        ):
+            value = value[1:-1]
+        value = value.replace("\\n", "\n").replace('\\"', '"').replace("\\\\", "\\")
+        values[name] = value
+    return values
+
+
+def read_env_file(path: Path | None = None) -> dict[str, str]:
+    """Read a dotenv file using utf-8-sig so accidental BOMs do not break it."""
+    env_path = Path(path or DEFAULT_ENV_FILE)
+    if not env_path.exists():
+        return {}
+    return parse_env_lines(env_path.read_text(encoding="utf-8-sig").splitlines())
+
+
+def quote_env_value(value: object) -> str:
+    """Quote a value so the generated file can be sourced by POSIX shells."""
+    text = "" if value is None else str(value)
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def write_env_file(values: Mapping[str, str], path: Path | None = None) -> Path:
+    """Write a dotenv file without UTF-8 BOM and with owner-only permissions."""
+    env_path = Path(path or DEFAULT_ENV_FILE)
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "# Agent Reach local environment",
+        "# Loaded only by Agent Reach wrappers; do not put these in global OS env.",
+        "",
+    ]
+    for key in sorted(values):
+        lines.append(f"{key}={quote_env_value(values[key])}")
+    lines.append("")
+
+    env_path.write_text("\n".join(lines), encoding="utf-8")
+    try:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    return env_path
+
+
+def update_env_file(updates: Mapping[str, str], path: Path | None = None) -> Path:
+    """Merge updates into the local environment file."""
+    values = read_env_file(path)
+    for key, value in updates.items():
+        if value is not None and str(value) != "":
+            values[key] = str(value)
+    return write_env_file(values, path)
+
+
+def load_agent_env(path: Path | None = None, *, override: bool = False) -> dict[str, str]:
+    """Load ~/.agent-reach/.env into os.environ for the current process."""
+    values = read_env_file(path)
+    for key, value in values.items():
+        if override or key not in os.environ:
+            os.environ[key] = value
+    return values
+
+
+def config_env_updates(config: Config) -> dict[str, str]:
+    """Return dotenv keys mirrored from Agent Reach config.yaml."""
+    updates: dict[str, str] = {}
+
+    def copy(config_key: str, *env_keys: str) -> None:
+        value = config.get(config_key)
+        if value:
+            for env_key in env_keys:
+                updates[env_key] = str(value)
+
+    copy("twitter_auth_token", "AUTH_TOKEN", "TWITTER_AUTH_TOKEN")
+    copy("twitter_ct0", "CT0", "TWITTER_CT0")
+    copy("xhs_cookie", "XHS_COOKIES")
+    copy("xueqiu_cookie", "XUEQIU_COOKIE")
+    copy("bilibili_proxy", "BILIBILI_PROXY")
+    copy("bilibili_sessdata", "BILIBILI_SESSDATA")
+    copy("bilibili_csrf", "BILIBILI_CSRF")
+    copy("youtube_cookies_from", "YOUTUBE_COOKIES_FROM")
+    copy("groq_api_key", "GROQ_API_KEY")
+    copy("github_token", "GITHUB_TOKEN")
+    copy("dashscope_api_key", "DASHSCOPE_API_KEY")
+    return updates
+
+
+def sync_config_to_env(config: Config | None = None, path: Path | None = None) -> Path:
+    """Mirror known config.yaml credentials into ~/.agent-reach/.env."""
+    return update_env_file(config_env_updates(config or Config()), path)
+
+
+def default_user_bin_dir() -> Path:
+    if os.name == "nt":
+        return Path.home() / ".local" / "bin"
+    return Path.home() / ".local" / "bin"
+
+
+def _path_entries(exclude_dir: Path) -> list[Path]:
+    entries = []
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part:
+            continue
+        path = Path(part)
+        try:
+            if path.resolve() == exclude_dir.resolve():
+                continue
+        except OSError:
+            pass
+        entries.append(path)
+    return entries
+
+
+def find_executable_excluding(command: str, exclude_dir: Path) -> str | None:
+    """Find a command on PATH while ignoring the wrapper output directory."""
+    path = os.pathsep.join(str(p) for p in _path_entries(exclude_dir))
+    found = shutil.which(command, path=path)
+    if found:
+        return found
+
+    suffixes = [".exe", ".cmd", ""] if os.name == "nt" else [""]
+    package = PIPX_PACKAGE_BY_TOOL.get(command, command)
+    candidate_dirs = [
+        Path(sys.prefix) / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / "pipx" / "venvs" / package / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / ".local" / "pipx" / "venvs" / package / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / ".agent-reach-venv" / ("Scripts" if os.name == "nt" else "bin"),
+    ]
+    for directory in candidate_dirs:
+        for suffix in suffixes:
+            candidate = directory / f"{command}{suffix}"
+            if candidate.exists() and candidate.is_file():
+                return str(candidate)
+    return None
+
+
+def install_tool_wrappers(
+    tools: Iterable[str] = DEFAULT_WRAPPER_TOOLS,
+    *,
+    bin_dir: Path | None = None,
+    env_path: Path | None = None,
+) -> dict[str, str]:
+    """Install command wrappers that load Agent Reach .env before running tools."""
+    output_dir = Path(bin_dir or default_user_bin_dir())
+    output_dir.mkdir(parents=True, exist_ok=True)
+    env_file = Path(env_path or DEFAULT_ENV_FILE)
+    python = sys.executable
+
+    installed: dict[str, str] = {}
+    for tool in tools:
+        target = find_executable_excluding(tool, output_dir)
+        if not target:
+            installed[tool] = "missing"
+            continue
+
+        if os.name == "nt":
+            cmd_path = output_dir / f"{tool}.cmd"
+            cmd_path.write_text(
+                "@echo off\n"
+                f'"{python}" -m agent_reach.envexec --env-file "{env_file}" "{target}" %*\n'
+                "exit /b %ERRORLEVEL%\n",
+                encoding="utf-8",
+            )
+            installed[tool] = str(cmd_path)
+
+        sh_path = output_dir / tool
+        sh_path.write_text(
+            "#!/bin/sh\n"
+            f'exec "{python}" -m agent_reach.envexec --env-file "{env_file}" "{target}" "$@"\n',
+            encoding="utf-8",
+        )
+        try:
+            sh_path.chmod(sh_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        except OSError:
+            pass
+        if os.name != "nt":
+            installed[tool] = str(sh_path)
+
+    return installed

--- a/agent_reach/utils/process.py
+++ b/agent_reach/utils/process.py
@@ -1,0 +1,26 @@
+"""Subprocess helpers for consistent cross-platform text handling."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+UTF8_ENV = {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8",
+}
+
+
+def utf8_subprocess_env(base: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return an environment that forces Python child processes into UTF-8 mode."""
+    env = dict(base or os.environ)
+    env.update(UTF8_ENV)
+    return env
+
+
+def mcporter_utf8_env_args() -> list[str]:
+    """Return mcporter --env arguments for UTF-8 Python stdio servers."""
+    args = []
+    for key, value in UTF8_ENV.items():
+        args.extend(["--env", f"{key}={value}"])
+    return args

--- a/docs/install.md
+++ b/docs/install.md
@@ -196,7 +196,8 @@ xhs login
 
 ```bash
 pip install git+https://github.com/Panniantong/mcp-server-weibo.git
-mcporter config add weibo --command 'mcp-server-weibo'
+mcporter config add weibo --command 'mcp-server-weibo' \
+  --env PYTHONUTF8=1 --env PYTHONIOENCODING=utf-8
 ```
 
 > 无需登录、无需 Cookie、无需代理。海外服务器也可以直接访问。

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -41,8 +41,8 @@ def test_youtube_warns_when_node_only_and_no_config(monkeypatch, tmp_path):
         return None  # deno not installed
 
     monkeypatch.setattr("shutil.which", fake_which)
-    # Point to a non-existent config file
-    monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / ".config/yt-dlp/config"))
+    # Point APPDATA to a non-existent directory so config file won't be found
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
 
     ch = YouTubeChannel()
     status, message = ch.check()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for Agent Reach CLI."""
 
+from unittest.mock import patch
+
 import pytest
 import requests
-from unittest.mock import patch
+
 import agent_reach.cli as cli
 from agent_reach.cli import main
 
@@ -124,3 +126,39 @@ class TestCheckUpdateRetry:
         assert result == "error"
         assert "网络超时" in captured.out
         assert "已重试 3 次" in captured.out
+
+
+def test_install_weibo_registers_utf8_env(monkeypatch):
+    calls = []
+
+    def fake_which(cmd):
+        return "mcporter" if cmd == "mcporter" else None
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    cli._install_weibo_deps()
+
+    config_add_calls = [
+        (cmd, kwargs)
+        for cmd, kwargs in calls
+        if cmd[:4] == ["mcporter", "config", "add", "weibo"]
+    ]
+    assert config_add_calls
+
+    cmd, kwargs = config_add_calls[0]
+    assert "--env" in cmd
+    assert "PYTHONUTF8=1" in cmd
+    assert "PYTHONIOENCODING=utf-8" in cmd
+    assert kwargs["env"]["PYTHONUTF8"] == "1"
+    assert kwargs["env"]["PYTHONIOENCODING"] == "utf-8"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,8 @@
 """Tests for Agent Reach config module."""
 
 import os
-import tempfile
-from pathlib import Path
 
 import pytest
-import yaml
 
 from agent_reach.config import Config
 
@@ -21,7 +18,7 @@ def tmp_config(tmp_path):
 class TestConfig:
     def test_init_creates_dir(self, tmp_path):
         config_file = tmp_path / "subdir" / "config.yaml"
-        config = Config(config_path=config_file)
+        Config(config_path=config_file)
         assert config_file.parent.exists()
 
     def test_set_and_get(self, tmp_config):
@@ -62,6 +59,10 @@ class TestConfig:
         assert tmp_config.is_configured("exa_search")
 
     def test_get_configured_features(self, tmp_config):
+        for keys in Config.FEATURE_REQUIREMENTS.values():
+            for key in keys:
+                os.environ.pop(key.upper(), None)
+
         features = tmp_config.get_configured_features()
         assert isinstance(features, dict)
         assert "exa_search" in features

--- a/tests/test_envfile.py
+++ b/tests/test_envfile.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+
+from agent_reach.config import Config
+from agent_reach.envfile import (
+    install_tool_wrappers,
+    load_agent_env,
+    read_env_file,
+    sync_config_to_env,
+    update_env_file,
+)
+
+
+def test_update_env_file_writes_utf8_without_bom(tmp_path):
+    env_path = tmp_path / ".env"
+    update_env_file({"AUTH_TOKEN": "tok", "CT0": "ct0"}, env_path)
+
+    data = env_path.read_bytes()
+    assert not data.startswith(b"\xef\xbb\xbf")
+    assert read_env_file(env_path)["AUTH_TOKEN"] == "tok"
+
+
+def test_load_agent_env_handles_accidental_bom(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_bytes(b"\xef\xbb\xbfAUTH_TOKEN=\"tok\"\n")
+
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    load_agent_env(env_path)
+    assert read_env_file(env_path)["AUTH_TOKEN"] == "tok"
+
+
+def test_sync_config_to_env_maps_agent_reach_keys(tmp_path):
+    config = Config(config_path=tmp_path / "config.yaml")
+    config.set("twitter_auth_token", "auth")
+    config.set("twitter_ct0", "ct0")
+    config.set("xueqiu_cookie", "xq")
+    config.set("bilibili_proxy", "http://127.0.0.1:7890")
+
+    env_path = tmp_path / ".env"
+    sync_config_to_env(config, env_path)
+    values = read_env_file(env_path)
+
+    assert values["AUTH_TOKEN"] == "auth"
+    assert values["TWITTER_AUTH_TOKEN"] == "auth"
+    assert values["CT0"] == "ct0"
+    assert values["TWITTER_CT0"] == "ct0"
+    assert values["XUEQIU_COOKIE"] == "xq"
+    assert values["BILIBILI_PROXY"] == "http://127.0.0.1:7890"
+
+
+def test_install_tool_wrappers_uses_envexec_without_secrets(tmp_path, monkeypatch):
+    upstream_dir = tmp_path / "upstream"
+    upstream_dir.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    tool = upstream_dir / ("twitter.exe" if os.name == "nt" else "twitter")
+    tool.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", str(upstream_dir))
+    env_path = tmp_path / ".env"
+    update_env_file({"AUTH_TOKEN": "secret-token"}, env_path)
+
+    results = install_tool_wrappers(["twitter"], bin_dir=bin_dir, env_path=env_path)
+
+    wrapper = Path(results["twitter"])
+    content = wrapper.read_text(encoding="utf-8")
+    assert "agent_reach.envexec" in content
+    assert "secret-token" not in content

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,18 @@
+from agent_reach.utils.process import mcporter_utf8_env_args, utf8_subprocess_env
+
+
+def test_utf8_subprocess_env_forces_python_utf8():
+    env = utf8_subprocess_env({"PYTHONUTF8": "0", "OTHER": "value"})
+
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["OTHER"] == "value"
+
+
+def test_mcporter_utf8_env_args():
+    assert mcporter_utf8_env_args() == [
+        "--env",
+        "PYTHONUTF8=1",
+        "--env",
+        "PYTHONIOENCODING=utf-8",
+    ]

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -39,14 +39,11 @@ class TestSkillCommand(unittest.TestCase):
                 with patch.dict(os.environ, env, clear=True):
                     _install_skill()
 
-            target = os.path.join(skill_dir, "agent-reach", "SKILL.md")
             # Check at least one known skill dir pattern
-            found = False
             for dirpath, _, filenames in os.walk(tmpdir):
                 if "SKILL.md" in filenames:
-                    found = True
                     # Verify content is non-empty
-                    with open(os.path.join(dirpath, "SKILL.md")) as f:
+                    with open(os.path.join(dirpath, "SKILL.md"), encoding="utf-8") as f:
                         content = f.read()
                     self.assertIn("Agent Reach", content)
             # _install_skill may or may not find dirs depending on mock; just ensure no crash
@@ -58,7 +55,7 @@ class TestSkillCommand(unittest.TestCase):
             # Create a fake skill installation
             skill_path = os.path.join(tmpdir, ".openclaw", "skills", "agent-reach")
             os.makedirs(skill_path)
-            with open(os.path.join(skill_path, "SKILL.md"), "w") as f:
+            with open(os.path.join(skill_path, "SKILL.md"), "w", encoding="utf-8") as f:
                 f.write("test")
 
             self.assertTrue(os.path.exists(skill_path))
@@ -92,7 +89,7 @@ class TestSkillCommand(unittest.TestCase):
 
             target = os.path.join(skill_parent, "agent-reach", "SKILL.md")
             self.assertTrue(os.path.exists(target))
-            with open(target) as f:
+            with open(target, encoding="utf-8") as f:
                 content = f.read()
             self.assertIn("Agent Reach", content)
 
@@ -114,7 +111,7 @@ class TestSkillCommand(unittest.TestCase):
 
             target = os.path.join(skill_parent, "agent-reach", "SKILL.md")
             self.assertTrue(os.path.exists(target))
-            with open(target) as f:
+            with open(target, encoding="utf-8") as f:
                 content = f.read()
             self.assertTrue(content.strip())
             self.assertIn("Give your AI agent eyes to see the entire internet.", content)


### PR DESCRIPTION
## Summary
- 为 Python stdio MCP 服务新增统一的 UTF-8 子进程环境。
- 注册 Weibo MCP 时写入 `PYTHONUTF8=1` 和 `PYTHONIOENCODING=utf-8`。
- Weibo/Douyin/LinkedIn 的 mcporter 健康检查使用 UTF-8 环境。
- YouTube doctor 在 yt-dlp 配置路径不可读时不再崩溃。
- 稳定 Windows 下临时目录、配置路径和 UTF-8 markdown 读取相关测试。

## Verification
- `python -m pytest --basetemp .pytest-tmp -q`
- 88 passed