### PR TITLE
security(channels): scrub URL credentials from error messages

### DIFF
--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -44,8 +44,9 @@ class V2EXChannel(Channel):
             self.active_backend = self.backends[0]
             return "ok", "公开 API 可用（热门主题、节点浏览、主题详情、用户信息）"
         except Exception as e:
+            from ..utils.text import scrub_url_credentials
             self.active_backend = None
-            return "warn", f"V2EX API 连接失败（可能需要代理）：{e}"
+            return "warn", f"V2EX API 连接失败（可能需要代理）：{scrub_url_credentials(e)}"
 
     # ------------------------------------------------------------------ #
     # Data-fetching methods

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -173,8 +173,9 @@ class XueqiuChannel(Channel):
                 return "ok", "公开 API 可用（行情、搜索、热帖、热股）"
             return "warn", "API 响应异常（返回数据为空）"
         except Exception as e:
+            from ..utils.text import scrub_url_credentials
             return "warn", (
-                f"Xueqiu API 连接失败：{e}。"
+                f"Xueqiu API 连接失败：{scrub_url_credentials(e)}。"
                 "请先登录雪球后运行：agent-reach configure --from-browser chrome"
             )
 

--- a/agent_reach/utils/text.py
+++ b/agent_reach/utils/text.py
@@ -2,7 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+# Matches `scheme://user:pass@` (or `scheme://user@`) so proxy / URL
+# credentials can be stripped before an error string reaches a log or the agent.
+# The scheme length is bounded and the userinfo is a single char class (it
+# already includes ":"), so there is no unbounded/nested quantifier and matching
+# stays linear — no quadratic backtracking on long credential-free strings.
+_URL_CREDENTIALS_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.\-]{0,19}://)[^/\s@]+@")
+
+
+def scrub_url_credentials(text: object) -> str:
+    """Redact `user:pass@` credentials embedded in any URL within ``text``.
+
+    Network exceptions (e.g. a urllib proxy error) frequently include the full
+    proxy URL, which may carry `user:pass`. Run untrusted/error text through
+    this before surfacing it to the user, the agent, or a log.
+    """
+    return _URL_CREDENTIALS_RE.sub(r"\1***@", str(text))
 
 
 def read_utf8_text(path: str | Path, default: str = "") -> str:

--- a/tests/test_scrub_credentials.py
+++ b/tests/test_scrub_credentials.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent_reach.utils.text.scrub_url_credentials."""
+
+import pytest
+
+from agent_reach.utils.text import scrub_url_credentials
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (
+            "proxy error: http://user:pass@1.2.3.4:8080 refused",
+            "proxy error: http://***@1.2.3.4:8080 refused",
+        ),
+        (
+            "https://alice:s3cret@proxy.example.com/path",
+            "https://***@proxy.example.com/path",
+        ),
+        # userinfo without password
+        ("socks5://token@host:1080", "socks5://***@host:1080"),
+        # no credentials — left untouched
+        ("https://example.com/no-creds", "https://example.com/no-creds"),
+        ("plain error with no url", "plain error with no url"),
+    ],
+)
+def test_scrub_url_credentials(raw, expected):
+    assert scrub_url_credentials(raw) == expected
+
+
+def test_accepts_non_str():
+    err = ValueError("connect to http://u:p@10.0.0.1:3128 failed")
+    out = scrub_url_credentials(err)
+    assert "u:p@" not in out
+    assert "http://***@10.0.0.1:3128" in out
+
+
+def test_multiple_urls_all_scrubbed():
+    raw = "http://a:b@h1 and https://c:d@h2"
+    out = scrub_url_credentials(raw)
+    assert "a:b@" not in out and "c:d@" not in out
+    assert out.count("***@") == 2


### PR DESCRIPTION
When a proxy is configured (`HTTP(S)_PROXY = http://user:pass@host`), a urllib network error can embed the full proxy URL — including `user:pass` — which the V2EX and Xueqiu health checks interpolated verbatim into the message returned to the user/agent. Adds `utils.text.scrub_url_credentials` (linear-time regex, bounded scheme length to avoid quadratic backtracking) and applies it at those sites. New `tests/test_scrub_credentials.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
