### PR TITLE
fix(cli): preserve skill customizations during doctor

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -9,10 +9,10 @@ Usage:
     agent-reach setup
 """
 
-import sys
 import argparse
 import json
 import os
+import sys
 import time
 
 from agent_reach import __version__
@@ -340,11 +340,25 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
-def _install_skill():
+def _skill_parent_dirs():
+    """Return known agent skill parent directories in installation priority order."""
+    skill_dirs = [
+        os.path.expanduser("~/.agents/skills"),      # Generic agents (priority)
+        os.path.expanduser("~/.openclaw/skills"),    # OpenClaw
+        os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
+    ]
+
+    openclaw_home = os.environ.get("OPENCLAW_HOME")
+    if openclaw_home:
+        skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
+
+    return skill_dirs
+
+
+def _install_skill(overwrite_existing: bool = True):
     """Install Agent Reach as an agent skill (OpenClaw / Claude Code / .agents)."""
-    import os
-    import shutil
     import importlib.resources
+    import shutil
 
     def _is_english_locale(value: str) -> bool:
         normalized = value.strip().lower()
@@ -368,9 +382,13 @@ def _install_skill():
         except FileNotFoundError:
             return skill_pkg.joinpath("SKILL.md").read_text(encoding="utf-8")
 
-    def _copy_skill_dir(target: str) -> bool:
+    def _copy_skill_dir(target: str) -> str | None:
         """Copy entire skill directory (locale-specific SKILL.md + references/)."""
         try:
+            if not overwrite_existing and os.path.exists(os.path.join(target, "SKILL.md")):
+                print(f"Skill already installed: {target}")
+                return "skipped"
+
             # Clear existing installation. A symlinked skill dir (dotfiles
             # setups) breaks shutil.rmtree — unlink the link itself instead.
             if os.path.islink(target):
@@ -404,38 +422,30 @@ def _install_skill():
                     with open(os.path.join(refs_target, name), "w", encoding="utf-8") as f:
                         f.write(content)
 
-            return True
+            return "installed"
         except Exception as e:
             print(f"  Warning: Could not install skill: {e}")
-            return False
-
-    # Determine skill install path (priority: .agents > openclaw > claude)
-    skill_dirs = [
-        os.path.expanduser("~/.agents/skills"),      # Generic agents (priority)
-        os.path.expanduser("~/.openclaw/skills"),    # OpenClaw
-        os.path.expanduser("~/.claude/skills"),      # Claude Code (if exists)
-    ]
-
-    # Insert OPENCLAW_HOME path at the beginning if environment variable is set
-    openclaw_home = os.environ.get("OPENCLAW_HOME")
-    if openclaw_home:
-        skill_dirs.insert(0, os.path.join(openclaw_home, ".openclaw", "skills"))
+            return None
 
     installed = False
-    for skill_dir in skill_dirs:
+    for skill_dir in _skill_parent_dirs():
         if os.path.isdir(skill_dir):
             target = os.path.join(skill_dir, "agent-reach")
-            if _copy_skill_dir(target):
+            install_result = _copy_skill_dir(target)
+            if install_result:
                 platform_name = "Agent" if ".agents" in skill_dir else "OpenClaw" if "openclaw" in skill_dir else "Claude Code"
-                print(f"Skill installed for {platform_name}: {target}")
+                if install_result == "installed":
+                    print(f"Skill installed for {platform_name}: {target}")
                 installed = True
 
     if not installed:
         # No known skill directory found — create for .agents by default
         target = os.path.expanduser("~/.agents/skills/agent-reach")
         os.makedirs(os.path.dirname(target), exist_ok=True)
-        if _copy_skill_dir(target):
-            print(f"Skill installed: {target}")
+        install_result = _copy_skill_dir(target)
+        if install_result:
+            if install_result == "installed":
+                print(f"Skill installed: {target}")
         else:
             print("  -- Could not install agent skill (optional)")
             print("  -- Tip: install OpenClaw, Claude Code, or create ~/.agents/skills/ manually")
@@ -1460,8 +1470,9 @@ def _cmd_doctor(args=None):
 
     rprint(format_report(results))
 
-    # Auto-install skill if not already present (fixes #154)
-    _install_skill()
+    # Auto-install missing skills only (fixes #154). Doctor is a diagnostic command,
+    # so it must not overwrite user-customized skills.
+    _install_skill(overwrite_existing=False)
 
 
 def _cmd_setup():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 import requests
+
 import agent_reach.cli as cli
 from agent_reach.cli import main
 
@@ -32,6 +33,47 @@ class TestCLI:
         captured = capsys.readouterr()
         assert "Agent Reach" in captured.out
         assert "✅" in captured.out
+
+    def test_doctor_preserves_existing_skill_install(self, tmp_path, monkeypatch, capsys):
+        agent_skill_dir = tmp_path / ".agents" / "skills" / "agent-reach"
+        agent_skill_dir.mkdir(parents=True)
+        skill_file = agent_skill_dir / "SKILL.md"
+        skill_file.write_text("custom instructions", encoding="utf-8")
+        claude_skill_parent = tmp_path / ".claude" / "skills"
+        claude_skill_parent.mkdir(parents=True)
+
+        monkeypatch.setattr(cli.os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+        monkeypatch.delenv("OPENCLAW_HOME", raising=False)
+        monkeypatch.setattr(
+            "agent_reach.doctor.check_all",
+            lambda config: {"web": {"status": "ok", "name": "Web", "message": "ok"}},
+        )
+        monkeypatch.setattr("agent_reach.doctor.format_report", lambda results: "Agent Reach\n✅ ok")
+
+        cli._cmd_doctor()
+
+        out = capsys.readouterr().out
+        assert skill_file.read_text(encoding="utf-8") == "custom instructions"
+        assert (claude_skill_parent / "agent-reach" / "SKILL.md").exists()
+        assert "Skill already installed:" in out
+        assert "Skill installed for Agent:" not in out
+        assert "Skill installed for Claude Code:" in out
+
+    def test_doctor_installs_skill_when_missing(self, tmp_path, monkeypatch):
+        skill_parent = tmp_path / ".agents" / "skills"
+        skill_parent.mkdir(parents=True)
+
+        monkeypatch.setattr(cli.os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+        monkeypatch.delenv("OPENCLAW_HOME", raising=False)
+        monkeypatch.setattr(
+            "agent_reach.doctor.check_all",
+            lambda config: {"web": {"status": "ok", "name": "Web", "message": "ok"}},
+        )
+        monkeypatch.setattr("agent_reach.doctor.format_report", lambda results: "Agent Reach\n✅ ok")
+
+        cli._cmd_doctor()
+
+        assert (skill_parent / "agent-reach" / "SKILL.md").exists()
 
     def test_transcribe_command_prints_text(self, capsys):
         with patch("agent_reach.transcribe.transcribe", return_value="hello transcript"):


### PR DESCRIPTION
## Summary

- Make `agent-reach doctor` install missing Agent Reach skills without overwriting existing `SKILL.md` files.
- Keep explicit skill installation behavior unchanged by preserving overwrite-by-default for `_install_skill()`.
- Add regression coverage for preserving customized skills, backfilling missing skill directories, and avoiding misleading install output for skipped targets.

## Root Cause

`agent-reach doctor` called `_install_skill()` unconditionally after printing the health report. `_install_skill()` clears and recreates existing skill directories, so a diagnostic command could silently replace a user-customized `SKILL.md` on every run.

## Validation

- `python -m pytest tests/test_cli.py::TestCLI::test_doctor_preserves_existing_skill_install tests/test_cli.py::TestCLI::test_doctor_installs_skill_when_missing tests/test_cli.py::TestCLI::test_doctor_runs`
- `python -m pytest`
- `python -m ruff check tests/test_cli.py`
- `git diff --check`

Notes: full-project `mypy agent_reach/cli.py` and `ruff check agent_reach tests` still report pre-existing issues outside this change, while the new regression path and full test suite pass.

Fixes #413