### PR TITLE
test(cli): cover XHS Docker container detection

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,44 @@ class TestCLI:
         assert auth_token == "token123"
         assert ct0 == "ct0abc"
 
+    def test_configure_xhs_cookies_detects_running_docker_container(self, monkeypatch, capsys):
+        calls = []
+
+        def fake_which(name):
+            if name == "docker":
+                return "/usr/bin/docker"
+            return None
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["/usr/bin/docker", "ps"]:
+                return subprocess.CompletedProcess(cmd, 0, "xiaohongshu-mcp\n", "")
+            if cmd[:4] == ["/usr/bin/docker", "exec", "xiaohongshu-mcp", "printenv"]:
+                return subprocess.CompletedProcess(cmd, 0, "/app/data/cookies.json\n", "")
+            if cmd[:2] == ["/usr/bin/docker", "cp"]:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            if cmd == ["/usr/bin/docker", "restart", "xiaohongshu-mcp"]:
+                return subprocess.CompletedProcess(cmd, 0, "xiaohongshu-mcp\n", "")
+            raise AssertionError(f"unexpected docker command: {cmd}")
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        cli._configure_xhs_cookies("a=1; b=2")
+
+        out = capsys.readouterr().out
+        assert calls[0] == [
+            "/usr/bin/docker",
+            "ps",
+            "--filter",
+            "name=xiaohongshu-mcp",
+            "--format",
+            "{{.Names}}",
+        ]
+        assert any(cmd[:2] == ["/usr/bin/docker", "cp"] for cmd in calls)
+        assert "container is not running" not in out
+        assert "Cookies written to xiaohongshu-mcp:/app/data/cookies.json" in out
+
     def test_install_rdt_cli_prefers_github_source(self, monkeypatch, capsys):
         state = {"rdt_installed": False}
         commands = []


### PR DESCRIPTION
## Summary
- Add regression coverage for the `configure xhs-cookies` Docker container detection path.
- Assert `docker ps` uses `--format "{{.Names}}"`, so it continues to emit running container names instead of an empty template.
- Verify the running-container flow reaches `docker cp` and does not incorrectly report `xiaohongshu-mcp` as stopped.

Closes #410

## Testing
- `python3 -m py_compile tests/test_cli.py agent_reach/cli.py`
- Manual stdlib simulation of `_configure_xhs_cookies("a=1; b=2")` with mocked Docker commands passed.
- Not run: `python3 -m pytest tests/test_cli.py -q` (local `python3` has no `pytest`; did not install dependencies per operator instruction).
- Not run: `python3 -m ruff check tests/test_cli.py agent_reach/cli.py` and `python3 -m ruff format --check tests/test_cli.py` (local `python3` has no `ruff`; did not install dependencies per operator instruction).