### PR TITLE
test(web): add unit tests for the WebChannel fallback

### DIFF
--- a/tests/test_web_channel.py
+++ b/tests/test_web_channel.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Dedicated tests for the ``web`` channel.
+
+``web`` is the tier-0 catch-all: ``can_handle`` must accept *anything* so it
+can back-stop every other channel, ``check`` must report ready without touching
+the network (it is the zero-overhead fallback), and ``read`` must normalise the
+URL before handing it to Jina Reader. Follow-up to #331 / #360 / #361,
+completing dedicated coverage for the channels that still lacked it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent_reach.channels.web import WebChannel, _UA
+
+
+def _resp(body=b"# Example\nfull text\n"):
+    """A urlopen() return value usable as a context manager."""
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = body
+    return cm
+
+
+# --- can_handle: universal fallback contract ---
+
+def test_can_handle_accepts_any_url():
+    channel = WebChannel()
+    for sample in [
+        "https://example.com",
+        "http://example.com/path?q=1",
+        "example.com",
+        "ftp://files.example.com/readme.txt",
+        "not a url at all",
+        "",
+    ]:
+        assert channel.can_handle(sample) is True, sample
+
+
+# --- check: ready without any network probe (零开销兜底) ---
+
+def test_check_is_ok_and_touches_no_network():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen") as mock_open:
+        status, message = channel.check()
+    assert status == "ok"
+    assert channel.active_backend == "Jina Reader"
+    assert "Jina Reader" in message
+    # The fallback channel must stay zero-overhead: no probing on check().
+    mock_open.assert_not_called()
+
+
+# --- read: URL normalisation + Jina Reader request shape ---
+
+def test_read_prepends_https_for_schemeless_url():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
+        out = channel.read("example.com/article")
+    req = mock_open.call_args.args[0]
+    assert req.full_url == "https://r.jina.ai/https://example.com/article"
+    assert out == "# Example\nfull text\n"
+
+
+def test_read_preserves_existing_http_scheme():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
+        channel.read("http://example.com")
+    req = mock_open.call_args.args[0]
+    # http:// must be kept as-is, not coerced to https:// nor double-prefixed.
+    assert req.full_url == "https://r.jina.ai/http://example.com"
+
+
+def test_read_preserves_existing_https_scheme():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
+        channel.read("https://example.com/deep/path")
+    req = mock_open.call_args.args[0]
+    assert req.full_url == "https://r.jina.ai/https://example.com/deep/path"
+
+
+def test_read_sends_expected_headers_and_timeout():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
+        channel.read("https://example.com")
+    req = mock_open.call_args.args[0]
+    assert req.headers == {"User-agent": _UA, "Accept": "text/plain"}
+    assert mock_open.call_args.kwargs["timeout"] == 30
+
+
+def test_read_decodes_utf8_body():
+    channel = WebChannel()
+    with patch("urllib.request.urlopen", return_value=_resp("café ☕\n".encode("utf-8"))):
+        out = channel.read("https://example.com")
+    assert out == "café ☕\n"


### PR DESCRIPTION
## What

Adds `tests/test_web_channel.py` — dedicated coverage for the `web` channel, which was the last channel without its own tests.

Seven tests lock the three contracts that make `web` the tier-0 catch-all:

- **`can_handle` is a universal fallback** — returns `True` for full URLs, schemeless hosts, non-`http` schemes, junk strings, and the empty string, so it can always back-stop the other channels.
- **`check()` is zero-overhead** — reports `ok` and selects the Jina Reader backend **without any network probe** (the inline comment notes this is intentional: `doctor` already touches the network through other channels, so the fallback stays cheap). The test asserts `urlopen` is never called.
- **`read()` normalises the URL** before handing it to Jina Reader: a schemeless URL gets `https://` prepended, while existing `http://` / `https://` schemes are preserved (not double-prefixed); the request carries the expected `User-Agent` / `Accept` headers and 30s timeout, and the UTF-8 body is decoded. `urlopen` is stubbed so the suite stays offline.

## Why

Follow-up to #331 and the invitation to cover the current channels — completes dedicated channel testing after the `rss` (#360) and `github` (#361) tests.

## Testing

```
pytest tests/test_web_channel.py -v   # 7 passed
pytest tests/                          # 161 passed, 8 skipped
```

All offline — no network calls.