### PR TITLE
fix(docs): Reddit requires authentication, correct misleading 'no login needed' claims

### DIFF
--- a/agent_reach/guides/setup-reddit.md
+++ b/agent_reach/guides/setup-reddit.md
@@ -8,7 +8,7 @@ Agent Reach 通过 **rdt-cli** 实现 Reddit 的搜索和阅读功能：
 - **搜索**：`rdt search "关键词"`
 - **阅读完整帖子+评论**：`rdt read POST_ID`
 
-免费，无需代理，无需 API Key，无需登录。
+免费，无需代理，无需 API Key。需要登录认证（`rdt login`，自动从浏览器提取 Cookie）。
 
 ## Agent 可自动完成的步骤
 

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -76,7 +76,7 @@ mcporter call 'douyin.get_douyin_download_link(share_link: "https://v.douyin.com
 mcporter call 'douyin.extract_douyin_text(share_link: "https://v.douyin.com/xxx/")'
 ```
 
-> **无需登录**
+> **需要登录**（`rdt login`，自动从浏览器提取 Cookie）。Reddit 自 2024 年起要求认证，未登录时所有请求返回 403。
 
 ## Twitter/X (twitter-cli)
 
@@ -223,6 +223,6 @@ rdt popular --limit 10
 rdt all --limit 10
 ```
 
-> **安装**: `pipx install rdt-cli`（确保 v0.4.2+）。无需登录即可搜索和阅读。
+> **安装**: `pipx install rdt-cli`（确保 v0.4.2+）。需要先登录（`rdt login`）才能搜索和阅读。
 > 需要登录的功能：`rdt feed --subs-only`（订阅列表）、`rdt saved`（收藏）。
 > 建议使用 `--yaml` 输出，对 AI agent 更友好。


### PR DESCRIPTION
## Problem

The docs claim Reddit works "无需登录" (no login needed) in several places, but the actual code (`reddit.py` lines 4-6) explicitly states:

```
NOTE: Reddit requires authentication since 2024. All API requests
return 403 without a valid session cookie. Run `rdt login` after
installation to authenticate.
```

Confirmed by testing — all `rdt` commands return 403 without running `rdt login` first.

## Changes

| File | Before | After |
|------|--------|-------|
| `guides/setup-reddit.md` | 「免费，无需代理，无需 API Key，无需登录。」 | 「免费，无需代理，无需 API Key。需要登录认证（`rdt login`，自动从浏览器提取 Cookie）。」 |
| `skill/references/social.md` L79 | 「**无需登录**」 | 「**需要登录**（`rdt login`，自动从浏览器提取 Cookie）。Reddit 自 2024 年起要求认证，未登录时所有请求返回 403。」 |
| `skill/references/social.md` L226 | 「无需登录即可搜索和阅读。」 | 「需要先登录（`rdt login`）才能搜索和阅读。」 |

Now consistent with the README main table (line 76, already says 「需要登录认证」) and the `doctor` check logic.

Closes #314