### PR TITLE
fix(security): create credential files atomically with 0o600 (CWE-732)

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1146,11 +1146,28 @@ def _configure_xhs_cookies(value):
     # Find the container
     docker = shutil.which("docker")
     if not docker:
-        # No Docker - write to a local file for manual import
+        # No Docker - write to a local file for manual import.
+        # Create with 0o600 atomically so the file is never world-readable
+        # between open() and a follow-up chmod() (same pattern Config.save()
+        # uses in config.py).
+        import stat
         cookie_path = os.path.expanduser("~/.agent-reach/xhs-cookies.json")
-        with open(cookie_path, "w") as f:
-            f.write(cookies_json)
-        os.chmod(cookie_path, 0o600)
+        try:
+            fd = os.open(
+                cookie_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                stat.S_IRUSR | stat.S_IWUSR,  # 0o600
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(cookies_json)
+        except OSError:
+            # Windows / unsupported flags — fall back to plain open + chmod.
+            with open(cookie_path, "w", encoding="utf-8") as f:
+                f.write(cookies_json)
+            try:
+                os.chmod(cookie_path, 0o600)
+            except OSError:
+                pass
         print(f"  Cookies saved to {cookie_path}")
         print("  Docker not found. Copy manually:")
         print(f"  docker cp {cookie_path} xiaohongshu-mcp:/app/data/cookies.json")

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -148,6 +148,28 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
     return results
 
 
+def _open_owner_only(path: str):
+    """Open *path* for writing, atomically creating it with mode 0o600.
+
+    Mirrors the pattern used by Config.save() in config.py: O_WRONLY|O_CREAT|
+    O_TRUNC + an explicit mode argument so the file is never briefly
+    world-readable between open() and a later os.chmod(). On Windows (or any
+    OS that rejects the open flags) we fall back to a plain open().
+    """
+    import os
+    import stat
+
+    try:
+        fd = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,  # 0o600
+        )
+        return os.fdopen(fd, "w", encoding="utf-8")
+    except OSError:
+        return open(path, "w", encoding="utf-8")
+
+
 def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
     """Sync Twitter credentials to ~/.config/xfetch/session.json (legacy xreach compat)."""
     import json
@@ -166,9 +188,8 @@ def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
                 session_data = {}
         session_data["authToken"] = auth_token
         session_data["ct0"] = ct0
-        with open(session_path, "w", encoding="utf-8") as sf:
+        with _open_owner_only(session_path) as sf:
             json.dump(session_data, sf, indent=2)
-        os.chmod(session_path, 0o600)
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, xfetch sync is best-effort
         pass
@@ -179,17 +200,19 @@ def _sync_bird_env(auth_token: str, ct0: str) -> None:
 
     bird reads AUTH_TOKEN and CT0 from environment variables. This writes a
     shell-sourceable file so users can `source ~/.config/bird/credentials.env`.
