### PR TITLE
security(config): create secret directories owner-only (0o700)

### DIFF
--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -35,8 +35,9 @@ class Config:
         self.load()
 
     def _ensure_dir(self):
-        """Create config directory if it doesn't exist."""
-        self.config_dir.mkdir(parents=True, exist_ok=True)
+        """Create config directory (owner-only; it holds tokens and cookies)."""
+        from agent_reach.utils.paths import make_private_dir
+        make_private_dir(self.config_dir)
 
     def load(self):
         """Load config from YAML file."""

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -176,8 +176,9 @@ def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
     import os
 
     try:
+        from agent_reach.utils.paths import make_private_dir
         xfetch_dir = os.path.join(os.path.expanduser("~"), ".config", "xfetch")
-        os.makedirs(xfetch_dir, exist_ok=True)
+        make_private_dir(xfetch_dir)
         session_path = os.path.join(xfetch_dir, "session.json")
         session_data: dict = {}
         if os.path.exists(session_path):
@@ -207,8 +208,9 @@ def _sync_bird_env(auth_token: str, ct0: str) -> None:
     import shlex
 
     try:
+        from agent_reach.utils.paths import make_private_dir
         bird_dir = os.path.join(os.path.expanduser("~"), ".config", "bird")
-        os.makedirs(bird_dir, exist_ok=True)
+        make_private_dir(bird_dir)
         env_path = os.path.join(bird_dir, "credentials.env")
         with _open_owner_only(env_path) as f:
             f.write(f"AUTH_TOKEN={shlex.quote(auth_token)}\n")

--- a/agent_reach/utils/paths.py
+++ b/agent_reach/utils/paths.py
@@ -7,6 +7,23 @@ import sys
 from pathlib import Path
 
 
+def make_private_dir(path: str | Path) -> Path:
+    """Create a directory (and parents) restricted to the owner (0o700).
+
+    The leaf directory may hold secrets (cookies, tokens). On POSIX the mode is
+    enforced with an explicit chmod because ``mkdir``'s mode argument is masked
+    by the umask (commonly yielding world-traversable 0o755). On Windows chmod
+    cannot express this and is a no-op; the user-profile ACL already applies.
+    """
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(p, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+    return p
+
+
 def get_ytdlp_config_dir() -> Path:
     """Return the recommended yt-dlp user config directory for this OS."""
 

--- a/tests/test_private_dir.py
+++ b/tests/test_private_dir.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent_reach.utils.paths.make_private_dir and Config dir perms."""
+
+import os
+import stat
+import sys
+
+import pytest
+
+from agent_reach.config import Config
+from agent_reach.utils.paths import make_private_dir
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX file modes not enforced on Windows"
+)
+
+
+def test_creates_directory(tmp_path):
+    d = tmp_path / "a" / "b"
+    out = make_private_dir(d)
+    assert out.is_dir()
+    assert out == d
+
+
+@posix_only
+def test_leaf_is_owner_only(tmp_path):
+    d = tmp_path / "secrets"
+    make_private_dir(d)
+    mode = stat.S_IMODE(os.stat(d).st_mode)
+    assert mode == 0o700
+
+
+def test_idempotent_on_existing_dir(tmp_path):
+    d = tmp_path / "exists"
+    d.mkdir()
+    # Must not raise when the dir already exists.
+    make_private_dir(d)
+    assert d.is_dir()
+
+
+@posix_only
+def test_config_dir_is_owner_only(tmp_path, monkeypatch):
+    cfg_dir = tmp_path / ".agent-reach"
+    cfg_path = cfg_dir / "config.yaml"
+    monkeypatch.setattr(Config, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(Config, "CONFIG_FILE", cfg_path)
+    Config(config_path=cfg_path)  # __init__ calls _ensure_dir
+    mode = stat.S_IMODE(os.stat(cfg_dir).st_mode)
+    assert mode == 0o700


### PR DESCRIPTION
Config / cookie-sync dirs (`~/.agent-reach`, `~/.config/xfetch`, `~/.config/bird`) hold tokens and session cookies but were created with the default umask (often world-traversable 0o755). Files were already 0o600; this closes the dir gap. Adds `utils.paths.make_private_dir` (mkdir + explicit chmod 0o700; no-op on Windows). New `tests/test_private_dir.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
