### PR TITLE
fix(xueqiu): populate pe_ttm/pb/eps in get_stock_quote

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -190,13 +190,27 @@ class XueqiuChannel(Channel):
 
         Returns a dict with keys:
           symbol, name, current, percent, chg, high, low, open, last_close,
-          volume, amount, market_capital, turnover_rate, pe_ttm, timestamp
+          volume, amount, market_capital, turnover_rate, pe_ttm, pe_forecast,
+          pb, eps, timestamp
+
+        Note:
+            Uses the ``extend=detail`` quote endpoint instead of
+            ``batch/quote.json``. The batch endpoint omits valuation fields,
+            so ``pe_ttm`` (and pb/eps) always came back ``None``. The detail
+            endpoint returns every field the batch one does, plus
+            pe_ttm/pe_forecast/pb/eps — and ``None`` for instruments that
+            legitimately have no valuation (e.g. indices).
         """
         data = _get_json(
-            f"https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol={symbol}"
+            f"https://stock.xueqiu.com/v5/stock/quote.json?symbol={symbol}&extend=detail"
         )
-        items = (data.get("data") or {}).get("items") or []
-        q = (items[0].get("quote") or {}) if items else {}
+        d = data.get("data") or {}
+        # detail endpoint -> data.quote ; batch endpoint -> data.items[0].quote
+        q = d.get("quote")
+        if not q:
+            items = d.get("items") or []
+            q = (items[0].get("quote") or {}) if items else {}
+        q = q or {}
         return {
             "symbol": q.get("symbol", symbol),
             "name": q.get("name", ""),
@@ -212,6 +226,9 @@ class XueqiuChannel(Channel):
             "market_capital": q.get("market_capital"),
             "turnover_rate": q.get("turnover_rate"),
             "pe_ttm": q.get("pe_ttm"),
+            "pe_forecast": q.get("pe_forecast"),
+            "pb": q.get("pb"),
+            "eps": q.get("eps"),
             "timestamp": q.get("timestamp"),
         }
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -429,6 +429,56 @@ class TestXueqiuChannel:
         assert quote["percent"] == 1.5
         assert quote["volume"] == 12345678
 
+    def test_get_stock_quote_detail_valuation(self, monkeypatch):
+        """The detail endpoint shape (data.quote) must expose valuation fields.
+
+        Regression for the batch endpoint omitting pe_ttm/pb/eps, which made
+        them always None.
+        """
+        import agent_reach.channels.xueqiu as xueqiu_mod
+
+        monkeypatch.setattr(xueqiu_mod, "_cookies_initialized", True)
+
+        # extend=detail returns a single `quote` object under `data`,
+        # not an `items` array.
+        fake_data = {
+            "data": {
+                "quote": {
+                    "symbol": "SH601138",
+                    "name": "工业富联",
+                    "current": 78.08,
+                    "percent": 7.49,
+                    "volume": 424968166,
+                    "market_capital": 1549426725535.0,
+                    "turnover_rate": 2.14,
+                    "pe_ttm": 38.117,
+                    "pe_forecast": 36.561,
+                    "pb": 8.793,
+                    "eps": 2.05,
+                    "timestamp": 1781766000000,
+                }
+            }
+        }
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_data).encode()
+
+        monkeypatch.setattr(xueqiu_mod._opener, "open", lambda req, timeout=None: FakeResponse())
+        quote = XueqiuChannel().get_stock_quote("SH601138")
+        assert quote["name"] == "工业富联"
+        assert quote["pe_ttm"] == 38.117
+        assert quote["pe_forecast"] == 36.561
+        assert quote["pb"] == 8.793
+        assert quote["eps"] == 2.05
+        assert quote["market_capital"] == 1549426725535.0
+
     # ------------------------------------------------------------------ #
     # search_stock
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
Fixes #398.

## Problem

`XueqiuChannel.get_stock_quote()` advertises a `pe_ttm` key but it was always `None` for every symbol. It queried `batch/quote.json`, whose `quote` object contains no valuation fields (`pe_ttm`/`pb`/`eps` simply aren't in the payload).

## Fix

Switch to the **detail** endpoint `https://stock.xueqiu.com/v5/stock/quote.json?symbol=...&extend=detail`. Its `data.quote` is a superset of the batch `quote` and additionally carries `pe_ttm`, `pe_forecast`, `pb`, `eps`.

- Parsing accepts **both** response shapes (`data.quote` for detail, `data.items[0].quote` for batch) so it's resilient if the endpoint shape ever changes.
- Added `pe_forecast`, `pb`, `eps` to the returned dict (and updated the docstring). Existing keys are unchanged.
- `check()` still uses the batch endpoint — untouched.

## Testing

- New regression test `test_get_stock_quote_detail_valuation` asserts the detail-shaped response populates `pe_ttm`/`pe_forecast`/`pb`/`eps`.
- Existing `test_get_stock_quote` (batch shape) still passes via the fallback path.
- Full suite: `pytest tests/test_channels.py` → **59 passed**.
- Verified live across markets (cookie configured):
  | symbol | pe_ttm |
  |---|---|
  | SH601138 工业富联 | 38.1 |
  | AAPL 苹果 | 35.7 |
  | 00700 腾讯 | 15.1 |
  | SH000001 上证指数 | None (correct — index) |