### PR TITLE
feat(skill): optimize SKILL.md description for better auto-triggering across agents

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -8,10 +8,10 @@ description: >
 
   Also MUST USE for: web搜索/搜/查/找/look up/research, 招聘/求职/jobs, 分享的链接/URL.
   Routes to CLI tools: xhs-cli, twitter-cli, rdt-cli, gh, yt-dlp, curl+Jina, mcporter.
-  17 platforms. Zero config for 8 channels. Use skill_view to load, then follow the routing table.
+  17 platforms. Zero config for 8 channels.
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/抖音/微博/推特/B站/V2EX/Reddit) / career(LinkedIn) / dev(github) / web(网页/文章/公众号/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
+  分类：search / social (小红书/抖音/微博/推特/B站/V2EX/Reddit) / career(LinkedIn) / dev(github) / web(网页/文章/公众号/RSS) / video(YouTube/B站/播客)。
 triggers:
   - search: 搜/查/找/search/搜索/查一下/帮我搜
   - social:

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: agent-reach
 description: >
-  Give your AI agent eyes to see the entire internet.
-  17 platforms via CLI, MCP, curl, and Python scripts.
-  Zero config for 8 channels.
+  MUST USE when user asks to search, browse, read, or interact with content from any of these platforms:
+  小红书/xiaohongshu/xhs, 抖音/douyin, Twitter/推特/X, 微博/weibo, B站/bilibili,
+  V2EX, Reddit, LinkedIn/领英, YouTube, GitHub code search, 微信公众号/WeChat articles,
+  小宇宙播客, 雪球/股票行情, RSS feeds, or any web URL.
+
+  Also MUST USE for: web搜索/搜/查/找/look up/research, 招聘/求职/jobs, 分享的链接/URL.
+  Routes to CLI tools: xhs-cli, twitter-cli, rdt-cli, gh, yt-dlp, curl+Jina, mcporter.
+  17 platforms. Zero config for 8 channels. Use skill_view to load, then follow the routing table.
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/抖音/微博/推特/B站/V2EX/Reddit) / career(LinkedIn) / dev(github) / web(网页/文章/公众号/RSS) / video(YouTube/B站/播客).
-
-  Use when user asks to search, read, or interact on any supported platform,
-  shares a URL, or asks to search the web.
+  分类：search / social (小红书/抖音/微博/推特/B站/V2EX/Reddit) / career(LinkedIn) / dev(github) / web(网页/文章/公众号/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
 triggers:
   - search: 搜/查/找/search/搜索/查一下/帮我搜
   - social:

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -7,7 +7,7 @@ description: >
 
   Also MUST USE for: web search, look up, research, find, share a URL/link, jobs/recruiting.
   Routes to CLI tools: xhs-cli, twitter-cli, rdt-cli, gh, yt-dlp, curl+Jina, mcporter.
-  17 platforms, zero config for 8 channels. Load with skill_view, then follow the routing table.
+  17 platforms, zero config for 8 channels.
 
   Triggers: "search twitter", "search xiaohongshu", "watch this video",
   "search the web", "look this up", "research", "youtube transcript",

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -1,18 +1,19 @@
 ---
 name: agent-reach
 description: >
-  Give your AI agent eyes to see the entire internet.
-  Search and read 17 platforms: Twitter/X, Reddit, YouTube, GitHub, Bilibili,
-  XiaoHongShu, Douyin, Weibo, WeChat Articles, Xiaoyuzhou Podcast, LinkedIn,
-  V2EX, Xueqiu, RSS, Exa web search, and any web page.
-  Zero config for 8 channels. Use when the user asks to search, read, or interact
-  on any supported platform, shares a URL, or asks to search the web.
+  MUST USE when user asks to search, browse, read, or interact with content from any supported platform:
+  Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, Douyin, Weibo,
+  WeChat Articles, Xiaoyuzhou Podcast, LinkedIn, V2EX, Xueqiu (stocks), RSS, or any web URL.
+
+  Also MUST USE for: web search, look up, research, find, share a URL/link, jobs/recruiting.
+  Routes to CLI tools: xhs-cli, twitter-cli, rdt-cli, gh, yt-dlp, curl+Jina, mcporter.
+  17 platforms, zero config for 8 channels. Load with skill_view, then follow the routing table.
+
   Triggers: "search twitter", "search xiaohongshu", "watch this video",
   "search the web", "look this up", "research", "youtube transcript",
   "search reddit", "read this link", "bilibili", "douyin video",
   "wechat article", "wechat official account", "weibo", "V2EX",
-  "xiaoyuzhou", "podcast", "xueqiu", "stock quote",
-  "install agent reach".
+  "xiaoyuzhou", "podcast", "xueqiu", "stock quote", "雪球", "股票".
 metadata:
   openclaw:
     homepage: https://github.com/Panniantong/Agent-Reach

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -117,7 +117,7 @@ class TestSkillCommand(unittest.TestCase):
             with open(target) as f:
                 content = f.read()
             self.assertTrue(content.strip())
-            self.assertIn("Give your AI agent eyes to see the entire internet.", content)
+            self.assertIn("WeChat Articles, Xiaoyuzhou Podcast", content)
             self.assertNotIn("搜推特", content)
             self.assertTrue(
                 os.path.exists(os.path.join(skill_parent, "agent-reach", "references"))


### PR DESCRIPTION
## Background

From #316: the current SKILL.md description uses a marketing tone (`Give your AI agent eyes to see the entire internet`), which doesn't match how agents like Claude Code and Hermes perform semantic matching for skill activation. As a result, the skill frequently gets skipped and users have to manually type `/agent-reach`.

## Approach

The description is the primary (and often only) auto-trigger mechanism for skills. Changed it from a product intro to an explicit trigger directive:

1. **Lead with "MUST USE when"** — tells the agent exactly when to load this skill
2. **List all platforms + common aliases** (Chinese + English) — improves semantic match hit rate
3. **Add generic trigger keywords** — web search, URL sharing, jobs/recruiting
4. **Keep routing table unchanged** — only the description frontmatter was modified

## Changes

### SKILL.md (Chinese)

```diff
- Give your AI agent eyes to see the entire internet.
- 17 platforms via CLI, MCP, curl, and Python scripts.
- Zero config for 8 channels.
+ MUST USE when user asks to search, browse, read, or interact with content from any of these platforms:
+ 小红书/xiaohongshu/xhs, 抖音/douyin, Twitter/推特/X, 微博/weibo, B站/bilibili,
+ V2EX, Reddit, LinkedIn/领英, YouTube, GitHub code search, 微信公众号/WeChat articles,
+ 小宇宙播客, 雪球/股票行情, RSS feeds, or any web URL.
```

### SKILL_en.md (English)

```diff
- Give your AI agent eyes to see the entire internet.
+ MUST USE when user asks to search, browse, read, or interact with content from any supported platform:
```

## Testing

After the change, saying "帮我搜一下微博上关于 A 股的讨论" in Hermes triggers the skill automatically — no manual `/agent-reach` needed.

Closes #316