### PR TITLE
feat(hermes): add Hermes Agent skill support

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -409,36 +409,116 @@ def _install_skill():
             print(f"  Warning: Could not install skill: {e}")
             return False
 
-    # Determine skill install path (priority: .agents > openclaw > claude)
-    skill_dirs = [
-        os.path.expanduser("~/.agents/skills"),      # Generic agents (priority)
-        os.path.expanduser("~/.openclaw/skills"),    # OpenClaw
-        os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
-    ]
+    def _copy_hermes_skill(target: str) -> bool:
+        """Copy Hermes-specific SKILL.md (SKILL_hermes.md) to target dir."""
+        try:
+            if os.path.islink(target):
+                os.unlink(target)
+            elif os.path.exists(target):
+                shutil.rmtree(target)
+            os.makedirs(target, exist_ok=True)
 
-    # Insert OPENCLAW_HOME path at the beginning if environment variable is set
+            # Get the Hermes-specific skill file from package
+            try:
+                from pathlib import Path as _Path
+                skill_pkg = _Path(str(importlib.resources.files("agent_reach"))) / "skill"
+            except Exception:
+                from pathlib import Path as _Path
+                skill_pkg = _Path(__file__).resolve().parent / "skill"
+
+            hermes_skill = skill_pkg.joinpath("SKILL_hermes.md")
+            if hermes_skill.exists():
+                with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
+                    f.write(hermes_skill.read_text(encoding="utf-8"))
+            else:
+                # Fall back to default skill file
+                skill_md = skill_pkg.joinpath("SKILL.md").read_text(encoding="utf-8")
+                with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
+                    f.write(skill_md)
+
+            # Copy references/ directory — best-effort, not a blocker
+            try:
+                refs_pkg = skill_pkg.joinpath("references")
+                if refs_pkg.is_dir():
+                    refs_target = os.path.join(target, "references")
+                    os.makedirs(refs_target, exist_ok=True)
+                    for ref_file in refs_pkg.iterdir():
+                        name = ref_file.name
+                        if name.endswith(".md"):
+                            content = ref_file.read_text(encoding="utf-8")
+                            with open(os.path.join(refs_target, name), "w", encoding="utf-8") as f:
+                                f.write(content)
+            except Exception:
+                # references/ is optional — don't fail the install
+                pass
+
+            return True
+        except Exception as e:
+            print(f"  Warning: Could not install Hermes skill: {e}")
+            return False
+
+    # ── Build skill directory list with explicit platform tags ─────────────
+    # Each entry is (expanded_path, platform_label).
+    # Platform identity is assigned at insertion time so the loop never
+    # needs to guess it from path substrings.
+    skill_dirs: list[tuple[str, str]] = []
+
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        skill_dirs.append((os.path.join(hermes_home, "skills"), "Hermes Agent"))
+        # Dual-install note: if HERMES_HOME != ~/.hermes, both that custom
+        # path AND ~/.hermes/skills (below) are provisioned. This is intentional
+        # — guarantees coverage regardless of which path the gateway reads.
+
+    skill_dirs.append((os.path.expanduser("~/.hermes/skills"), "Hermes Agent"))
+    skill_dirs.append((os.path.expanduser("~/.agents/skills"), "Agent"))
+
     openclaw_home = os.environ.get("OPENCLAW_HOME")
     if openclaw_home:
-        skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
+        skill_dirs.append((os.path.join(openclaw_home, ".openclaw", "skills"), "OpenClaw"))
 
+    skill_dirs.append((os.path.expanduser("~/.openclaw/skills"), "OpenClaw"))
+    skill_dirs.append((os.path.expanduser("~/.claude/skills"), "Claude Code"))
+
+    # ── Install loop ──────────────────────────────────────────────────────
     installed = False
-    for skill_dir in skill_dirs:
-        if os.path.isdir(skill_dir):
-            target = os.path.join(skill_dir, "agent-reach")
-            if _copy_skill_dir(target):
-                platform_name = "Agent" if ".agents" in skill_dir else "OpenClaw" if "openclaw" in skill_dir else "Claude Code"
-                print(f"Skill installed for {platform_name}: {target}")
-                installed = True
+    for skill_dir, platform_name in skill_dirs:
+        if not os.path.isdir(skill_dir):
+            continue
+
+        target = os.path.join(skill_dir, "agent-reach")
+
+        if platform_name == "Hermes Agent":
+            ok = _copy_hermes_skill(target)
+        else:
+            ok = _copy_skill_dir(target)
+
+        if ok:
+            print(f"  ✓ Skill installed for {platform_name}: {target}")
+            installed = True
 
     if not installed:
         # No known skill directory found — create for .agents by default
         target = os.path.expanduser("~/.agents/skills/agent-reach")
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        if _copy_skill_dir(target):
-            print(f"Skill installed: {target}")
-        else:
-            print("  -- Could not install agent skill (optional)")
-            print("  -- Tip: install OpenClaw, Claude Code, or create ~/.agents/skills/ manually")
+        parent_dir = os.path.dirname(target)
+
+        # Broken symlink (e.g. from stow/chezmoi dotfile managers) causes
+        # os.makedirs(exist_ok=True) to raise FileExistsError — os.path.isdir()
+        # returns False for broken links, so exist_ok's safety check fails.
+        # Unlink the dead link before creating the directory.
+        if os.path.islink(parent_dir) and not os.path.exists(parent_dir):
+            os.unlink(parent_dir)
+
+        try:
+            os.makedirs(parent_dir, exist_ok=True)
+            if _copy_skill_dir(target):
+                print(f"Skill installed: {target}")
+            else:
+                print("  -- Could not install agent skill (optional)")
+                print("  -- Tip: install OpenClaw, Claude Code, Hermes Agent, or create ~/.agents/skills/ manually")
+        except Exception as e:
+            print(f"  -- Could not initialize default fallback path: {e}")
+            print("  -- Tip: install OpenClaw, Claude Code, Hermes Agent, or create ~/.agents/skills/ manually")
 
 
 def _uninstall_skill():
