### PR TITLE
fix(deps): bump yt-dlp, requests, python-dotenv to patch disclosed CVEs

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,13 +2,13 @@
 # Usage:
 #   pip install -c constraints.txt -e .[dev]
 
-requests==2.32.5
+requests==2.33.0
 feedparser==6.0.12
-python-dotenv==1.2.1
+python-dotenv==1.2.2
 loguru==0.7.3
 PyYAML==6.0.3
 rich==14.3.2
-yt-dlp==2025.5.22
+yt-dlp==2026.6.9
 
 pytest==8.0.0
 ruff==0.15.1


### PR DESCRIPTION
Hi — thanks for Agent Reach! This is a small, automated dependency-bump PR that updates three pinned packages in `constraints.txt` to releases that fix **already-public** CVEs. No source changes; only the tested-version pins move.

### yt-dlp `2025.5.22` → `2026.6.9`
This is the meaningful one — `agent_reach/transcribe.py` feeds remote URLs to `yt-dlp`, so the library is the most exposed dependency. `2026.6.9` fixes five advisories:

| Advisory | Severity | Issue |
|---|---|---|
| [GHSA-69qj-pvh9-c5wg](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-69qj-pvh9-c5wg) | High | Command injection via `--exec` output template |
| [GHSA-vx4q-3cr2-7cg2](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-vx4q-3cr2-7cg2) / CVE-2026-50574 | High | Code execution via manifest downloads with aria2c |
| [GHSA-c6mh-fpjc-4pr3](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-c6mh-fpjc-4pr3) / CVE-2026-50023 | High | Dangerous file-type creation (`.desktop`/`.url`/`.webloc`) |
| [GHSA-g3gw-q23r-pgqm](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-g3gw-q23r-pgqm) / CVE-2026-26331 | High | Command injection via `--netrc-cmd` |
| [GHSA-f7j3-774f-rfhj](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-f7j3-774f-rfhj) / CVE-2026-50019 | Moderate | Cookie leak via the `curl` external downloader |

### requests `2.32.5` → `2.33.0`
[GHSA-gc5v-m9x4-r6x2](https://github.com/psf/requests/security/advisories/GHSA-gc5v-m9x4-r6x2) / CVE-2026-25645 (Moderate) — insecure temp-file reuse in `extract_zipped_paths()`. Not reachable from Agent Reach's code (that helper isn't called), so this is a defense-in-depth bump.

### python-dotenv `1.2.1` → `1.2.2`
[GHSA-mf9w-mj56-hr94](https://github.com/theskumar/python-dotenv/security/advisories/GHSA-mf9w-mj56-hr94) / CVE-2026-28684 (Moderate) — symlink-following file overwrite in `set_key()`/`unset_key()`. Also not reachable (Agent Reach manages its own YAML config), so likewise defense-in-depth.

All three bumps satisfy the existing floors in `pyproject.toml` (`yt-dlp>=2024.0`, `requests>=2.28`, `python-dotenv>=1.0`). Detected with [osv.dev](https://osv.dev/). Worth a quick `pytest` run on your side to confirm the pinned set still resolves cleanly — feel free to take only the yt-dlp bump if you'd prefer to keep this minimal.

---
Filed by [Aeon](https://github.com/aeonframework/aeon).
