### PR TITLE
fix(meta): add Python 3.13 classifier, fix yt-dlp specifier, bump pytest for 3.13

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ PyYAML==6.0.3
 rich==14.3.2
 yt-dlp==2025.5.22
 
-pytest==8.0.0
+pytest==8.4.2
 ruff==0.15.1
 mypy==1.19.1
 types-requests==2.32.4.20260107

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -34,7 +35,7 @@ dependencies = [
     "loguru>=0.7",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "yt-dlp>=2024.0",
+    "yt-dlp>=2024.1.1",
 ]
 
 [project.optional-dependencies]
@@ -42,7 +43,7 @@ browser = ["playwright>=1.40"]
 cookies = ["browser-cookie3>=0.19"]
 all = ["playwright>=1.40", "mcp[cli]>=1.0", "browser-cookie3>=0.19"]
 dev = [
-    "pytest>=8.0",
+    "pytest>=8.1",
     "ruff>=0.8",
     "mypy>=1.12",
     "types-requests>=2.32",


### PR DESCRIPTION
## Problem

Three metadata/packaging bugs that affect PyPI discoverability, installation, and CI reliability.

---

### 1 — Python 3.13 missing from classifiers

The CI matrix already tests Python 3.10 – 3.13 (all four), but `pyproject.toml` only declares classifiers through 3.12. Users browsing PyPI see an unverified 3.13 combination and may avoid installing on 3.13.

```toml
# Added
"Programming Language :: Python :: 3.13",
```

---

### 2 — `yt-dlp>=2024.0` references a non-existent release

yt-dlp uses **date-based versioning** (`YYYY.M.D`). The release `2024.0` was never published — the first 2024 release was `2024.1.1`.  
While pip resolves the constraint correctly in practice (it finds the next higher real version), the specifier is misleading and can confuse tooling that reads the metadata.

```toml
# Before
"yt-dlp>=2024.0",
# After
"yt-dlp>=2024.1.1",
```

---

### 3 — `pytest==8.0.0` predates Python 3.13 in `constraints.txt`

pytest 8.0.0 was released 2024-01-27, **before** Python 3.13 went GA (2024-10-07). It is not in pytest's own tested matrix for 3.13. The 3.13 CI leg therefore runs against an untested pytest version.

- Pinned to `pytest==8.4.2` (latest stable, fully supports 3.13).
- Raised `pyproject.toml` dev lower bound from `>=8.0` → `>=8.1` (the first release that began tracking 3.13 compatibility).

```
# constraints.txt
- pytest==8.0.0
+ pytest==8.4.2
```

---

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Add 3.13 classifier; fix yt-dlp specifier; raise pytest lower bound |
| `constraints.txt` | Pin `pytest==8.4.2` |

## Relation to existing PRs

Checked against all open PRs (#407–#436) — none touches classifiers, yt-dlp version specifiers, or the pytest pin in `constraints.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)