### PR TITLE
fix(core): use PEP 440 version comparison and fix Xueqiu cookie loading

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -85,7 +85,25 @@ def _load_cookies_from_browser() -> bool:
             if not any(c.get("name") == "xq_a_token" for c in cookies):
                 return False
             for c in cookies:
-                _cookie_jar.set(c["name"], c["value"], domain=c.get("domain", ".xueqiu.com"))
+                cookie = http.cookiejar.Cookie(
+                    version=0,
+                    name=c["name"],
+                    value=c["value"],
+                    port=None,
+                    port_specified=False,
+                    domain=c.get("domain", ".xueqiu.com"),
+                    domain_specified=True,
+                    domain_initial_dot=True,
+                    path=c.get("path", "/"),
+                    path_specified=True,
+                    secure=True,
+                    expires=None,
+                    discard=True,
+                    comment=None,
+                    comment_url=None,
+                    rest={},
+                )
+                _cookie_jar.set_cookie(cookie)
             return True
         except ImportError:
             import browser_cookie3

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1656,22 +1656,26 @@ _UPDATE_INSTRUCTIONS = (
 
 
 def _is_newer_version(remote: str, local: str) -> bool:
-    """True if remote is strictly newer than local (semantic compare).
+    """True if remote is strictly newer than local (PEP 440 compare).
 
     A plain != would tell users "update available" when their local build is
     AHEAD of the latest release (e.g. installed from main during a release
     window) — and walk them into a downgrade.
     """
-    def parse(v):
-        try:
-            return tuple(int(x) for x in v.strip().split("."))
-        except ValueError:
-            return None
-
-    r, l = parse(remote), parse(local)
-    if r is None or l is None:
-        return remote != local  # unparseable — fall back to old behavior
-    return r > l
+    try:
+        from packaging.version import Version, InvalidVersion
+        return Version(remote.strip()) > Version(local.strip())
+    except (InvalidVersion, Exception):
+        # Unparseable — fall back to tuple comparison
+        def parse(v):
+            try:
+                return tuple(int(x) for x in v.strip().split("."))
+            except ValueError:
+                return None
+        r, l = parse(remote), parse(local)
+        if r is None or l is None:
+            return remote != local
+        return r > l
 
 
 def _cmd_check_update():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "feedparser>=6.0",
     "python-dotenv>=1.0",
     "loguru>=0.7",
+    "packaging>=21.0",
     "pyyaml>=6.0",
     "rich>=13.0",
     "yt-dlp>=2024.0",


### PR DESCRIPTION
## Summary

Two bugfixes from audit report #378:

### Fix 1: P3-15 — Version comparison (`cli.py`)

**Problem:** `_is_newer_version()` uses manual tuple parsing that cannot handle PEP 440 versions (pre-release, post-release, dev, build metadata).

**Fix:** Use `packaging.version.Version` for proper PEP 440 comparison with graceful fallback to tuple comparison if parsing fails.

### Fix 2: P2-08 — Xueqiu browser cookie loading (`channels/xueqiu.py`)

**Problem:** `_cookie_jar.set(name, value, domain=...)` is called on `http.cookiejar.CookieJar` which does **not** have a `.set()` method (only `requests.cookies.RequestsCookieJar` does). This causes a silent `AttributeError` caught by the broad `except Exception`, making the rookiepy cookie path always fail.

**Fix:** Construct proper `http.cookiejar.Cookie` objects and use `_cookie_jar.set_cookie()`, consistent with the existing `_inject_cookie_string()` pattern in the same file.

## Changes

- `agent_reach/cli.py` — Replaced manual version parsing with `packaging.version.Version`
- `agent_reach/channels/xueqiu.py` — Fixed cookie loading to use proper Cookie objects
- `pyproject.toml` — Added `packaging>=21.0` dependency

## Verification

- `pip install -e .` — success
- `pytest tests/ -v` — **162 tests passed**

## References

Addresses P3-15 and P2-08 from #378