### PR TITLE
[codex] add AtomGit mirror to footer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Yes! Agent Reach is an installer + configuration tool — any AI coding agent th
 
 [腾讯云 OpenClaw](https://www.tencentcloud.com/act/pro/intl-openclaw?referral_code=G76Y819A&lang=zh&pg=) — 在腾讯云Lighthouse秒级部署OpenClaw全能助手，可通过对话丝滑接入Agent Reach，给你的OpenClaw一键装上互联网能力。
 
+[AtomGit 镜像](https://atomgit.com/qq_51337814/Agent-Reach) — Agent Reach 的 AtomGit 同步镜像，便于国内访问与克隆。
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date&v=20260309)](https://star-history.com/#Panniantong/Agent-Reach&Date)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -332,6 +332,8 @@ For collaboration or questions, add me on WeChat — I'll invite you to the comm
 
 [OpenClaw on Tencent Cloud](https://www.tencentcloud.com/act/pro/intl-openclaw?referral_code=G76Y819A&lang=en&pg=) — One-click OpenClaw on Tencent Cloud: chat to connect Agent Reach & unlock internet power.
 
+[AtomGit mirror](https://atomgit.com/qq_51337814/Agent-Reach) — Synchronized AtomGit mirror for Agent Reach.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Panniantong/Agent-Reach&type=Date&v=20260309)](https://star-history.com/#Panniantong/Agent-Reach&Date)


### PR DESCRIPTION
## Summary
- add the AtomGit mirror under the Chinese README footer links
- add the same AtomGit mirror under the English README Friends section

## Why
The mirror link should exist for the G-Star/AtomGit onboarding commitment, but it should live with the existing footer partner links instead of the README header.

## Checks
- git diff --check
- attempted pytest tests/ -v, but this local shell has no pytest command
- attempted python3 -m pytest tests/ -v, but system python3 has no pytest module