### PR TITLE
docs(agent): fix stale command contract docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.5.0
 
 ## Structure
 - `agent_reach/cli.py` — CLI entry point (argparse)
-- `agent_reach/core.py` — Core read/search routing logic
+- `agent_reach/core.py` — Health-check facade around doctor/config
 - `agent_reach/config.py` — Config management (YAML, env vars)
 - `agent_reach/doctor.py` — Diagnostics engine
 - `agent_reach/channels/` — One file per platform (twitter.py, reddit.py, youtube.py, etc.)
@@ -28,8 +28,8 @@ Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.5.0
 
 ## Conventions
 - Python 3.10+ with type hints
-- Each channel is a single file in `channels/`, inherits from `BaseChannel`
-- Channel contract: must implement `can_handle(url)`, `read(url)`, `search(query)`, `check()` methods
+- Each channel is a single file in `channels/`, inherits from `Channel`
+- Channel contract: implement `can_handle(url)` and `check(config)`; `check()` must set `active_backend` when a backend is usable
 - Use `loguru` for logging, `rich` for CLI output
 - Commit format: `type(scope): message` (one commit = one thing)
 - All upstream tool calls go through public API/CLI, never hack internals

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Agent Reach uses a unified channel interface. To add a new platform:
 1. Create a new file in `agent_reach/channels/`
 2. Implement the channel contract (see existing channels for examples)
 3. Add tests in `tests/test_channels.py`
-4. Update `agent_reach/doctor.py` to include the new channel
+4. Register the channel in `agent_reach/channels/__init__.py`
 5. Update documentation
 
 ## Pull Request Guidelines

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Agent Reach
 
-> Give your AI agent eyes to see the entire internet. A unified CLI tool that lets AI agents read and search across 12+ platforms — Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, Instagram, LinkedIn, Boss直聘, RSS, and any web page. One install, zero API fees.
+> Agent Reach installs, configures, and diagnoses upstream tools for 13 platforms — Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, V2EX, Xueqiu, LinkedIn, Xiaoyuzhou, RSS, web pages, and web search.
 
 ## Quick Start
 
@@ -10,17 +10,17 @@
 
 ## Core Commands
 
-- [CLI Usage](https://github.com/Panniantong/Agent-Reach/blob/main/docs/install.md): `agent-reach read <url>` reads any URL, `agent-reach search-twitter "query"` searches Twitter, etc.
+- [CLI Usage](https://github.com/Panniantong/Agent-Reach/blob/main/docs/install.md): `agent-reach install --env=auto` installs upstream tools; `agent-reach doctor --json` reports health and `active_backend`. For read/search commands, use [SKILL.md](https://github.com/Panniantong/Agent-Reach/blob/main/agent_reach/skill/SKILL.md).
 
 ## Key Features
 
 - Read any URL: tweets, Reddit posts, YouTube videos (transcripts), GitHub repos, articles, XiaoHongShu notes, Bilibili videos, RSS feeds
-- Search across platforms: Twitter/X, Reddit, GitHub, YouTube, Bilibili, XiaoHongShu, Instagram, LinkedIn, Boss直聘, Web (via Exa)
+- Search across platforms: Twitter/X, Reddit, GitHub, YouTube, Bilibili, XiaoHongShu, V2EX, Xueqiu, LinkedIn, Web (via Exa)
 - Self-diagnosis: `agent-reach doctor` checks what works and what needs setup
 - Auto-installs dependencies: `agent-reach install --env=auto`
-- Cookie-based auth for platforms that require login (Twitter, XiaoHongShu, Instagram)
+- Cookie-based auth for platforms that require login (Twitter, XiaoHongShu, Reddit)
 - Proxy support for platforms that block server IPs (Reddit, Bilibili)
-- Zero API fees: all backends are free and open-source (bird CLI, yt-dlp, Jina Reader, instaloader, etc.)
+- Backend checks cover OpenCLI, twitter-cli, rdt-cli, bili-cli, yt-dlp, Jina Reader, Exa, and platform APIs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Update agent-facing project docs to describe the current doctor/config-focused core instead of removed read/search routing.
- Replace stale channel contract wording with the current `Channel` `can_handle` / `check` / `active_backend` contract.
- Correct `llms.txt` command, platform, and backend guidance so agents use install/doctor plus `SKILL.md` instead of removed wrapper commands.

## Why
Agent-facing docs still described wrapper-era commands and channel APIs, which can cause agents to run obsolete `agent-reach read/search-*` commands even when doctor reports the current backend state correctly.

## Test Plan
- [x] `. /tmp/agent-reach-stopgap-venv/bin/activate && pytest tests/ -v`
- [x] `git diff --cached --check` before commit
- [x] Checked changed docs for stale wrapper-era command and channel-contract patterns
