### PR TITLE
feat(health): add Channel Health Registry

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 """
 Agent Reach CLI — installer, doctor, and configuration tool.
 
@@ -126,6 +126,7 @@ def main():
 
     # ── watch ──
     sub.add_parser("watch", help="Quick health check + update check (for scheduled tasks)")
+    sub.add_parser("health", help="Show channel health status")
 
     # ── version ──
     sub.add_parser("version", help="Show version")
@@ -149,6 +150,8 @@ def main():
         _cmd_check_update()
     elif args.command == "watch":
         _cmd_watch()
+    elif args.command == "health":
+        _cmd_health(args)
     elif args.command == "setup":
         _cmd_setup()
     elif args.command == "install":
@@ -1736,6 +1739,20 @@ def _cmd_check_update():
     return "error"
 
 
+def _cmd_health(args=None):
+    """Print channel health status table."""
+    from agent_reach.config import Config
+    from agent_reach.doctor import check_all
+    from agent_reach.health import get_registry
+
+    config = Config()
+    check_all(config)  # Populates the health registry
+    registry = get_registry()
+
+    for name in sorted(registry.get_all_health().keys()):
+        health = registry.get_health(name)
+        print(f"{health.channel_name:20s} {health.status.value.upper()}")
+
 def _cmd_watch():
     """Quick health check + update check, designed for scheduled tasks.
 
@@ -1803,3 +1820,4 @@ def _cmd_watch():
 
 if __name__ == "__main__":
     main()
+

