### PR TITLE
[codex] Add local env wrappers for agent tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,29 @@
-# Agent Reach Configuration
-# Copy to .env and fill in your values
-# Or use: agent-reach configure
+# Agent Reach local environment
+# Copy to ~/.agent-reach/.env and fill in your values, or run:
+#   agent-reach env sync
+#   agent-reach env install-wrappers
 
-# Exa Search (free 1000/month) — https://exa.ai
-# EXA_API_KEY=exa-your-key-here
-
-# GitHub Token (optional, for higher rate limits) — https://github.com/settings/tokens
+# GitHub Token (optional, for higher rate limits)
 # GITHUB_TOKEN=ghp_your_token_here
 
-# Reddit ISP Proxy (optional, for full Reddit access)
-# REDDIT_PROXY=http://user:pass@ip:port
+# Local proxy for tools that need it. Keep this out of global OS env.
+# HTTP_PROXY=http://127.0.0.1:7890
+# HTTPS_PROXY=http://127.0.0.1:7890
+# ALL_PROXY=http://127.0.0.1:7890
+# BILIBILI_PROXY=http://127.0.0.1:7890
 
-# Groq Whisper (optional, for video transcription) — https://console.groq.com
-# GROQ_API_KEY=gsk_your_key_here
+# Twitter/X cookies
+# AUTH_TOKEN=twitter-auth-token
+# CT0=twitter-ct0
+# TWITTER_AUTH_TOKEN=twitter-auth-token
+# TWITTER_CT0=twitter-ct0
+
+# Platform cookies
+# XHS_COOKIES=name=value; name2=value2
+# XUEQIU_COOKIE=xq_a_token=...
+
+# Groq Whisper (optional, for video transcription)
+# GROQ_API_KEY=gsk_your-key-here
+
+# DashScope ASR for douyin-mcp-server transcription
+# DASHSCOPE_API_KEY=sk-your-key-here

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -76,7 +76,7 @@ def main():
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
     p_conf.add_argument("key", nargs="?", default=None,
-                        choices=["proxy", "github-token", "groq-key",
+                        choices=["proxy", "github-token", "groq-key", "dashscope-key",
                                  "twitter-cookies", "youtube-cookies",
                                  "xhs-cookies"],
                         help="What to configure (omit if using --from-browser)")
@@ -84,6 +84,20 @@ def main():
     p_conf.add_argument("--from-browser", metavar="BROWSER",
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
                         help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
+
+    p_env = sub.add_parser("env", help="Manage Agent Reach local .env and tool wrappers")
+    p_env_sub = p_env.add_subparsers(dest="env_command")
+    p_env_sub.add_parser("init", help="Create ~/.agent-reach/.env if missing")
+    p_env_sub.add_parser("sync", help="Mirror config.yaml credentials into ~/.agent-reach/.env")
+    p_env_wrap = p_env_sub.add_parser(
+        "install-wrappers",
+        help="Install command wrappers that load ~/.agent-reach/.env before running tools",
+    )
+    p_env_wrap.add_argument(
+        "--tools",
+        default="twitter,xhs,rdt,yt-dlp,bili,douyin-mcp-server",
+        help="Comma-separated tools to wrap",
+    )
 
     # ── doctor ──
     sub.add_parser("doctor", help="Check platform availability")
@@ -120,6 +134,12 @@ def main():
 
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        try:
+            from agent_reach.envfile import load_agent_env
+            load_agent_env(override=False)
+        except Exception:
+            pass
 
     if not args.command:
         parser.print_help()
@@ -141,6 +161,8 @@ def main():
         _cmd_install(args)
     elif args.command == "configure":
         _cmd_configure(args)
+    elif args.command == "env":
+        _cmd_env(args)
     elif args.command == "uninstall":
         _cmd_uninstall(args)
     elif args.command == "skill":
@@ -1041,6 +1063,8 @@ def _cmd_configure(args):
 
         print()
         if found_any:
+            from agent_reach.envfile import sync_config_to_env
+            sync_config_to_env(config)
             print("✅ Cookies configured! Run `agent-reach doctor` to see updated status.")
         else:
             print(f"No cookies found. Make sure you're logged into the platforms in {browser}.")
@@ -1059,6 +1083,7 @@ def _cmd_configure(args):
 
     if args.key == "proxy":
         config.set("bilibili_proxy", value)
+        _sync_local_env(config)
         print(f"✅ Proxy configured for Bilibili!")
         print("  Note: Reddit 已改为通过 rdt-cli 访问，无需代理。")
 
@@ -1071,6 +1096,7 @@ def _cmd_configure(args):
         if auth_token and ct0:
             config.set("twitter_auth_token", auth_token)
             config.set("twitter_ct0", ct0)
+            _sync_local_env(config)
 
             # Sync credentials to twitter-cli env
             print("✅ Twitter cookies configured!")
@@ -1106,6 +1132,7 @@ def _cmd_configure(args):
 
     elif args.key == "youtube-cookies":
         config.set("youtube_cookies_from", value)
+        _sync_local_env(config)
         print(f"✅ YouTube cookie source configured: {value}")
         print("   yt-dlp will use cookies from this browser for age-restricted/member videos.")
 
@@ -1114,11 +1141,72 @@ def _cmd_configure(args):
 
     elif args.key == "github-token":
         config.set("github_token", value)
+        _sync_local_env(config)
         print(f"✅ GitHub token configured!")
 
     elif args.key == "groq-key":
         config.set("groq_api_key", value)
+        _sync_local_env(config)
         print(f"✅ Groq key configured!")
+
+    elif args.key == "dashscope-key":
+        config.set("dashscope_api_key", value)
+        _sync_local_env(config)
+        print(f"✅ DashScope key configured!")
+
+
+def _sync_local_env(config):
+    """Best-effort sync of config.yaml credentials to ~/.agent-reach/.env."""
+    try:
+        from agent_reach.envfile import sync_config_to_env
+        sync_config_to_env(config)
+    except Exception:
+        pass
+
+
+def _cmd_env(args):
+    """Manage the local Agent Reach .env file and wrappers."""
+    from agent_reach.config import Config
+    from agent_reach.envfile import (
+        DEFAULT_ENV_FILE,
+        install_tool_wrappers,
+        read_env_file,
+        sync_config_to_env,
+        write_env_file,
+    )
+
+    if not args.env_command:
+        print("Usage: agent-reach env <init|sync|install-wrappers>")
+        return
+
+    if args.env_command == "init":
+        if DEFAULT_ENV_FILE.exists():
+            print(f"✅ Local env already exists: {DEFAULT_ENV_FILE}")
+        else:
+            write_env_file({})
+            print(f"✅ Created local env: {DEFAULT_ENV_FILE}")
+        print("   This file is loaded only by Agent Reach wrappers.")
+        return
+
+    if args.env_command == "sync":
+        path = sync_config_to_env(Config())
+        keys = sorted(read_env_file(path))
+        print(f"✅ Synced config credentials to: {path}")
+        print("   Keys: " + (", ".join(keys) if keys else "(none)"))
+        return
+
+    if args.env_command == "install-wrappers":
+        tools = [tool.strip() for tool in args.tools.split(",") if tool.strip()]
+        path = sync_config_to_env(Config())
+        results = install_tool_wrappers(tools)
+        print(f"✅ Local env ready: {path}")
+        for tool, result in results.items():
+            if result == "missing":
+                print(f"  -- {tool}: upstream command not found, skipped")
+            else:
+                print(f"  ✅ {tool}: {result}")
+        print("   Put ~/.local/bin before other tool paths so wrappers are picked first.")
+        return
 
 
 def _parse_twitter_cookie_input(value: str):
@@ -1221,6 +1309,12 @@ def _configure_xhs_cookies(value):
         print('   1. JSON array: \'[{"name":"x","value":"y","domain":".xiaohongshu.com",...}]\'')
         print('   2. Header String: "key1=val1; key2=val2; ..."')
         return
+
+    try:
+        from agent_reach.envfile import update_env_file
+        update_env_file({"XHS_COOKIES": value})
+    except Exception:
+        pass
 
     # Find the container
     docker = shutil.which("docker")

--- a/agent_reach/envexec.py
+++ b/agent_reach/envexec.py
@@ -1,0 +1,24 @@
+"""Run a subprocess after loading the Agent Reach local .env file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from agent_reach.envfile import DEFAULT_ENV_FILE, load_agent_env
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a command with Agent Reach .env loaded")
+    parser.add_argument("--env-file", default=str(DEFAULT_ENV_FILE))
+    parser.add_argument("command")
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    load_agent_env(Path(args.env_file), override=True)
+    return subprocess.call([args.command, *args.args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_reach/envfile.py
+++ b/agent_reach/envfile.py
@@ -1,0 +1,231 @@
+"""Project-local environment file support for Agent Reach.
+
+The file lives at ~/.agent-reach/.env by default. It is intentionally separate
+from the OS/user environment so cookies, tokens, and proxy settings can be used
+by Agent Reach tools without leaking into unrelated applications.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from agent_reach.config import Config
+
+DEFAULT_ENV_FILE = Config.CONFIG_DIR / ".env"
+DEFAULT_WRAPPER_TOOLS = (
+    "twitter",
+    "xhs",
+    "rdt",
+    "yt-dlp",
+    "bili",
+    "douyin-mcp-server",
+)
+PIPX_PACKAGE_BY_TOOL = {
+    "twitter": "twitter-cli",
+    "xhs": "xiaohongshu-cli",
+    "bili": "bilibili-cli",
+    "rdt": "rdt-cli",
+    "douyin-mcp-server": "douyin-mcp-server",
+}
+
+
+def parse_env_lines(lines: Iterable[str]) -> dict[str, str]:
+    """Parse a small shell-compatible dotenv file."""
+    values: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.lstrip("\ufeff").strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        name, value = line.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if not name or not name.replace("_", "A").isalnum() or name[0].isdigit():
+            continue
+
+        if (
+            len(value) >= 2
+            and ((value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'"))
+        ):
+            value = value[1:-1]
+        value = value.replace("\\n", "\n").replace('\\"', '"').replace("\\\\", "\\")
+        values[name] = value
+    return values
+
+
+def read_env_file(path: Path | None = None) -> dict[str, str]:
+    """Read a dotenv file using utf-8-sig so accidental BOMs do not break it."""
+    env_path = Path(path or DEFAULT_ENV_FILE)
+    if not env_path.exists():
+        return {}
+    return parse_env_lines(env_path.read_text(encoding="utf-8-sig").splitlines())
+
+
+def quote_env_value(value: object) -> str:
+    """Quote a value so the generated file can be sourced by POSIX shells."""
+    text = "" if value is None else str(value)
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{escaped}"'
+
+
+def write_env_file(values: Mapping[str, str], path: Path | None = None) -> Path:
+    """Write a dotenv file without UTF-8 BOM and with owner-only permissions."""
+    env_path = Path(path or DEFAULT_ENV_FILE)
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "# Agent Reach local environment",
+        "# Loaded only by Agent Reach wrappers; do not put these in global OS env.",
+        "",
+    ]
+    for key in sorted(values):
+        lines.append(f"{key}={quote_env_value(values[key])}")
+    lines.append("")
+
+    env_path.write_text("\n".join(lines), encoding="utf-8")
+    try:
+        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+    return env_path
+
+
+def update_env_file(updates: Mapping[str, str], path: Path | None = None) -> Path:
+    """Merge updates into the local environment file."""
+    values = read_env_file(path)
+    for key, value in updates.items():
+        if value is not None and str(value) != "":
+            values[key] = str(value)
+    return write_env_file(values, path)
+
+
+def load_agent_env(path: Path | None = None, *, override: bool = False) -> dict[str, str]:
+    """Load ~/.agent-reach/.env into os.environ for the current process."""
+    values = read_env_file(path)
+    for key, value in values.items():
+        if override or key not in os.environ:
+            os.environ[key] = value
+    return values
+
+
+def config_env_updates(config: Config) -> dict[str, str]:
+    """Return dotenv keys mirrored from Agent Reach config.yaml."""
+    updates: dict[str, str] = {}
+
+    def copy(config_key: str, *env_keys: str) -> None:
+        value = config.get(config_key)
+        if value:
+            for env_key in env_keys:
+                updates[env_key] = str(value)
+
+    copy("twitter_auth_token", "AUTH_TOKEN", "TWITTER_AUTH_TOKEN")
+    copy("twitter_ct0", "CT0", "TWITTER_CT0")
+    copy("xhs_cookie", "XHS_COOKIES")
+    copy("xueqiu_cookie", "XUEQIU_COOKIE")
+    copy("bilibili_proxy", "BILIBILI_PROXY")
+    copy("bilibili_sessdata", "BILIBILI_SESSDATA")
+    copy("bilibili_csrf", "BILIBILI_CSRF")
+    copy("youtube_cookies_from", "YOUTUBE_COOKIES_FROM")
+    copy("groq_api_key", "GROQ_API_KEY")
+    copy("github_token", "GITHUB_TOKEN")
+    copy("dashscope_api_key", "DASHSCOPE_API_KEY")
+    return updates
+
+
+def sync_config_to_env(config: Config | None = None, path: Path | None = None) -> Path:
+    """Mirror known config.yaml credentials into ~/.agent-reach/.env."""
+    return update_env_file(config_env_updates(config or Config()), path)
+
+
+def default_user_bin_dir() -> Path:
+    if os.name == "nt":
+        return Path.home() / ".local" / "bin"
+    return Path.home() / ".local" / "bin"
+
+
+def _path_entries(exclude_dir: Path) -> list[Path]:
+    entries = []
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part:
+            continue
+        path = Path(part)
+        try:
+            if path.resolve() == exclude_dir.resolve():
+                continue
+        except OSError:
+            pass
+        entries.append(path)
+    return entries
+
+
+def find_executable_excluding(command: str, exclude_dir: Path) -> str | None:
+    """Find a command on PATH while ignoring the wrapper output directory."""
+    path = os.pathsep.join(str(p) for p in _path_entries(exclude_dir))
+    found = shutil.which(command, path=path)
+    if found:
+        return found
+
+    suffixes = [".exe", ".cmd", ""] if os.name == "nt" else [""]
+    package = PIPX_PACKAGE_BY_TOOL.get(command, command)
+    candidate_dirs = [
+        Path(sys.prefix) / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / "pipx" / "venvs" / package / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / ".local" / "pipx" / "venvs" / package / ("Scripts" if os.name == "nt" else "bin"),
+        Path.home() / ".agent-reach-venv" / ("Scripts" if os.name == "nt" else "bin"),
+    ]
+    for directory in candidate_dirs:
+        for suffix in suffixes:
+            candidate = directory / f"{command}{suffix}"
+            if candidate.exists() and candidate.is_file():
+                return str(candidate)
+    return None
+
+
+def install_tool_wrappers(
+    tools: Iterable[str] = DEFAULT_WRAPPER_TOOLS,
+    *,
+    bin_dir: Path | None = None,
+    env_path: Path | None = None,
+) -> dict[str, str]:
+    """Install command wrappers that load Agent Reach .env before running tools."""
+    output_dir = Path(bin_dir or default_user_bin_dir())
+    output_dir.mkdir(parents=True, exist_ok=True)
+    env_file = Path(env_path or DEFAULT_ENV_FILE)
+    python = sys.executable
+
+    installed: dict[str, str] = {}
+    for tool in tools:
+        target = find_executable_excluding(tool, output_dir)
+        if not target:
+            installed[tool] = "missing"
+            continue
+
+        if os.name == "nt":
+            cmd_path = output_dir / f"{tool}.cmd"
+            cmd_path.write_text(
+                "@echo off\n"
+                f'"{python}" -m agent_reach.envexec --env-file "{env_file}" "{target}" %*\n'
+                "exit /b %ERRORLEVEL%\n",
+                encoding="utf-8",
+            )
+            installed[tool] = str(cmd_path)
+
+        sh_path = output_dir / tool
+        sh_path.write_text(
+            "#!/bin/sh\n"
+            f'exec "{python}" -m agent_reach.envexec --env-file "{env_file}" "{target}" "$@"\n',
+            encoding="utf-8",
+        )
+        try:
+            sh_path.chmod(sh_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        except OSError:
+            pass
+        if os.name != "nt":
+            installed[tool] = str(sh_path)
+
+    return installed

--- a/tests/test_envfile.py
+++ b/tests/test_envfile.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+
+from agent_reach.config import Config
+from agent_reach.envfile import (
+    install_tool_wrappers,
+    load_agent_env,
+    read_env_file,
+    sync_config_to_env,
+    update_env_file,
+)
+
+
+def test_update_env_file_writes_utf8_without_bom(tmp_path):
+    env_path = tmp_path / ".env"
+    update_env_file({"AUTH_TOKEN": "tok", "CT0": "ct0"}, env_path)
+
+    data = env_path.read_bytes()
+    assert not data.startswith(b"\xef\xbb\xbf")
+    assert read_env_file(env_path)["AUTH_TOKEN"] == "tok"
+
+
+def test_load_agent_env_handles_accidental_bom(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_bytes(b"\xef\xbb\xbfAUTH_TOKEN=\"tok\"\n")
+
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    load_agent_env(env_path)
+    assert read_env_file(env_path)["AUTH_TOKEN"] == "tok"
+
+
+def test_sync_config_to_env_maps_agent_reach_keys(tmp_path):
+    config = Config(config_path=tmp_path / "config.yaml")
+    config.set("twitter_auth_token", "auth")
+    config.set("twitter_ct0", "ct0")
+    config.set("xueqiu_cookie", "xq")
+    config.set("bilibili_proxy", "http://127.0.0.1:7890")
+
+    env_path = tmp_path / ".env"
+    sync_config_to_env(config, env_path)
+    values = read_env_file(env_path)
+
+    assert values["AUTH_TOKEN"] == "auth"
+    assert values["TWITTER_AUTH_TOKEN"] == "auth"
+    assert values["CT0"] == "ct0"
+    assert values["TWITTER_CT0"] == "ct0"
+    assert values["XUEQIU_COOKIE"] == "xq"
+    assert values["BILIBILI_PROXY"] == "http://127.0.0.1:7890"
+
+
+def test_install_tool_wrappers_uses_envexec_without_secrets(tmp_path, monkeypatch):
+    upstream_dir = tmp_path / "upstream"
+    upstream_dir.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    tool = upstream_dir / ("twitter.exe" if os.name == "nt" else "twitter")
+    tool.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", str(upstream_dir))
+    env_path = tmp_path / ".env"
+    update_env_file({"AUTH_TOKEN": "secret-token"}, env_path)
+
+    results = install_tool_wrappers(["twitter"], bin_dir=bin_dir, env_path=env_path)
+
+    wrapper = Path(results["twitter"])
+    content = wrapper.read_text(encoding="utf-8")
+    assert "agent_reach.envexec" in content
+    assert "secret-token" not in content


### PR DESCRIPTION
## Summary

Adds a project-local Agent Reach environment layer so cookies, tokens, and proxy settings can live in `~/.agent-reach/.env` instead of global OS environment variables.

## What changed

- Adds `agent_reach.envfile` for reading/writing `~/.agent-reach/.env` without UTF-8 BOM and with owner-only permissions where supported.
- Adds `agent_reach.envexec`, a small runner that loads the local env file before executing an upstream tool.
- Adds `agent-reach env init`, `agent-reach env sync`, and `agent-reach env install-wrappers`.
- Mirrors known `config.yaml` values into local env keys used by upstream tools, including Twitter, XHS, Xueqiu, Bilibili, Groq, GitHub, and DashScope.
- Extends `.env.example` with the local-env keys.

## Why

Some upstream tools need cookie or proxy environment variables, but setting them globally can affect unrelated apps. This keeps those values scoped to Agent Reach tool processes and supports automated agent calls without requiring users to manually source env files.

## Validation

- `python -m pytest tests/test_envfile.py -q`
- `python -m agent_reach.cli env --help`
- `python -m ruff check agent_reach/envfile.py agent_reach/envexec.py tests/test_envfile.py`