### PR TITLE
fix: correct stale twitter flag, MP3 case match, reddit tier, bird residue

### DIFF
--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -19,7 +19,7 @@ class RedditChannel(Channel):
     name = "reddit"
     description = "Reddit 帖子和评论"
     backends = ["rdt-cli"]
-    tier = 0
+    tier = 1  # Reddit requires login since 2024 (rdt login) — not zero-config
 
     def can_handle(self, url: str) -> bool:
         from urllib.parse import urlparse

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -35,7 +35,7 @@ echo "===================="
 # Step 1: 提取音频 URL 和标题
 echo "🔍 正在解析页面..."
 PAGE=$(curl -s "$URL")
-AUDIO_URL=$(echo "$PAGE" | perl -ne 'while (/(https:\/\/media\.xyzcdn\.net\/[^"]*\.(?:m4a|mp3))/g) { print "$1\n" }' | head -1)
+AUDIO_URL=$(echo "$PAGE" | perl -ne 'while (/(https:\/\/media\.xyzcdn\.net\/[^"]*\.(?:m4a|mp3))/gi) { print "$1\n" }' | head -1)
 TITLE=$(echo "$PAGE" | perl -ne 'if (/"title":"([^"]*)"/) { print "$1\n"; last }' | head -1)
 
 if [ -z "$AUDIO_URL" ]; then

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -58,7 +58,7 @@ curl -s "https://r.jina.ai/URL"
 gh search repos "query" --sort stars --limit 10
 
 # Twitter 搜索
-twitter search "query" --limit 10
+twitter search "query" -n 10
 
 # YouTube/B站字幕
 yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -86,7 +86,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 > ⚠️ **OpenClaw users: enable `exec` permission first**
 >
-> Agent Reach relies on the Agent running shell commands (`pip install`, `mcporter`, `bird`, etc.). If your OpenClaw uses the default `messaging` tool profile, the Agent won't be able to run them. **Enable `exec` before installing:**
+> Agent Reach relies on the Agent running shell commands (`pip install`, `mcporter`, `twitter`, etc.). If your OpenClaw uses the default `messaging` tool profile, the Agent won't be able to run them. **Enable `exec` before installing:**
 >
 > ```bash
 > openclaw config set tools.profile "coding"


### PR DESCRIPTION
Four one-line correctness fixes found while live-testing community PRs on macOS:

1. **SKILL.md (zh)**: `twitter search --limit 10` → `-n 10`. twitter-cli v0.8.5 has no `--limit` (verified: usage error; real flag is `-n, --max`). Agents following the skill hit an error on every Twitter search. (`gh`/`rdt` keep `--limit` — those are valid.)
2. **transcribe_xiaoyuzhou.sh**: audio regex now case-insensitive — current episodes serve uppercase `.MP3` (live-verified on a real episode page; extraction returned empty before, returns the URL after).
3. **reddit.py**: `tier = 0` → `tier = 1` — its own docstring says Reddit requires login since 2024; tier is doctor display metadata only (no install behavior change).
4. **docs/README_en.md**: one leftover `bird` reference → `twitter` (came in with #330).

85 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)