+    Values are passed through shlex.quote so a token containing a quote, $, or
+    backtick cannot break out into shell syntax when the file is sourced.
     """
     import os
+    import shlex
 
     try:
         bird_dir = os.path.join(os.path.expanduser("~"), ".config", "bird")
         os.makedirs(bird_dir, exist_ok=True)
         env_path = os.path.join(bird_dir, "credentials.env")
-        with open(env_path, "w", encoding="utf-8") as f:
-            f.write(f'AUTH_TOKEN="{auth_token}"\n')
-            f.write(f'CT0="{ct0}"\n')
-        os.chmod(env_path, 0o600)
+        with _open_owner_only(env_path) as f:
+            f.write(f"AUTH_TOKEN={shlex.quote(auth_token)}\n")
+            f.write(f"CT0={shlex.quote(ct0)}\n")
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, bird env sync is best-effort
         pass

--- a/tests/test_cookie_extract_perms.py
+++ b/tests/test_cookie_extract_perms.py
@@ -56,9 +56,13 @@ def test_sync_bird_env_quotes_shell_metachars(tmp_path, monkeypatch):
     later `source ~/.config/bird/credentials.env` into arbitrary shell.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
-    hostile_auth = 'inj"; touch /tmp/agent-reach-pwn; #'
-    hostile_ct0 = "ct0_$(touch /tmp/agent-reach-pwn-ct0)"
-    pwn_marker = tmp_path / "should-not-exist"
+    # Side-effect markers live under tmp_path (auto-cleaned by pytest) rather
+    # than a shared absolute /tmp path — otherwise one vulnerable run leaves a
+    # marker behind that fails every later run on the same machine/CI runner.
+    pwn_auth = tmp_path / "pwn-auth"
+    pwn_ct0 = tmp_path / "pwn-ct0"
+    hostile_auth = f'inj"; touch {pwn_auth}; #'
+    hostile_ct0 = f"ct0_$(touch {pwn_ct0})"
     _sync_bird_env(hostile_auth, hostile_ct0)
     env_path = tmp_path / ".config" / "bird" / "credentials.env"
 
@@ -81,6 +85,5 @@ def test_sync_bird_env_quotes_shell_metachars(tmp_path, monkeypatch):
     assert lines["AUTH"] == hostile_auth, "auth_token round-trip broke — injection possible"
     assert lines["CT0"] == hostile_ct0, "ct0 round-trip broke — injection possible"
     # And no side-effect files materialised.
-    assert not os.path.exists("/tmp/agent-reach-pwn")
-    assert not os.path.exists("/tmp/agent-reach-pwn-ct0")
-    assert not pwn_marker.exists()
+    assert not pwn_auth.exists()
+    assert not pwn_ct0.exists()

--- a/tests/test_cookie_extract_perms.py
+++ b/tests/test_cookie_extract_perms.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Verify credential files written by cookie sync helpers and CLI helpers
+are owner-only (0o600) and that values containing shell metacharacters do
+not break the shell-sourceable env file produced by _sync_bird_env().
+
+Companion to tests/test_config.py::test_save_creates_file_with_restricted_permissions —
+the same threat-model claim ("Cookie/Token only stored locally, 600
+permissions") covers these paths.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from agent_reach.cookie_extract import _sync_bird_env, _sync_xfetch_session
+
+
+def _owner_only(path: str) -> bool:
+    mode = os.stat(path).st_mode
+    return not (mode & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX perm semantics only")
+def test_sync_xfetch_session_writes_0600(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _sync_xfetch_session("auth_xxx", "ct0_yyy")
+    session_path = tmp_path / ".config" / "xfetch" / "session.json"
+    assert session_path.exists(), "expected ~/.config/xfetch/session.json"
+    assert _owner_only(str(session_path)), "session.json must be 0o600"
+    # Round-trip the content so we know we didn't accidentally corrupt JSON.
+    data = json.loads(session_path.read_text(encoding="utf-8"))
+    assert data["authToken"] == "auth_xxx"
+    assert data["ct0"] == "ct0_yyy"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX perm semantics only")
+def test_sync_bird_env_writes_0600(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _sync_bird_env("auth_xxx", "ct0_yyy")
+    env_path = tmp_path / ".config" / "bird" / "credentials.env"
+    assert env_path.exists(), "expected ~/.config/bird/credentials.env"
+    assert _owner_only(str(env_path)), "credentials.env must be 0o600"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX sh needed for sourcing")
+def test_sync_bird_env_quotes_shell_metachars(tmp_path, monkeypatch):
+    """Tokens containing ", $, `, ; etc. must not break out of the assignment.
+
+    Prior implementation used `f'AUTH_TOKEN="{auth_token}"'` which an attacker-
+    controlled cookie containing a literal `"` could break out of, turning a
+    later `source ~/.config/bird/credentials.env` into arbitrary shell.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    hostile_auth = 'inj"; touch /tmp/agent-reach-pwn; #'
+    hostile_ct0 = "ct0_$(touch /tmp/agent-reach-pwn-ct0)"
+    pwn_marker = tmp_path / "should-not-exist"
+    _sync_bird_env(hostile_auth, hostile_ct0)
+    env_path = tmp_path / ".config" / "bird" / "credentials.env"
+
+    # Sourcing the file must NOT execute the injected payload. Read back the
+    # exported values from a subshell instead — they should equal the originals.
+    probe = (
+        f". {env_path}; "
+        f'printf "AUTH=%s\\nCT0=%s\\n" "$AUTH_TOKEN" "$CT0"'
+    )
+    result = subprocess.run(
+        ["sh", "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+    lines = dict(
+        line.split("=", 1) for line in result.stdout.strip().splitlines() if "=" in line
+    )
+    assert lines["AUTH"] == hostile_auth, "auth_token round-trip broke — injection possible"
+    assert lines["CT0"] == hostile_ct0, "ct0 round-trip broke — injection possible"
+    # And no side-effect files materialised.
+    assert not os.path.exists("/tmp/agent-reach-pwn")
+    assert not os.path.exists("/tmp/agent-reach-pwn-ct0")
+    assert not pwn_marker.exists()


### PR DESCRIPTION
## Summary

Two credential-writing call sites (`_sync_xfetch_session` in
`agent_reach/cookie_extract.py` and the no-Docker fallback in
`_configure_xhs_cookies` in `agent_reach/cli.py`) create credential files
with `open(path, "w")` and then call `os.chmod(path, 0o600)` *after* the
write. Between those two calls the file lives with the user's umask
default (typically world-readable on Linux), which contradicts the README's
explicit promise that "Cookie/Token only stored locally, 600 permissions"
and is also out of step with `Config.save()` in `agent_reach/config.py`,
which already creates `config.yaml` atomically with the owner-only mode via
`os.open(..., 0o600)`.

This PR routes both call sites through the same atomic-create-with-mode
pattern `Config.save()` uses, and also hardens `_sync_bird_env()` against a
secondary shell-metacharacter breakout in the `source`-able env file it
writes (more on that below).

## Impact

- **CWE-732 (Incorrect Permission Assignment for Critical Resource).** Brief
  TOCTOU window where credential files (`~/.config/xfetch/session.json` with
  Twitter `auth_token` + `ct0`; `~/.agent-reach/xhs-cookies.json` with full
  XHS cookies) are world-readable. A concurrent process on the same host that
  is racing the cookie sync — even a low-privilege one — can read the
  credentials in that window. Single-user laptops are mostly safe in
  practice; shared dev VMs and CI runners that have other processes are not.
- **CWE-78 / CWE-94 (shell-source injection)** on `_sync_bird_env()`. It
  writes `AUTH_TOKEN="{auth_token}"\n` and `CT0="{ct0}"\n` to
  `~/.config/bird/credentials.env`. The function's own docstring says users
  `source ~/.config/bird/credentials.env`. A token containing a literal `"`,
  `$`, or backtick — possible whenever the user pastes a cookie string from
  an untrusted source via `agent-reach configure twitter-cookies "..."` —
  breaks out of the assignment and executes arbitrary commands on the next
  `source`. The function is currently dead code in the migration path from
  xreach → bird, but the alias `_sync_bird_credentials = _sync_bird_env`
  suggests external callers and the wiring will land soon — the regression
  test in this PR pins the safe behaviour either way.

## Location

- `agent_reach/cookie_extract.py:151` — `_sync_xfetch_session()` (write
  path for `~/.config/xfetch/session.json`)
- `agent_reach/cookie_extract.py:177` — `_sync_bird_env()` (write path for
  `~/.config/bird/credentials.env`)
- `agent_reach/cli.py:1149` — `_configure_xhs_cookies()` no-Docker fallback
  (write path for `~/.agent-reach/xhs-cookies.json`)

## Fix

- New shared `_open_owner_only(path)` helper in `cookie_extract.py` that
  uses `os.open(..., O_WRONLY|O_CREAT|O_TRUNC, stat.S_IRUSR|stat.S_IWUSR)`
  and falls back to `open()` on platforms that reject the flags (Windows) —
  the same try/except pattern `Config.save()` already uses.
- `_sync_xfetch_session()` and `_sync_bird_env()` route through that
  helper; the trailing `os.chmod()` calls are dropped because the file is
  created at the right mode in one syscall.
- `_configure_xhs_cookies()` no-Docker fallback uses the same atomic
  `os.open(...)` pattern inline (it already imports `os` and `stat` at the
  module level, so the helper isn't worth moving across modules).
- `_sync_bird_env()` switches from `f'KEY="{value}"'` to
  `f'KEY={shlex.quote(value)}'`, so any value round-trips losslessly through
  `source` even when it contains `"`, `$`, backticks, or semicolons.

## Verification

`pytest tests/test_cookie_extract_perms.py tests/test_config.py -v` →
**14 / 14 pass** locally on Python 3.12.3.

Three new tests in `tests/test_cookie_extract_perms.py` mirror the
existing `test_save_creates_file_with_restricted_permissions` style:

1. `test_sync_xfetch_session_writes_0600` — writes session.json into a
   `HOME=tmp_path` sandbox; asserts no group/other read or write bits.
2. `test_sync_bird_env_writes_0600` — same check for credentials.env.
3. `test_sync_bird_env_quotes_shell_metachars` — regression for the
   shell-source injection class. Passes a hostile auth_token
   (`'inj"; touch /tmp/agent-reach-pwn; #'`) and ct0
   (`'ct0_$(touch /tmp/agent-reach-pwn-ct0)'`), sources the resulting
   `credentials.env` in `sh -c`, and asserts the values round-trip
   losslessly and no side-effect files materialise.

Full suite (`pytest tests/ --ignore=tests/test_xiaoyuzhou_install.py`):
**105 / 106 pass**. The single pre-existing failure
(`test_get_configured_features`) is unrelated — it asserts no feature is
configured in a fresh `Config`, but `Config.get()` falls back to env vars
and the CI runner has `GITHUB_TOKEN` set, so the
`github_token` feature appears configured. The same failure reproduces on
`main` before this PR's diff is applied.

## Detected by

Aeon + manual review of `cookie_extract.py` / `cli.py` against the README's
"600 permissions" claim, and Semgrep
`python.lang.security.audit.insecure-file-permissions`.

- Severity: **medium** (CWE-732 + CWE-78/94 dead-but-imminently-wired)
- CWE: CWE-732, CWE-78, CWE-94

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
