### PR TITLE
feat(skill): support project-local skill install scope

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -76,6 +76,9 @@ def main():
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
                                 "reddit,bilibili,linkedin,all)")
+    p_install.add_argument("--scope", choices=["auto", "project", "user"], default="auto",
+                           help="Skill install scope: auto (project if .claude/ found, else user), "
+                                "project (project-local .claude/skills/), user (global ~/.agents/skills/)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -108,6 +111,9 @@ def main():
                                help="Install SKILL.md to agent skill directories")
     p_skill_group.add_argument("--uninstall", action="store_true",
                                help="Remove SKILL.md from agent skill directories")
+    p_skill.add_argument("--scope", choices=["auto", "project", "user"], default="auto",
+                         help="Skill install scope: auto (project if .claude/ found, else user), "
+                              "project (project-local .claude/skills/), user (global ~/.agents/skills/)")
 
     # ── format ──
     p_format = sub.add_parser("format", help="Clean and format platform API output")
@@ -319,7 +325,7 @@ def _cmd_install(args):
         print()
 
         # ── Install agent skill ──
-        _install_skill()
+        _install_skill(scope=args.scope)
 
         print(f"✅ Installation complete! {ok}/{total} channels active.")
 
@@ -340,7 +346,26 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
-def _install_skill():
+def _find_project_claude_dir(start: str | None = None) -> str | None:
+    """Walk from start (default cwd) up to filesystem root looking for a .claude/ directory.
+
+    Returns the absolute path to the .claude directory if found, else None.
+    """
+    import os
+
+    current = os.path.abspath(start or os.getcwd())
+    while True:
+        candidate = os.path.join(current, ".claude")
+        if os.path.isdir(candidate):
+            return candidate
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def _install_skill(scope: str = "auto"):
     """Install Agent Reach as an agent skill (OpenClaw / Claude Code / .agents)."""
     import os
     import shutil
@@ -409,36 +434,73 @@ def _install_skill():
             print(f"  Warning: Could not install skill: {e}")
             return False
 
-    # Determine skill install path (priority: .agents > openclaw > claude)
-    skill_dirs = [
-        os.path.expanduser("~/.agents/skills"),      # Generic agents (priority)
-        os.path.expanduser("~/.openclaw/skills"),    # OpenClaw
-        os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
-    ]
+    # ── Scope-aware skill install (issue #333) ──
+    # scope=auto: project-local if .claude/ exists in cwd/parents, else global
+    # scope=project: always project-local (create .claude/skills/agent-reach if needed)
+    # scope=user: always global (existing behavior)
 
-    # Insert OPENCLAW_HOME path at the beginning if environment variable is set
-    openclaw_home = os.environ.get("OPENCLAW_HOME")
-    if openclaw_home:
-        skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
-
-    installed = False
-    for skill_dir in skill_dirs:
-        if os.path.isdir(skill_dir):
-            target = os.path.join(skill_dir, "agent-reach")
-            if _copy_skill_dir(target):
-                platform_name = "Agent" if ".agents" in skill_dir else "OpenClaw" if "openclaw" in skill_dir else "Claude Code"
-                print(f"Skill installed for {platform_name}: {target}")
-                installed = True
-
-    if not installed:
-        # No known skill directory found — create for .agents by default
-        target = os.path.expanduser("~/.agents/skills/agent-reach")
-        os.makedirs(os.path.dirname(target), exist_ok=True)
+    def _install_to_project(project_claude_dir: str) -> bool:
+        """Install skill to project-local .claude/skills/agent-reach."""
+        skills_dir = os.path.join(project_claude_dir, "skills")
+        os.makedirs(skills_dir, exist_ok=True)
+        target = os.path.join(skills_dir, "agent-reach")
         if _copy_skill_dir(target):
