### PR TITLE
fix(config): mask twitter ct0 in config output

### DIFF
--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -103,7 +103,7 @@ class Config:
         """Return config as dict (masks sensitive values)."""
         masked = {}
         for k, v in self.data.items():
-            if any(s in k.lower() for s in ("key", "token", "password", "proxy")):
+            if any(s in k.lower() for s in ("key", "token", "password", "proxy", "ct0")):
                 masked[k] = f"{str(v)[:8]}..." if v else None
             else:
                 masked[k] = v

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for Agent Reach config module."""
 
-import os
-import tempfile
-from pathlib import Path
-
 import pytest
-import yaml
 
 from agent_reach.config import Config
 
@@ -21,7 +16,7 @@ def tmp_config(tmp_path):
 class TestConfig:
     def test_init_creates_dir(self, tmp_path):
         config_file = tmp_path / "subdir" / "config.yaml"
-        config = Config(config_path=config_file)
+        Config(config_path=config_file)
         assert config_file.parent.exists()
 
     def test_set_and_get(self, tmp_config):
@@ -73,6 +68,11 @@ class TestConfig:
         masked = tmp_config.to_dict()
         assert masked["exa_api_key"] == "super-se..."
         assert masked["normal_setting"] == "visible"
+
+    def test_to_dict_masks_twitter_ct0(self, tmp_config):
+        tmp_config.set("twitter_ct0", "csrf-secret-value-here")
+        masked = tmp_config.to_dict()
+        assert masked["twitter_ct0"] == "csrf-sec..."
 
     def test_save_creates_file_with_restricted_permissions(self, tmp_path):
         import stat


### PR DESCRIPTION
## Summary

- Mask config keys containing `ct0` in `Config.to_dict()` so `twitter_ct0` is no longer returned in plaintext.
- Add a regression test that verifies `twitter_ct0` follows the same masked output path as other credential keys.
- Clean up pre-existing lint noise in the touched config test file.

## Root Cause

`Config.to_dict()` only treated keys containing `key`, `token`, `password`, or `proxy` as sensitive. The Twitter/X CSRF token key is named `twitter_ct0`, so it missed that substring check and could be exposed by diagnostic output.

Fixes #412.

## Testing

- `uv run pytest tests/test_config.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check agent_reach/config.py tests/test_config.py`
- `uv run mypy agent_reach/config.py`

Note: repo-wide `ruff check agent_reach tests` and `mypy agent_reach` still report pre-existing issues in unrelated files; the changed files pass the focused checks above and the full pytest suite passes.
