### PR TITLE
chore: stop tracking .claude/settings.local.json (personal local config)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:community.groq.com)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 .env
 .agent-reach/
 *.log
+
+# Claude Code personal permission settings — local only, never commit
+.claude/settings.local.json


### PR DESCRIPTION
It's Claude Code's per-user permission allowlist — auto-modified on every
permission approval, so it kept dirtying the working tree and risked
leaking personal settings into the public repo. Local file is preserved.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
