### PR TITLE
fix: remove duplicate guides force-include causing wheel build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ build-backend = "hatchling.build"
 packages = ["agent_reach"]
 
 [tool.hatch.build.targets.wheel.force-include]
-"agent_reach/guides" = "agent_reach/guides"
 # Keep the whole skill directory so SKILL.md, SKILL_en.md, and references/ ship together.
 "agent_reach/skill" = "agent_reach/skill"
 "agent_reach/scripts" = "agent_reach/scripts"


### PR DESCRIPTION
## Problem

`pip install git+https://github.com/Panniantong/Agent-Reach.git` fails with:

```
ValueError: A second file is being added to the wheel archive at the same path: `agent_reach/guides/setup-exa.md`.
```

## Root Cause

In `pyproject.toml`, the wheel config has `packages = ["agent_reach"]` which already includes everything under `agent_reach/`. The `force-include` directive for `"agent_reach/guides" = "agent_reach/guides"` causes every file in the guides directory to be added twice to the wheel.

## Fix

Removed the duplicate `force-include` entry for `agent_reach/guides`. The guides are still included in the wheel because the `packages` directive already captures them.

## Verification

After this fix, `pip install -e .` completes successfully.