### PR TITLE
docs: add shared agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Project
+Agent Reach is a Python CLI + library that gives AI agents read/search access to internet platforms.
+It is a capability layer and installer/doctor for upstream tools — not a wrapper around them.
+
+## What to read first
+- `README.md` for the public-facing overview and supported platforms
+- `docs/install.md` and `docs/update.md` for install/update flow
+- `docs/troubleshooting.md` for common failure modes
+- `CLAUDE.md` for the repo's detailed agent notes and conventions
+
+## Working rules
+- Prefer the smallest safe change that solves the actual problem.
+- Do not re-architect upstream tools or invent new scraping paths when an existing backend works.
+- Keep changes aligned with the repo's "glue layer" design: route and call upstream tools directly.
+- If behavior changes, update tests and docs together.
+- Run the relevant tests before claiming success; for broad changes, use `pytest tests/ -v`.
+- Keep version numbers in sync across `pyproject.toml`, `agent_reach/__init__.py`, and `tests/test_cli.py`.
+- Use a feature branch; do not push directly to `main`.
+
+## Platform/auth conventions
+- Cookie-based auth for Twitter/XHS: use Cookie-Editor export, not QR scan.
+- Treat local credentials as local-only; do not upload tokens/cookies into the repo.
+- Follow the installer's safe mode when an environment is uncertain.
+
+## Useful commands
+- `python -m agent_reach.cli doctor`
+- `python -m agent_reach.cli install --env=auto`
+- `pytest tests/ -v`
+- `bash test.sh`
+
+## Notes for multi-agent setups
+- Hermes, Codex, OpenCode, Claude Code, and similar agents should all follow this file.
+- If a tool has its own project-memory file, this repo should still use the same shared conventions above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Shared agent instructions
+- This repo also has `AGENTS.md`; treat it as the shared baseline for Hermes, Codex, OpenCode, Claude Code, and similar agents.
+- Keep the repo in "glue layer" mode: route and call upstream tools directly instead of re-architecting them.
+
 ## Project
 Agent Reach — Python CLI + library that gives AI agents read/search access to 13 internet platforms.
 Positioning: installer + doctor + config tool. NOT a wrapper — after install, agents call upstream tools directly.


### PR DESCRIPTION
## Summary
- Add repo-wide `AGENTS.md` guidance for Hermes, Codex, OpenCode, Claude Code, and other coding agents
- Update `CLAUDE.md` to point agents at the shared instructions
- Preserve the repo’s glue-layer approach and version-sync expectations

## Test Plan
- Documentation-only change; no runtime tests needed