@@ -446,10 +526,16 @@ def _uninstall_skill():
     import shutil
 
     skill_dirs = [
+        ("~/.hermes/skills/agent-reach", "Hermes Agent"),
         ("~/.openclaw/skills/agent-reach", "OpenClaw"),
         ("~/.claude/skills/agent-reach", "Claude Code"),
         ("~/.agents/skills/agent-reach", "Agent"),
     ]
+
+    # Also check HERMES_HOME
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        skill_dirs.insert(0, (os.path.join(hermes_home, "skills", "agent-reach"), "Hermes Agent"))
 
     # Also check OPENCLAW_HOME
     openclaw_home = os.environ.get("OPENCLAW_HOME")

--- a/agent_reach/skill/SKILL_hermes.md
+++ b/agent_reach/skill/SKILL_hermes.md
@@ -1,0 +1,84 @@
+---
+name: agent-reach
+description: "Give your AI Agent eyes to see the entire internet — search & read 13+ platforms (Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, LinkedIn, RSS, Web, V2EX, Xueqiu, Xiaoyuzhou). Multi-backend routing with auto-fallback."
+version: 1.5.0
+author: Neo Reid
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [web, research, search, social-media, github, youtube, rss, scraping, agent-reach]
+    related_skills: [web-search, youtube-content, github-code-review, arxiv]
+    homepage: https://github.com/Panniantong/Agent-Reach
+triggers:
+  - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
+  - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
+  - social:
+    - 小红书: xiaohongshu/xhs/小红书/红书
+    - Twitter: twitter/推特/x.com/推文
+    - B站: bilibili/b站/哔哩哔哩
+    - V2EX: v2ex
+    - Reddit: reddit
+  - career: 招聘/职位/求职/linkedin/领英/找工作
+  - dev: github/代码/仓库/gh/issue/pr/分支/commit
+  - web: 网页/链接/文章/rss/读一下/打开这个
+  - video: youtube/视频/播客/字幕/小宇宙/转录/yt
+  - finance: 雪球/股票/stock/xueqiu/行情/基金
+---
+
+# Agent Reach — Internet Access Router
+
+Gives Hermes read/search access to **13+ platforms** through a unified capability layer. Agent Reach handles install, config, health checks, and multi-backend routing — after install, agents call upstream tools directly.
+
+## Golden Rule: Verify Once Per Session
+
+At the **start** of a research task, run:
+
+```bash
+agent-reach doctor --json
+```
+
+Cache the result for the duration of this task. **Re-check** only when a platform command returns output that signals failure — an empty body, HTTP error page, or a non-zero exit code. Exit code alone is insufficient (e.g. `curl` returns 0 on HTTP 404 without `-f`).
+
+This trades per-command freshness for speed — acceptably safe because backends don't change mid-session, but if a platform silently degrades mid-task the cached result will be stale until the next task start.
+
+Check the `active_backend` and `status` fields for each platform:
+- `"status": "ok"` → Use the static commands below
+- `"status": "error"` or `"status": "missing"` → **Do not keep retrying.** Switch to an alternative approach: web search, browser automation, or ask the user.
+- Backends change over time — re-run doctor only when a command fails.
+
+## Platform Routing Table
+
+| Intent | Category | Primary Command |
+|--------|----------|-----------------|
+| **Web page** | web | `curl -s "https://r.jina.ai/URL"` |
+| **Web search** | search | `mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'` |
+| **Twitter/X** | social | `twitter tweet <url>` / `twitter search "query"` |
+| **Reddit** | social | `opencli reddit search "query"` or `rdt search "query"` |
+| **Bilibili** | social | `bili search "query"` / `bili detail <avid>` |
+| **XiaoHongShu** | social | `opencli xiaohongshu search "query"` |
+| **V2EX** | social | `curl -s "https://www.v2ex.com/api/v2/topics/hot"` |
+| **GitHub** | dev | `gh search repos "query" --sort stars --limit 10` |
+| **YouTube** | video | `yt-dlp --write-sub --skip-download --sub-lang en "URL"` |
+| **RSS** | web | `python3 -c "import feedparser; ..."` |
+| **LinkedIn** | career | linkedin-mcp or Jina Reader |
+| **Xueqiu** | finance | Stock search via configured CLI |
+| **Xiaoyuzhou** | video | `agent-reach transcribe <url>` |
+
+> **When a command fails:** Run `agent-reach doctor --json` to check the current active backend. If the backend is dead, do NOT keep retrying — use an alternative method (native web tools, browser fallback, or tell the user).
+
+## Installation
+
+```bash
+pip install agent-reach
+agent-reach install --env=auto
+agent-reach skill --install   # Hermes skill
+```
+
+## Update Check
+
+After multi-platform research, run:
+
+```bash
+agent-reach check-update
+```


### PR DESCRIPTION
- New SKILL_hermes.md with session-level caching and content-aware invalidation
- cli.py: (path, platform) tuples replace fragile substring matching
- Fix: HERMES_HOME paths now correctly detected
- Fix: removed fall-through duplicate print in install loop
- Fix: broken-symlink guard in makedirs() fallback
- Fix: references/ copy is best-effort, not a blocker