### PR TITLE
security(channels): match URL host by exact/subdomain, not substring

### DIFF
--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -39,9 +39,8 @@ class BilibiliChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "bilibili.com" in d or "b23.tv" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "bilibili.com", "b23.tv")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -13,8 +13,8 @@ class GitHubChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "github.com" in urlparse(url).netloc.lower()
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "github.com")
 
     def check(self, config=None):
         # 真跑 gh auth status 探活。注意：未登录时 rc!=0 是正常业务态（warn），不是 error。

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -16,8 +16,8 @@ class LinkedInChannel(Channel):
     tier = 2
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "linkedin.com" in urlparse(url).netloc.lower()
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "linkedin.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -39,10 +39,9 @@ class RedditChannel(Channel):
     tier = 1  # no zero-config path exists — see module docstring
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
+        from ..utils.urlmatch import host_matches
 
-        d = urlparse(url).netloc.lower()
-        return "reddit.com" in d or "redd.it" in d
+        return host_matches(url, "reddit.com", "redd.it")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -12,9 +12,8 @@ class TwitterChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "x.com" in d or "twitter.com" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "x.com", "twitter.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -28,9 +28,8 @@ class V2EXChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "v2ex.com" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "v2ex.com")
 
     # ------------------------------------------------------------------ #
     # Health check

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -153,9 +153,8 @@ class XiaoHongShuChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaohongshu.com" in d or "xhslink.com" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "xiaohongshu.com", "xhslink.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -14,9 +14,8 @@ class XiaoyuzhouChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaoyuzhoufm.com" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "xiaoyuzhoufm.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -154,8 +154,8 @@ class XueqiuChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        d = urllib.parse.urlparse(url).netloc.lower()
-        return "xueqiu.com" in d
+        from ..utils.urlmatch import host_matches
+        return host_matches(url, "xueqiu.com")
 
     # ------------------------------------------------------------------ #
     # Health check

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -27,10 +27,9 @@ class YouTubeChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
+        from ..utils.urlmatch import host_matches
 
-        d = urlparse(url).netloc.lower()
-        return "youtube.com" in d or "youtu.be" in d
+        return host_matches(url, "youtube.com", "youtu.be")
 
     def check(self, config=None):
         # 真跑 yt-dlp --version 探活，区分未装 / venv 断链 / 跑不动

--- a/agent_reach/utils/urlmatch.py
+++ b/agent_reach/utils/urlmatch.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Host matching for channel routing.
+
+Channels decide whether they own a URL via ``can_handle``. A naive substring
+test like ``"github.com" in urlparse(url).netloc`` also matches look-alike hosts
+(``github.com.evil.com``, ``evil-github.com``) and userinfo tricks
+(``github.com@evil.com`` — the netloc contains "github.com" but the real host is
+``evil.com``). Routing an attacker-controlled URL to a *credentialed* channel
+(e.g. one that attaches cookies or a logged-in CLI) lets it exercise that
+channel's session against a host the user never intended.
+
+``host_matches`` extracts the real hostname (``urlsplit`` excludes userinfo and
+port) and requires an exact or proper-subdomain match.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+def host_matches(url: str, *domains: str) -> bool:
+    """True if the URL's host equals one of ``domains`` or is a subdomain of it.
+
+    Uses the parsed hostname (not netloc), so embedded credentials and ports
+    cannot smuggle a look-alike host past the check.
+    """
+    try:
+        host = urlsplit(url).hostname
+    except ValueError:
+        return False
+    if not host:
+        return False
+    host = host.lower()
+    for domain in domains:
+        d = domain.lower().strip(".")
+        if host == d or host.endswith("." + d):
+            return True
+    return False

--- a/tests/test_urlmatch.py
+++ b/tests/test_urlmatch.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent_reach.utils.urlmatch.host_matches and channel routing."""
+
+import pytest
+
+from agent_reach.utils.urlmatch import host_matches
+
+
+class TestHostMatches:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/u/r",
+            "https://www.github.com/u/r",
+            "https://api.github.com/repos",
+            "HTTPS://GitHub.com/u/r",
+            "https://github.com:443/u/r",
+        ],
+    )
+    def test_matches_domain_and_subdomains(self, url):
+        assert host_matches(url, "github.com")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com.evil.com/u/r",   # look-alike suffix
+            "https://evil-github.com/u/r",        # look-alike prefix
+            "https://github.com@evil.com/u/r",    # userinfo trick — real host is evil.com
+            "https://notgithub.com/u/r",
+            "https://example.com/github.com",     # only in path
+        ],
+    )
+    def test_rejects_lookalikes_and_userinfo(self, url):
+        assert not host_matches(url, "github.com")
+
+    def test_multiple_domains(self):
+        assert host_matches("https://youtu.be/abc", "youtube.com", "youtu.be")
+        assert host_matches("https://www.youtube.com/watch", "youtube.com", "youtu.be")
+        assert not host_matches("https://vimeo.com/1", "youtube.com", "youtu.be")
+
+    def test_non_url_inputs(self):
+        assert not host_matches("github.com/u/r", "github.com")  # no scheme → no host
+        assert not host_matches("", "github.com")
+        assert not host_matches("not a url", "github.com")
+
+
+class TestChannelRoutingNoLongerBypassable:
+    def test_credentialed_channels_reject_userinfo_lookalike(self):
+        # The exact bypass class: an attacker URL whose netloc *contains* the
+        # real domain but whose host is evil.com must not be claimed by the
+        # credentialed channel.
+        from agent_reach.channels.github import GitHubChannel
+        from agent_reach.channels.twitter import TwitterChannel
+        from agent_reach.channels.xueqiu import XueqiuChannel
+
+        assert not GitHubChannel().can_handle("https://github.com@evil.com/x")
+        assert not GitHubChannel().can_handle("https://github.com.evil.com/x")
+        assert not TwitterChannel().can_handle("https://x.com.evil.com/x")
+        assert not XueqiuChannel().can_handle("https://xueqiu.com@evil.com/x")
+
+    def test_legitimate_urls_still_route(self):
+        from agent_reach.channels.github import GitHubChannel
+        from agent_reach.channels.reddit import RedditChannel
+
+        assert GitHubChannel().can_handle("https://github.com/panniantong/agent-reach")
+        assert RedditChannel().can_handle("https://www.reddit.com/r/python")
+        assert RedditChannel().can_handle("https://redd.it/abc")


### PR DESCRIPTION
`can_handle` used `"github.com" in urlparse(url).netloc`, which also matches look-alike hosts (`github.com.evil.com`, `evil-github.com`) and userinfo tricks (`github.com@evil.com` — netloc contains the domain but the real host is evil.com). Routing such a URL to a credentialed channel exercises its cookies/session against an unintended host. Adds `utils/urlmatch.host_matches` (parsed hostname, exact-or-subdomain) and switches all 10 domain channels to it. New `tests/test_urlmatch.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