-            print(f"Skill installed: {target}")
+            print(f"Skill installed (project-local): {target}")
+            return True
+        return False
+
+    def _install_to_global() -> bool:
+        """Install skill to global/user directories (existing behavior)."""
+        skill_dirs = [
+            os.path.expanduser("~/.agents/skills"),      # Generic agents (priority)
+            os.path.expanduser("~/.openclaw/skills"),    # OpenClaw
+            os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
+        ]
+
+        # Insert OPENCLAW_HOME path at the beginning if environment variable is set
+        openclaw_home = os.environ.get("OPENCLAW_HOME")
+        if openclaw_home:
+            skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
+
+        installed = False
+        for skill_dir in skill_dirs:
+            if os.path.isdir(skill_dir):
+                target = os.path.join(skill_dir, "agent-reach")
+                if _copy_skill_dir(target):
+                    platform_name = "Agent" if ".agents" in skill_dir else "OpenClaw" if "openclaw" in skill_dir else "Claude Code"
+                    print(f"Skill installed for {platform_name}: {target}")
+                    installed = True
+
+        if not installed:
+            # No known skill directory found — create for .agents by default
+            target = os.path.expanduser("~/.agents/skills/agent-reach")
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            if _copy_skill_dir(target):
+                print(f"Skill installed: {target}")
+            else:
+                print("  -- Could not install agent skill (optional)")
+                print("  -- Tip: install OpenClaw, Claude Code, or create ~/.agents/skills/ manually")
+                return False
+        return True
+
+    if scope == "project":
+        project_claude = _find_project_claude_dir()
+        if project_claude:
+            _install_to_project(project_claude)
         else:
-            print("  -- Could not install agent skill (optional)")
-            print("  -- Tip: install OpenClaw, Claude Code, or create ~/.agents/skills/ manually")
+            # No .claude/ found — create in cwd
+            project_claude = os.path.join(os.getcwd(), ".claude")
+            os.makedirs(project_claude, exist_ok=True)
+            _install_to_project(project_claude)
+    elif scope == "user":
+        _install_to_global()
+    else:
+        # scope == "auto": prefer project-local if .claude/ exists
+        project_claude = _find_project_claude_dir()
+        if project_claude:
+            _install_to_project(project_claude)
+        else:
+            _install_to_global()
 
 
 def _uninstall_skill():
@@ -480,7 +542,7 @@ def _uninstall_skill():
 def _cmd_skill(args):
     """Manage agent skill registration."""
     if args.install:
-        _install_skill()
+        _install_skill(scope=args.scope)
     elif args.uninstall:
         _uninstall_skill()
 

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from agent_reach.cli import _install_skill, _uninstall_skill
+from agent_reach.cli import _install_skill, _uninstall_skill, _find_project_claude_dir
 
 
 class TestSkillCommand(unittest.TestCase):
@@ -107,7 +107,7 @@ class TestSkillCommand(unittest.TestCase):
                 env.pop("OPENCLAW_HOME", None)
                 env["LANG"] = "en_US.UTF-8"
                 with patch.dict(os.environ, env, clear=True):
-                    _install_skill()
+                    _install_skill(scope="user")
 
             target = os.path.join(skill_parent, "agent-reach", "SKILL.md")
             self.assertTrue(os.path.exists(target))
@@ -119,6 +119,131 @@ class TestSkillCommand(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(skill_parent, "agent-reach", "references"))
             )
