### PR TITLE
docs(en): document safe mode and OpenClaw exec requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
-  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10+-green.svg?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.8+"></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10+-green.svg?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="https://github.com/Panniantong/agent-reach/stargazers"><img src="https://img.shields.io/github/stars/Panniantong/agent-reach?style=for-the-badge" alt="GitHub Stars"></a>
 </p>
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -84,6 +84,15 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 ## Quick Start
 
+> ⚠️ **OpenClaw users: enable `exec` permission first**
+>
+> Agent Reach relies on the Agent running shell commands (`pip install`, `mcporter`, `bird`, etc.). If your OpenClaw uses the default `messaging` tool profile, the Agent won't be able to run them. **Enable `exec` before installing:**
+>
+> ```bash
+> openclaw config set tools.profile "coding"
+> ```
+> Or set `"tools": { "profile": "coding" }` in `~/.openclaw/openclaw.json`. After changing it, restart the Gateway (`openclaw gateway restart`) and start a new conversation. Other platforms (Claude Code, Cursor, Windsurf, etc.) are not affected.
+
 Copy this to your AI Agent (Claude Code, OpenClaw, Cursor, etc.):
 
 ```
@@ -95,6 +104,12 @@ The Agent auto-installs, detects your environment, and tells you what's ready.
 > 🔄 **Already installed?** Update in one command:
 > ```
 > Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md
+> ```
+
+> 🛡️ **Worried about security?** Use safe mode — it won't auto-install system packages, it only tells you what you need:
+> ```
+> Install Agent Reach (safe mode): https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/install.md
+> Use the --safe flag during install
 > ```
 
 <details>


### PR DESCRIPTION
## What

Brings the English README to parity with the Chinese one on two install topics, plus a small badge fix.

1. **OpenClaw `exec` prerequisite** — the Chinese README warns OpenClaw users to enable `tools.profile "coding"` before installing, otherwise the Agent silently can't run the install shell commands. This warning was missing from `docs/README_en.md`.
2. **Safe install mode** — `--safe` is a real, supported flag (`agent_reach/cli.py`, documented in `docs/install.md`) that avoids auto-installing system packages. It was documented in Chinese only.
3. **Version badge** — `README.md` badge alt-text said `Python 3.8+` while the badge image and `requires-python = ">=3.10"` both say 3.10+. Aligned to 3.10+.

## Why

English-only users were not told about a security-relevant install mode, and OpenClaw users could hit a silent failure with no guidance. These are additive doc fixes — no behavior change.
