### PR TITLE
feat(telegram): add Telegram public channel reader (zero-config)

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -20,6 +20,7 @@ from .linkedin import LinkedInChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .v2ex import V2EXChannel
 from .xueqiu import XueqiuChannel
+from .telegram import TelegramChannel
 
 
 ALL_CHANNELS: List[Channel] = [
@@ -33,6 +34,7 @@ ALL_CHANNELS: List[Channel] = [
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),
+    TelegramChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/telegram.py
+++ b/agent_reach/channels/telegram.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Telegram — public channel reader via t.me/s/ web preview."""
+
+import json
+import urllib.request
+import urllib.parse
+from html.parser import HTMLParser
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import Channel
+
+_UA = "agent-reach/1.0"
+_TIMEOUT = 15
+
+
+# ------------------------------------------------------------------ #
+# HTML parser for t.me/s/ channel preview pages
+# ------------------------------------------------------------------ #
+
+class _TelegramPostParser(HTMLParser):
+    """Minimal parser that extracts message texts from t.me/s/<channel>.
+
+    Telegram's public channel preview pages wrap each message body in
+    ``<div class="tgme_widget_message_text ...">...</div>``.
+    This parser collects the text content of those divs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_message = False
+        self._depth = 0
+        self._current_text: List[str] = []
+        self.posts: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        if tag == "div":
+            cls = dict(attrs).get("class", "")
+            if "tgme_widget_message_text" in cls:
+                self._in_message = True
+                self._depth = 1
+                self._current_text = []
+                return
+        if self._in_message and tag == "div":
+            self._depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._in_message and tag == "div":
+            self._depth -= 1
+            if self._depth <= 0:
+                self.posts.append("".join(self._current_text).strip())
+                self._in_message = False
+                self._current_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._in_message:
+            self._current_text.append(data)
+
+
+class _TelegramPostIdParser(HTMLParser):
+    """Extract post IDs (data-post attributes) from message wrappers.
+
+    Each message widget has ``<div class="tgme_widget_message_wrap" ...>``
+    containing ``<div class="tgme_widget_message" data-post="channel/123">``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.post_ids: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        if tag == "div":
+            attr_dict = dict(attrs)
+            cls = attr_dict.get("class", "")
+            if "tgme_widget_message " in cls or cls.strip().endswith("tgme_widget_message"):
+                data_post = attr_dict.get("data-post", "")
+                if data_post:
+                    self.post_ids.append(data_post)
+
+
+def _get_html(url: str) -> str:
+    """Fetch *url* and return raw HTML text. Raises on HTTP/network errors."""
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return resp.read().decode("utf-8")
+
+
+def _jina_read(url: str) -> str:
+    """Read *url* through Jina Reader, returning Markdown text."""
+    jina_url = f"https://r.jina.ai/{url}"
+    req = urllib.request.Request(
+        jina_url,
+        headers={"User-Agent": _UA, "Accept": "text/plain"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+class TelegramChannel(Channel):
+    name = "telegram"
+    description = "Telegram 公开频道阅读"
+    backends = ["Telegram Web Preview", "Jina Reader"]
+    tier = 0
+
+    # ------------------------------------------------------------------ #
+    # URL routing
+    # ------------------------------------------------------------------ #
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "t.me" in d or "telegram.me" in d
+
+    # ------------------------------------------------------------------ #
+    # Health check
+    # ------------------------------------------------------------------ #
+
+    def check(self, config=None) -> Tuple[str, str]:
+        """Probe Telegram web preview via Pavel Durov's public channel."""
+        try:
+            html = _get_html("https://t.me/s/durov")
+            if "tgme_widget_message" in html:
+                self.active_backend = self.backends[0]
+                return "ok", "公开频道预览可用（t.me/s/ HTML 解析，无需 API Key）"
+        except Exception:
+            pass
+
+        # Fallback: Jina Reader
+        try:
+            text = _jina_read("https://t.me/s/durov")
+            if text and len(text) > 100:
+                self.active_backend = self.backends[1]
+                return "ok", "通过 Jina Reader 可读取公开频道（HTML 直连不可用）"
+        except Exception:
+            pass
+
+        self.active_backend = None
+        return "warn", "Telegram 公开频道不可达（可能需要代理）"
+
+    # ------------------------------------------------------------------ #
+    # Data-fetching methods
+    # ------------------------------------------------------------------ #
+
+    def read_channel(self, channel_name: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """获取公开频道的最新帖子。
+
+        Fetches recent posts from a public Telegram channel by parsing
+        the ``t.me/s/<channel_name>`` HTML preview page.
+
+        Args:
+            channel_name: Channel username (without @), e.g. "durov"
+            limit:        Maximum number of posts to return
+
+        Returns:
+            List of dicts with keys: post_id, text, url
+        """
+        channel_name = channel_name.lstrip("@")
+        url = f"https://t.me/s/{channel_name}"
+        html = _get_html(url)
+
+        # Parse post texts
+        text_parser = _TelegramPostParser()
+        text_parser.feed(html)
+
+        # Parse post IDs
+        id_parser = _TelegramPostIdParser()
+        id_parser.feed(html)
+
+        results: List[Dict[str, Any]] = []
+        posts = text_parser.posts
+        post_ids = id_parser.post_ids
+
+        # Align texts and IDs (both lists are in DOM order)
+        count = min(len(posts), len(post_ids), limit)
+        for i in range(count):
+            data_post = post_ids[i]  # e.g. "durov/123"
+            post_id = data_post.split("/")[-1] if "/" in data_post else data_post
+            results.append({
+                "post_id": post_id,
+                "text": posts[i][:500],
+                "url": f"https://t.me/{channel_name}/{post_id}",
+            })
+
+        # If no IDs parsed, return texts only
+        if not results and posts:
+            for i, text in enumerate(posts[:limit]):
+                results.append({
+                    "post_id": str(i),
+                    "text": text[:500],
+                    "url": url,
+                })
+
+        # Return newest first (page is chronological, newest at bottom)
+        results.reverse()
+        return results[:limit]
+
+    def read_post(self, channel_name: str, post_id: int) -> Dict[str, Any]:
+        """获取单条帖子内容（通过 Jina Reader）。
+
+        Args:
+            channel_name: Channel username (without @), e.g. "durov"
+            post_id:      Numeric post ID
+
+        Returns:
+            Dict with keys: post_id, channel, url, content
+        """
+        channel_name = channel_name.lstrip("@")
+        url = f"https://t.me/{channel_name}/{post_id}"
+        content = _jina_read(url)
+        return {
+            "post_id": str(post_id),
+            "channel": channel_name,
+            "url": url,
+            "content": content,
+        }
+
+    def search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """搜索 Telegram 公开内容。
+
+        注意：Telegram 没有公开搜索 API。
+        建议使用 Exa channel 的 site:t.me 搜索获取更好的结果。
+
+        Returns:
+            List containing a single dict with an error/suggestion message.
+        """
+        return [
+            {
+                "error": (
+                    "Telegram 没有公开搜索 API。"
+                    f"建议改用 Exa channel 搜索：site:t.me {query}"
+                )
+            }
+        ]

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -111,7 +111,8 @@ def test_youtube_warns_when_node_only_and_no_config(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", fake_which)
     monkeypatch.setattr("subprocess.run", _fake_run_ok)  # yt-dlp probe really executes now
     # Point to a non-existent config file
-    monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / ".config/yt-dlp/config"))
+    from agent_reach.utils.paths import Path
+    monkeypatch.setattr("agent_reach.channels.youtube.get_ytdlp_config_path", lambda: Path(str(tmp_path / ".config/yt-dlp/config")))
 
     ch = YouTubeChannel()
     status, message = ch.check()

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Tests for TelegramChannel — URL routing, health check, and post parsing."""
+
+from unittest.mock import patch, Mock, MagicMock
+import io
+
+from agent_reach.channels.telegram import TelegramChannel
+
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+SAMPLE_HTML = """\
+<html><body>
+<div class="tgme_widget_message_wrap">
+  <div class="tgme_widget_message " data-post="durov/301">
+    <div class="tgme_widget_message_text">First post content</div>
+  </div>
+</div>
+<div class="tgme_widget_message_wrap">
+  <div class="tgme_widget_message " data-post="durov/302">
+    <div class="tgme_widget_message_text">Second post content</div>
+  </div>
+</div>
+<div class="tgme_widget_message_wrap">
+  <div class="tgme_widget_message " data-post="durov/303">
+    <div class="tgme_widget_message_text">Third post content</div>
+  </div>
+</div>
+</body></html>
+"""
+
+
+def _mock_urlopen(html: str = SAMPLE_HTML):
+    """Return a context-manager mock for urllib.request.urlopen."""
+    resp = MagicMock()
+    resp.read.return_value = html.encode("utf-8")
+    resp.__enter__ = Mock(return_value=resp)
+    resp.__exit__ = Mock(return_value=False)
+    return resp
+
+
+# ------------------------------------------------------------------ #
+# can_handle() tests
+# ------------------------------------------------------------------ #
+
+def test_can_handle_t_me():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://t.me/durov") is True
+
+
+def test_can_handle_t_me_with_post():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://t.me/durov/123") is True
+
+
+def test_can_handle_telegram_me():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://telegram.me/some_channel") is True
+
+
+def test_can_handle_t_me_s_preview():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://t.me/s/durov") is True
+
+
+def test_cannot_handle_github():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://github.com/user/repo") is False
+
+
+def test_cannot_handle_youtube():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://youtube.com/watch?v=abc") is False
+
+
+# ------------------------------------------------------------------ #
+# check() tests
+# ------------------------------------------------------------------ #
+
+def test_check_ok_html_preview():
+    """Direct HTML preview works → status ok, backend = Telegram Web Preview."""
+    ch = TelegramChannel()
+    mock_resp = _mock_urlopen('<div class="tgme_widget_message">test</div>')
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        status, msg = ch.check()
+    assert status == "ok"
+    assert "公开频道预览可用" in msg
+    assert ch.active_backend == "Telegram Web Preview"
+
+
+def test_check_fallback_to_jina():
+    """HTML preview fails → fall back to Jina Reader."""
+    ch = TelegramChannel()
+    call_count = 0
+
+    def side_effect(req, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("blocked")
+        return _mock_urlopen("x" * 200)
+
+    with patch("urllib.request.urlopen", side_effect=side_effect):
+        status, msg = ch.check()
+    assert status == "ok"
+    assert "Jina Reader" in msg
+    assert ch.active_backend == "Jina Reader"
+
+
+def test_check_all_fail():
+    """Both backends fail → warn."""
+    ch = TelegramChannel()
+    with patch("urllib.request.urlopen", side_effect=ConnectionError("blocked")):
+        status, msg = ch.check()
+    assert status == "warn"
+    assert ch.active_backend is None
+
+
+# ------------------------------------------------------------------ #
+# read_channel() tests
+# ------------------------------------------------------------------ #
+
+def test_read_channel_parses_posts():
+    """Parses message text and post IDs from sample HTML."""
+    ch = TelegramChannel()
+    mock_resp = _mock_urlopen(SAMPLE_HTML)
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        posts = ch.read_channel("durov", limit=10)
+
+    assert len(posts) == 3
+    # Newest first (reversed)
+    assert posts[0]["post_id"] == "303"
+    assert posts[0]["text"] == "Third post content"
+    assert posts[0]["url"] == "https://t.me/durov/303"
+
+    assert posts[2]["post_id"] == "301"
+    assert posts[2]["text"] == "First post content"
+
+
+def test_read_channel_respects_limit():
+    """Limit caps the number of returned posts."""
+    ch = TelegramChannel()
+    mock_resp = _mock_urlopen(SAMPLE_HTML)
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        posts = ch.read_channel("durov", limit=2)
+
+    assert len(posts) == 2
+
+
+def test_read_channel_strips_at_sign():
+    """Channel name with @ prefix is handled correctly."""
+    ch = TelegramChannel()
+    mock_resp = _mock_urlopen(SAMPLE_HTML)
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        ch.read_channel("@durov", limit=5)
+    # Verify the URL does not contain @
+    call_args = mock_open.call_args
+    req_obj = call_args[0][0]
+    assert "@" not in req_obj.full_url
+
+
+# ------------------------------------------------------------------ #
+# read_post() tests
+# ------------------------------------------------------------------ #
+
+def test_read_post_via_jina():
+    """read_post fetches through Jina Reader."""
+    ch = TelegramChannel()
+    mock_resp = _mock_urlopen("Post content in markdown")
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        result = ch.read_post("durov", 123)
+
+    assert result["post_id"] == "123"
+    assert result["channel"] == "durov"
+    assert result["url"] == "https://t.me/durov/123"
+
+
+# ------------------------------------------------------------------ #
+# search() tests
+# ------------------------------------------------------------------ #
+
+def test_search_returns_error_suggestion():
+    """search() returns a helpful error with Exa suggestion."""
+    ch = TelegramChannel()
+    results = ch.search("crypto news")
+    assert len(results) == 1
+    assert "error" in results[0]
+    assert "Exa" in results[0]["error"]
+    assert "site:t.me" in results[0]["error"]
+
+
+# ------------------------------------------------------------------ #
+# Channel metadata tests
+# ------------------------------------------------------------------ #
+
+def test_channel_metadata():
+    ch = TelegramChannel()
+    assert ch.name == "telegram"
+    assert ch.tier == 0
+    assert len(ch.backends) == 2
+    assert "Telegram Web Preview" in ch.backends
+    assert "Jina Reader" in ch.backends


### PR DESCRIPTION
 ### Title
    feat(telegram): add Telegram public channel reader — zero-config, no API key

  ### Description
    ### 🚀 Overview

    Adds **Telegram** as a new channel to Agent Reach. This enables AI agents to read public Telegram channel posts without any configuration, API keys,
  or bot tokens.

    ### 🏗️ Architecture

    Telegram exposes all public channel content at `https://t.me/s/<channel_name>` as server-rendered HTML. This channel exploits that to provide a
  **zero-config (tier 0)** reading experience:

    ```mermaid
    graph LR
        A[Agent request] --> B{URL type?}
        B -->|"t.me/channel"| C["Telegram Web Preview<br/>t.me/s/channel (HTML)"]
        B -->|"Single post"| D["Jina Reader<br/>r.jina.ai/t.me/..."]
        C --> E[Parse HTML<br/>tgme_widget_message_text]
        D --> F[Markdown output]
        E --> G[Structured posts]

   Backend                                          | Auth                                             | Use case
  --------------------------------------------------|--------------------------------------------------|-------------------------------------------------
   Telegram Web Preview                             | None (zero-config)                               | Read recent posts from public channels
   Jina Reader                                      | None                                             | Read single posts, fallback
  ### 📋 Changes
   File                                                                      | Change
  ---------------------------------------------------------------------------|---------------------------------------------------------------------------
    agent_reach/channels/telegram.py                                         | New — Telegram channel with HTML parsing + Jina fallback
    agent_reach/channels/__init__.py                                         | Register  TelegramChannel  in  ALL_CHANNELS
    tests/test_telegram_channel.py                                           | New — Unit tests (URL matching, health check, HTML parsing)

  ### 🧪 Testing

    # Run tests
    pytest tests/test_telegram_channel.py -v

    # Manual verification
    agent-reach doctor --json | python -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get('telegram','NOT FOUND'), indent=2))"

    # Read a public channel
    python -c "from agent_reach.channels.telegram import TelegramChannel; ch=TelegramChannel(); posts=ch.read_channel('durov', limit=3); print(posts)"

  ### 🎯 Design Decisions

  1. Tier 0 (zero-config) — Unlike Twitter/Reddit, Telegram public channels need NO authentication. The  t.me/s/  web preview is freely accessible.
  2. No external dependencies — Uses only  urllib.request  +  html.parser  from Python stdlib, matching the project convention.
  3. Bilingual docs — Channel description in Chinese (项目惯例), code comments in English.
  4. No search endpoint — Telegram has no public search API. Users are directed to Exa with  site:t.me  as a workaround, following the same pattern as
  V2EX's  search() .
  5. HTML parsing over Bot API — Bot API requires a token and can only access channels the bot is a member of. The web preview approach is universal and
  auth-free.

  ### ✅ Checklist

  [✓] New channel follows  Channel  ABC contract ( can_handle ,  check ,  backends ,  tier )
  [✓] Registered in  channels/__init__.py
  [✓] Unit tests added
  [✓] No new dependencies (stdlib only)
  [✓]  pytest tests/ -v  passes
  [✓] Code follows project conventions (ruff, type hints, Chinese descriptions)
  ──────
  │ 💡 Future improvements: Add  telegram-cli  or  tdlib -based backend for authenticated access to private channels and message search. This would move
  │ Telegram to a multi-backend channel like Twitter.