### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project
 Agent Reach — Python CLI + library that gives AI agents read/search access to 14+ internet platforms.
 Positioning: installer + doctor + config tool. NOT a wrapper — after install, agents call upstream tools directly.
-Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.3.0
+Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.4.1
 
 ## Commands
 - `pip install -e .` — Dev install

--- a/agent_reach/__init__.py
+++ b/agent_reach/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Agent Reach — Give your AI Agent eyes to see the entire internet."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Neo Reid"
 
 from agent_reach.core import AgentReach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-reach"
-version = "1.4.0"
+version = "1.4.1"
 description = "Give your AI Agent eyes to see the entire internet. Search + Read 10+ platforms."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,7 +89,7 @@ class TestCheckUpdateRetry:
 
         sequence = [
             R(429, headers={"Retry-After": "3"}),
-            R(200, payload={"tag_name": "v1.4.0"}),
+            R(200, payload={"tag_name": "v1.4.1"}),
         ]
 
         with patch("requests.get", side_effect=sequence):


### PR DESCRIPTION
Bumps version in all three canonical places (pyproject.toml, __init__.py, tests/test_cli.py) plus the stale CLAUDE.md line (was still 1.3.0).

v1.4.1 = #329 (source-install fix) + #340 (wheel CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)