--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 """Environment health checker — powered by channels.
 
 Each channel knows how to check itself. Doctor just collects the results.
@@ -7,6 +7,7 @@ Each channel knows how to check itself. Doctor just collects the results.
 from typing import Dict
 from agent_reach.config import Config
 from agent_reach.channels import get_all_channels
+from agent_reach.health import update_from_doctor_results
 
 
 def check_all(config: Config) -> Dict[str, dict]:
@@ -32,6 +33,10 @@ def check_all(config: Config) -> Dict[str, dict]:
             "backends": ch.backends,
             "active_backend": active,
         }
+
+    # Populate the shared health registry (fire-and-forget side effect).
+    update_from_doctor_results(results)
+
     return results
 
 
@@ -125,3 +130,4 @@ def format_report(results: Dict[str, dict]) -> str:
             pass
 
     return "\n".join(lines)
+

--- a/agent_reach/health.py
+++ b/agent_reach/health.py
@@ -1,0 +1,87 @@
+﻿# -*- coding: utf-8 -*-
+"""Channel health state — populated transparently when doctor runs.
+
+Usage::
+
+    from agent_reach.health import get_registry
+
+    registry = get_registry()
+    health = registry.get_health("github")
+    print(health.status)   # ChannelStatus.HEALTHY
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, Optional
+
+
+class ChannelStatus(Enum):
+    """Current health of a single channel."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass
+class ChannelHealth:
+    """Health record for one channel at a point in time."""
+
+    channel_name: str
+    status: ChannelStatus
+    last_checked: datetime
+    failure_reason: Optional[str] = None
+
+
+class HealthRegistry:
+    """In-memory store of the latest channel health state."""
+
+    def __init__(self):
+        self._health: Dict[str, ChannelHealth] = {}
+
+    def update_health(self, channel_name: str, health: ChannelHealth) -> None:
+        self._health[channel_name] = health
+
+    def get_health(self, channel_name: str) -> Optional[ChannelHealth]:
+        return self._health.get(channel_name)
+
+    def get_all_health(self) -> Dict[str, ChannelHealth]:
+        return dict(self._health)
+
+
+_registry = HealthRegistry()
+
+
+def get_registry() -> HealthRegistry:
+    return _registry
+
+
+_STATUS_MAP = {
+    "ok": ChannelStatus.HEALTHY,
+    "warn": ChannelStatus.DEGRADED,
+    "off": ChannelStatus.UNAVAILABLE,
+    "error": ChannelStatus.DEGRADED,
+}
+
+
+def update_from_doctor_results(results: Dict[str, dict]) -> None:
+    """Populate the registry from a ``doctor.check_all()`` result dict."""
+    registry = get_registry()
+    for name, data in results.items():
+        health = ChannelHealth(
+            channel_name=name,
+            status=_STATUS_MAP.get(data["status"], ChannelStatus.DEGRADED),
+            last_checked=datetime.now(timezone.utc),
+            failure_reason=data.get("message") if data.get("status") != "ok" else None,
+        )
+        registry.update_health(name, health)
+
+
+__all__ = [
+    "ChannelStatus",
+    "ChannelHealth",
+    "HealthRegistry",
+    "get_registry",
+    "update_from_doctor_results",
+]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 """Tests for doctor module."""
 
 import pytest
@@ -124,3 +124,61 @@ def test_stale_active_backend_does_not_leak_into_errored_result(monkeypatch):
     results = doctor.check_all(config=None)
     assert results["boom"]["status"] == "error"
     assert results["boom"]["active_backend"] is None
+
+
+
+class TestDoctorHealthRegistryIntegration:
+    """Verify that check_all() populates the shared HealthRegistry."""
+
+    def test_registry_updated_after_check_all(self, tmp_config, monkeypatch):
+        s1 = _StubChannel(
+            "h_ok", "OK Channel", 0, "ok", "全部正常", ["tool"], active_backend="tool"
+        )
+        s2 = _StubChannel(
+            "h_warn_auth", "Miss Auth", 1, "warn", "未登录",
+        )
+        s3 = _StubChannel(
+            "h_warn_missing", "Not Installed", 1, "warn", "未安装 tool",
+        )
+        s4 = _StubChannel(
+            "h_off", "Unavailable", 2, "off", "tool 不可用",
+        )
+        s5 = _StubChannel(
+            "h_error", "Broken", 2, "error", "启动异常",
+        )
+        s6 = _StubChannel(
+            "h_rate", "Rate Limited", 1, "warn", "rate limit exceeded",
+        )
+
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [s1, s2, s3, s4, s5, s6],
+        )
+
+        from agent_reach.health import ChannelStatus, get_registry
+
+        doctor.check_all(tmp_config)
+        registry = get_registry()
+
+        assert registry.get_health("h_ok").status == ChannelStatus.HEALTHY
+        assert registry.get_health("h_warn_auth").status == ChannelStatus.DEGRADED
+        assert registry.get_health("h_warn_missing").status == ChannelStatus.DEGRADED
+        assert registry.get_health("h_off").status == ChannelStatus.UNAVAILABLE
+        assert registry.get_health("h_error").status == ChannelStatus.DEGRADED
+        assert registry.get_health("h_rate").status == ChannelStatus.DEGRADED
+
+    def test_health_record_contains_details(self, tmp_config, monkeypatch):
+        s = _StubChannel("h_detail", "Detail Test", 0, "warn", "gh 未安装")
+        monkeypatch.setattr(doctor, "get_all_channels", lambda: [s])
+
+        from agent_reach.health import get_registry
+
+        doctor.check_all(tmp_config)
+        health = get_registry().get_health("h_detail")
+
+        assert health is not None
+        assert health.channel_name == "h_detail"
+        assert health.failure_reason == "gh 未安装"
+        assert health.last_checked is not None
+

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,111 @@
+﻿# -*- coding: utf-8 -*-
+"""Tests for the Channel Health Registry."""
+
+from datetime import datetime
+
+import pytest
+
+from agent_reach.health import (
+    ChannelStatus,
+    ChannelHealth,
+    HealthRegistry,
+    get_registry,
+    update_from_doctor_results,
+)
+
+
+class TestChannelStatus:
+    def test_members_have_correct_values(self):
+        assert ChannelStatus.HEALTHY.value == "healthy"
+        assert ChannelStatus.DEGRADED.value == "degraded"
+        assert ChannelStatus.UNAVAILABLE.value == "unavailable"
+
+
+class TestChannelHealth:
+    def test_basic_fields(self):
+        now = datetime(2026, 6, 18, 12, 0, 0)
+        h = ChannelHealth(
+            channel_name="github",
+            status=ChannelStatus.HEALTHY,
+            last_checked=now,
+        )
+        assert h.channel_name == "github"
+        assert h.status == ChannelStatus.HEALTHY
+        assert h.last_checked == now
+        assert h.failure_reason is None
+
+    def test_with_failure_reason(self):
+        now = datetime.now()
+        h = ChannelHealth(
+            channel_name="twitter",
+            status=ChannelStatus.DEGRADED,
+            last_checked=now,
+            failure_reason="Cookie expired",
+        )
+        assert h.failure_reason == "Cookie expired"
+
+
+class TestHealthRegistry:
+    def test_update_and_get(self):
+        registry = HealthRegistry()
+        now = datetime.now()
+        h = ChannelHealth("github", ChannelStatus.HEALTHY, now)
+        registry.update_health("github", h)
+        assert registry.get_health("github") is h
+        assert registry.get_health("unknown") is None
+
+    def test_get_all_health(self):
+        registry = HealthRegistry()
+        now = datetime.now()
+        h1 = ChannelHealth("github", ChannelStatus.HEALTHY, now)
+        h2 = ChannelHealth("twitter", ChannelStatus.DEGRADED, now)
+        registry.update_health("github", h1)
+        registry.update_health("twitter", h2)
+        all_h = registry.get_all_health()
+        assert all_h == {"github": h1, "twitter": h2}
+
+    def test_update_replaces_existing(self):
+        registry = HealthRegistry()
+        now = datetime.now()
+        h1 = ChannelHealth("github", ChannelStatus.HEALTHY, now)
+        h2 = ChannelHealth("github", ChannelStatus.DEGRADED, now, failure_reason="API timeout")
+        registry.update_health("github", h1)
+        registry.update_health("github", h2)
+        assert registry.get_health("github").status == ChannelStatus.DEGRADED
+
+    def test_get_all_returns_copy(self):
+        registry = HealthRegistry()
+        all_h = registry.get_all_health()
+        assert isinstance(all_h, dict)
+
+    def test_singleton_get_registry(self):
+        r1 = get_registry()
+        r2 = get_registry()
+        assert r1 is r2
+
+
+class TestDoctorStatusMapping:
+    @pytest.mark.parametrize(
+        ("doctor_status", "expected"),
+        [
+            ("ok", ChannelStatus.HEALTHY),
+            ("warn", ChannelStatus.DEGRADED),
+            ("off", ChannelStatus.UNAVAILABLE),
+            ("error", ChannelStatus.DEGRADED),
+        ],
+    )
+    def test_mapping(self, doctor_status, expected):
+        results = {
+            "ch": {"status": doctor_status, "message": "irrelevant", "name": "...",
+                   "tier": 0, "backends": [], "active_backend": None},
+        }
+        update_from_doctor_results(results)
+        assert get_registry().get_health("ch").status == expected
+
+    def test_unknown_status_falls_to_degraded(self):
+        results = {
+            "ch": {"status": "bogus", "message": "weird", "name": "...",
+                   "tier": 0, "backends": [], "active_backend": None},
+        }
+        update_from_doctor_results(results)
+        assert get_registry().get_health("ch").status == ChannelStatus.DEGRADED


### PR DESCRIPTION
Lightweight in-memory health registry populated transparently when doctor runs.  Exposes current channel state (HEALTHY/DEGRADED/UNAVAILABLE) via gent-reach health and the get_registry() API.

- ChannelStatus, ChannelHealth, HealthRegistry in new health.py
- doctor.check_all() stores results in the shared registry
- gent-reach health prints a simple status table
- No routing, scoring, or persistence — just state