### PR TITLE
[codex] remove AtomGit README promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10+-green.svg?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="https://github.com/Panniantong/agent-reach/stargazers"><img src="https://img.shields.io/github/stars/Panniantong/agent-reach?style=for-the-badge" alt="GitHub Stars"></a>
-  <a href="https://atomgit.com/qq_51337814/Agent-Reach"><img src="https://atomgit.com/qq_51337814/Agent-Reach/star/badge.svg" alt="AtomGit Stars"></a>
-</p>
-
-<p align="center">
-  🇨🇳 国内访问：本项目托管于 <a href="https://atomgit.com/qq_51337814/Agent-Reach">AtomGit 镜像</a>（与 GitHub 自动同步，克隆更快）
 </p>
 
 <p align="center">

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -12,11 +12,6 @@
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10+-green.svg?style=for-the-badge&logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="https://github.com/Panniantong/agent-reach/stargazers"><img src="https://img.shields.io/github/stars/Panniantong/agent-reach?style=for-the-badge" alt="GitHub Stars"></a>
-  <a href="https://atomgit.com/qq_51337814/Agent-Reach"><img src="https://atomgit.com/qq_51337814/Agent-Reach/star/badge.svg" alt="AtomGit Stars"></a>
-</p>
-
-<p align="center">
-  🇨🇳 In China? This project is also hosted on the <a href="https://atomgit.com/qq_51337814/Agent-Reach">AtomGit mirror</a> (auto-synced with GitHub, faster cloning)
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- remove the AtomGit badge and mirror promotion from the Chinese README header
- remove the same AtomGit mirror promotion from the English README header

## Why
The GitHub README was still showing the AtomGit promo because the previous removal was only local and had not reached the remote default branch.

## Checks
- git diff --cached --check
- text search confirmed no AtomGit/atomgit/domestic access/auto-synced references remain in the local README files