### PR TITLE
fix(transcribe): clean up auto-created temp directories

### DIFF
--- a/agent_reach/transcribe.py
+++ b/agent_reach/transcribe.py
@@ -214,7 +214,8 @@ def transcribe(
     """Transcribe a URL or local file path. Returns the joined transcript text.
 
     `provider` is one of `auto` (groq → openai), `groq`, or `openai`.
-    `out_dir` defaults to a fresh temp directory; intermediate files stay there.
+    `out_dir` defaults to a fresh temp directory that is removed when this returns.
+    Pass `out_dir` to keep intermediate files in a caller-owned directory.
     """
     cfg = config or Config()
     order = _provider_order(provider)
@@ -224,8 +225,17 @@ def transcribe(
         names = ", ".join(PROVIDERS[p]["key_field"] for p in order)
         raise NoProviderConfigured(f"no provider key configured (need one of: {names})")
 
-    work_dir = Path(out_dir) if out_dir else Path(tempfile.mkdtemp(prefix="transcribe-"))
-    work_dir.mkdir(parents=True, exist_ok=True)
+    if out_dir:
+        work_dir = Path(out_dir)
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return _run_transcribe(source, order, cfg, work_dir)
+
+    with tempfile.TemporaryDirectory(prefix="transcribe-") as tmp_dir:
+        return _run_transcribe(source, order, cfg, Path(tmp_dir))
+
+
+def _run_transcribe(source: str, order: List[str], cfg: Config, work_dir: Path) -> str:
+    """Run the transcription pipeline inside an already-owned work directory."""
 
     src_path = Path(source)
     if src_path.is_file():

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -216,6 +216,114 @@ class TestOrchestrator:
         )
         assert text == "part one\npart two"
 
+    def test_auto_temp_dir_removed_after_success(self, monkeypatch, fake_config):
+        fake_config.set("groq_api_key", "gsk_test")
+        captured = {}
+
+        def fake_download(source, out_dir):
+            captured["work_dir"] = out_dir
+            audio = out_dir / "source.m4a"
+            audio.write_bytes(b"audio")
+            return audio
+
+        def fake_compress(src, out_dir):
+            compressed = out_dir / "compressed.m4a"
+            compressed.write_bytes(b"x")
+            return compressed
+
+        monkeypatch.setattr(tr, "download_audio", fake_download)
+        monkeypatch.setattr(tr, "compress_audio", fake_compress)
+        monkeypatch.setattr(
+            tr,
+            "_transcribe_with_fallback",
+            lambda chunk, order, cfg: "transcript text",
+        )
+
+        text = tr.transcribe("https://example.com/audio", config=fake_config)
+
+        assert text == "transcript text"
+        assert not captured["work_dir"].exists()
+
+    def test_auto_temp_dir_removed_after_pipeline_error(self, monkeypatch, fake_config):
+        fake_config.set("groq_api_key", "gsk_test")
+        captured = {}
+
+        def fake_download(source, out_dir):
+            captured["work_dir"] = out_dir
+            audio = out_dir / "source.m4a"
+            audio.write_bytes(b"audio")
+            return audio
+
+        def boom_compress(src, out_dir):
+            raise tr.TranscribeError("compress failed")
+
+        monkeypatch.setattr(tr, "download_audio", fake_download)
+        monkeypatch.setattr(tr, "compress_audio", boom_compress)
+
+        with pytest.raises(tr.TranscribeError, match="compress failed"):
+            tr.transcribe("https://example.com/audio", config=fake_config)
+
+        assert not captured["work_dir"].exists()
+
+    def test_auto_temp_dir_removed_after_transcription_error(self, monkeypatch, fake_config):
+        fake_config.set("groq_api_key", "gsk_test")
+        captured = {}
+
+        def fake_download(source, out_dir):
+            captured["work_dir"] = out_dir
+            audio = out_dir / "source.m4a"
+            audio.write_bytes(b"audio")
+            return audio
+
+        def fake_compress(src, out_dir):
+            compressed = out_dir / "compressed.m4a"
+            compressed.write_bytes(b"x")
+            return compressed
+
+        def boom_transcribe(chunk, order, cfg):
+            raise tr.TranscribeError("provider failed")
+
+        monkeypatch.setattr(tr, "download_audio", fake_download)
+        monkeypatch.setattr(tr, "compress_audio", fake_compress)
+        monkeypatch.setattr(tr, "_transcribe_with_fallback", boom_transcribe)
+
+        with pytest.raises(tr.TranscribeError, match="provider failed"):
+            tr.transcribe("https://example.com/audio", config=fake_config)
+
+        assert not captured["work_dir"].exists()
+
+    def test_explicit_out_dir_is_preserved(self, monkeypatch, fake_config, tmp_path):
+        fake_config.set("groq_api_key", "gsk_test")
+        work_dir = tmp_path / "work"
+
+        def fake_download(source, out_dir):
+            audio = out_dir / "source.m4a"
+            audio.write_bytes(b"audio")
+            return audio
+
+        def fake_compress(src, out_dir):
+            compressed = out_dir / "compressed.m4a"
+            compressed.write_bytes(b"x")
+            return compressed
+
+        monkeypatch.setattr(tr, "download_audio", fake_download)
+        monkeypatch.setattr(tr, "compress_audio", fake_compress)
+        monkeypatch.setattr(
+            tr,
+            "_transcribe_with_fallback",
+            lambda chunk, order, cfg: "transcript text",
+        )
+
+        text = tr.transcribe(
+            "https://example.com/audio",
+            out_dir=work_dir,
+            config=fake_config,
+        )
+
+        assert text == "transcript text"
+        assert (work_dir / "source.m4a").exists()
+        assert (work_dir / "compressed.m4a").exists()
+
     def test_no_provider_configured_fails_fast(self, fake_config, chunk_file):
         with pytest.raises(tr.NoProviderConfigured):
             tr.transcribe(str(chunk_file), config=fake_config)


### PR DESCRIPTION
## Summary
- Replace the auto-created `transcribe()` work directory with a `TemporaryDirectory()` context so downloaded, compressed, and chunked audio files are removed on success and failure.
- Preserve explicit `out_dir` behavior by treating caller-provided directories as caller-owned storage for intermediate files.
- Add regression coverage for automatic temp-dir cleanup, exception cleanup, and explicit `out_dir` preservation.

## Root Cause
`transcribe()` used `tempfile.mkdtemp(prefix="transcribe-")` when `out_dir` was not provided, then never removed that directory after audio download/compression/chunking. URL transcription calls could leave large `source.*`, `compressed.m4a`, and `chunk_*.m4a` files under `/tmp/transcribe-*`.

Fixes #411

## Testing
- `uv run --extra dev pytest tests/test_transcribe.py`
- `uv run --extra dev pytest`
- `uv run --extra dev ruff check agent_reach/transcribe.py tests/test_transcribe.py`
- `uv run --extra dev ruff format --check agent_reach/transcribe.py tests/test_transcribe.py`
- `uv run --extra dev mypy agent_reach/transcribe.py`

## Notes
- Full-repository `ruff check agent_reach tests`, `ruff format --check agent_reach tests`, and `mypy agent_reach` were also attempted. They currently report pre-existing issues in unrelated files; this PR keeps the diff scoped to the transcription cleanup fix.