+
+    # ── Tests for issue #333: --scope flag ──
+
+    def test_find_project_claude_dir_found_in_cwd(self):
+        """_find_project_claude_dir should find .claude in the given directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = os.path.join(tmpdir, ".claude")
+            os.makedirs(claude_dir)
+            result = _find_project_claude_dir(start=tmpdir)
+            self.assertEqual(result, claude_dir)
+
+    def test_find_project_claude_dir_found_in_parent(self):
+        """_find_project_claude_dir should find .claude in a parent directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = os.path.join(tmpdir, ".claude")
+            os.makedirs(claude_dir)
+            child = os.path.join(tmpdir, "sub", "deep")
+            os.makedirs(child)
+            result = _find_project_claude_dir(start=child)
+            self.assertEqual(result, claude_dir)
+
+    def test_find_project_claude_dir_not_found(self):
+        """_find_project_claude_dir returns None when no .claude exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _find_project_claude_dir(start=tmpdir)
+            self.assertIsNone(result)
+
+    def test_scope_auto_uses_project_local_when_claude_exists(self):
+        """scope=auto installs to project-local .claude/skills when .claude exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create project .claude dir
+            claude_dir = os.path.join(tmpdir, ".claude")
+            os.makedirs(claude_dir)
+
+            with patch("agent_reach.cli._find_project_claude_dir", return_value=claude_dir), \
+                 patch("agent_reach.cli.os.path.expanduser",
+                       side_effect=lambda p: p.replace("~", os.path.join(tmpdir, "home"))), \
+                 patch.dict(os.environ, {}, clear=False):
+                env = os.environ.copy()
+                env.pop("OPENCLAW_HOME", None)
+                with patch.dict(os.environ, env, clear=True):
+                    _install_skill(scope="auto")
+
+            target = os.path.join(claude_dir, "skills", "agent-reach", "SKILL.md")
+            self.assertTrue(os.path.exists(target))
+            with open(target, encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("Agent Reach", content)
+
+    def test_scope_user_ignores_project_local(self):
+        """scope=user installs to global dirs even when .claude exists in project."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create project .claude dir
+            claude_dir = os.path.join(tmpdir, "project", ".claude")
+            os.makedirs(claude_dir)
+
+            # Create a global skill dir
+            global_skill_dir = os.path.join(tmpdir, "home", ".agents", "skills")
+            os.makedirs(global_skill_dir)
+
+            with patch("agent_reach.cli._find_project_claude_dir", return_value=claude_dir), \
+                 patch("agent_reach.cli.os.path.expanduser",
+                       side_effect=lambda p: p.replace("~", os.path.join(tmpdir, "home"))), \
+                 patch.dict(os.environ, {}, clear=False):
+                env = os.environ.copy()
+                env.pop("OPENCLAW_HOME", None)
+                with patch.dict(os.environ, env, clear=True):
+                    _install_skill(scope="user")
+
+            # Should NOT install to project-local
+            project_target = os.path.join(claude_dir, "skills", "agent-reach", "SKILL.md")
+            self.assertFalse(os.path.exists(project_target))
+
+            # Should install to global
+            global_target = os.path.join(global_skill_dir, "agent-reach", "SKILL.md")
+            self.assertTrue(os.path.exists(global_target))
+
+    def test_scope_project_creates_claude_skills_when_no_claude_exists(self):
+        """scope=project creates .claude/skills/agent-reach in cwd when no .claude found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("agent_reach.cli._find_project_claude_dir", return_value=None), \
+                 patch("os.getcwd", return_value=tmpdir), \
+                 patch.dict(os.environ, {}, clear=False):
+                env = os.environ.copy()
+                env.pop("OPENCLAW_HOME", None)
+                with patch.dict(os.environ, env, clear=True):
+                    _install_skill(scope="project")
+
+            target = os.path.join(tmpdir, ".claude", "skills", "agent-reach", "SKILL.md")
+            self.assertTrue(os.path.exists(target))
+            with open(target, encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("Agent Reach", content)
+
+    def test_cli_parser_accepts_scope_for_install(self):
+        """The real CLI parser should pass --scope through to install."""
+        from agent_reach.cli import main
+
+        captured = {}
+
+        def fake_cmd_install(args):
+            captured["scope"] = args.scope
+            captured["dry_run"] = args.dry_run
+
+        with patch("sys.argv", ["agent-reach", "install", "--scope=project", "--dry-run"]), \
+             patch("agent_reach.cli._cmd_install", side_effect=fake_cmd_install):
+            main()
+
+        self.assertEqual(captured["scope"], "project")
+        self.assertTrue(captured["dry_run"])
+
+    def test_cli_parser_accepts_scope_for_skill_install(self):
+        """The real CLI parser should pass --scope through to skill --install."""
+        from agent_reach.cli import main
+
+        captured = {}
+
+        def fake_install_skill(scope="auto"):
+            captured["scope"] = scope
+
+        with patch("sys.argv", ["agent-reach", "skill", "--install", "--scope=user"]), \
+             patch("agent_reach.cli._install_skill", side_effect=fake_install_skill):
+            main()
+
+        self.assertEqual(captured["scope"], "user")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements #333 by making Agent Reach skill installation project-aware for Claude Code projects.

## Changes

- Add `--scope {auto,project,user}` to:
  - `agent-reach install`
  - `agent-reach skill --install`
- Add `_find_project_claude_dir()` helper to detect `.claude/` in cwd or parent directories.
- Update `_install_skill(scope="auto")`:
  - `auto`: install to project-local `.claude/skills/agent-reach` when `.claude/` exists, otherwise use existing global behavior.
  - `project`: install to project-local and create `<cwd>/.claude/skills/agent-reach` when needed.
  - `user`: preserve existing global/user install behavior.
- Add tests for scope behavior and CLI parser integration.

## Verification

- `pytest tests/test_skill_command.py -v` — 13 passed
- `pytest tests/ -v` — 170 passed

Closes #333