### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/docs/dependency-locking.md
+++ b/docs/dependency-locking.md
@@ -11,7 +11,7 @@ Agent Reach uses `constraints.txt` as a reproducible dependency baseline.
 ## Install with constraints
 
 ```bash
-pip install -c constraints.txt -e .[dev]
+pip install -c constraints.txt -e '.[dev]'
 ```
 
 ## Update workflow


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `docs/dependency-locking.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`