### PR TITLE
fix(xueqiu): replace non-existent CookieJar.set() with _inject_cookie_string in rookiepy path

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -85,7 +85,10 @@ def _load_cookies_from_browser() -> bool:
             if not any(c.get("name") == "xq_a_token" for c in cookies):
                 return False
             for c in cookies:
-                _cookie_jar.set(c["name"], c["value"], domain=c.get("domain", ".xueqiu.com"))
+                # rookiepy returns plain dicts; use _inject_cookie_string so the
+                # existing Cookie-construction logic handles domain/path/flags.
+                # (CookieJar has no .set() method — calling it raises AttributeError.)
+                _inject_cookie_string(f"{c['name']}={c['value']}")
             return True
         except ImportError:
             import browser_cookie3

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -621,6 +621,43 @@ class TestXueqiuChannel:
         cookie_names = {c.name for c in xq_mod._cookie_jar}
         assert "xq_a_token" in cookie_names
 
+    def test_load_cookies_from_browser_rookiepy_path(self, monkeypatch):
+        """_load_cookies_from_browser() must inject cookies when rookiepy is present.
+
+        Regression test for a bug where the code called ``_cookie_jar.set()``
+        (a non-existent method on ``http.cookiejar.CookieJar``) instead of
+        ``_inject_cookie_string()``.  The resulting ``AttributeError`` was
+        silently swallowed by the outer ``except Exception`` block, so Xueqiu
+        cookies were never loaded when rookiepy was installed.
+        """
+        import sys
+        import types
+        import agent_reach.channels.xueqiu as xq_mod
+
+        # Snapshot and clear the shared cookie jar so the assertion is isolated.
+        existing_cookies = list(xq_mod._cookie_jar)
+        xq_mod._cookie_jar.clear()
+
+        fake_cookies = [
+            {"name": "xq_a_token", "value": "TOKEN_ROOKIEPY", "domain": ".xueqiu.com"},
+            {"name": "xq_is_login", "value": "1", "domain": ".xueqiu.com"},
+        ]
+        fake_rookiepy = types.ModuleType("rookiepy")
+        fake_rookiepy.chrome = lambda *a, **kw: fake_cookies  # type: ignore[attr-defined]
+
+        monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+
+        result = xq_mod._load_cookies_from_browser()
+
+        assert result is True, "_load_cookies_from_browser should return True when xq_a_token present"
+        cookie_names = {c.name for c in xq_mod._cookie_jar}
+        assert "xq_a_token" in cookie_names, "xq_a_token must be injected into the CookieJar"
+
+        # Restore cookie jar state so other tests are unaffected.
+        xq_mod._cookie_jar.clear()
+        for c in existing_cookies:
+            xq_mod._cookie_jar.set_cookie(c)
+
     def test_get_json_sends_referer_and_browser_ua(self, monkeypatch):
         """_get_json() must send Referer and a browser-like User-Agent."""
         import agent_reach.channels.xueqiu as xueqiu_mod


### PR DESCRIPTION
## Problem

When **rookiepy is installed**, `_load_cookies_from_browser()` in `agent_reach/channels/xueqiu.py` silently fails to load any Xueqiu cookies, so authenticated stock APIs always fall back to the homepage-only session and return empty data.

### Root cause

The code calls `_cookie_jar.set()` on an `http.cookiejar.CookieJar` instance:

```python
for c in cookies:
    _cookie_jar.set(c["name"], c["value"], domain=c.get("domain", ".xueqiu.com"))
```

**`CookieJar` has no `.set()` method** — only `.set_cookie(cookie)`. Calling it raises `AttributeError`.

```python
>>> import http.cookiejar
>>> hasattr(http.cookiejar.CookieJar(), 'set')
False
```

The `AttributeError` is not caught by the inner `except ImportError` block. It propagates to the outer `except Exception: return False`, which silently swallows it. Result: `_load_cookies_from_browser()` returns `False` even when rookiepy finds valid Xueqiu cookies.

### Impact

Any user who has `rookiepy` installed (directly or as a transitive dependency) gets no benefit from browser cookie extraction for Xueqiu. The channel falls back to an anonymous session, causing `check()` to report `warn` and authenticated data calls to return empty results — without any error message.

The `browser_cookie3` path (the else branch) is unaffected: it correctly uses `.set_cookie(cookie)` with proper `Cookie` objects.

## Fix

Replace the broken `.set()` call with the existing `_inject_cookie_string()` helper already in this module — the same function used by `_load_cookies_from_config()`. It constructs proper `http.cookiejar.Cookie` objects and calls `.set_cookie()` correctly:

```python
# Before
for c in cookies:
    _cookie_jar.set(c["name"], c["value"], domain=c.get("domain", ".xueqiu.com"))

# After
for c in cookies:
    _inject_cookie_string(f"{c['name']}={c['value']}")
```

## Test

Added `test_load_cookies_from_browser_rookiepy_path` to `tests/test_channels.py`:

- Injects a fake `rookiepy` module via `sys.modules` returning a cookie list with `xq_a_token`
- Calls `_load_cookies_from_browser()` directly
- Asserts it returns `True` and that `xq_a_token` is actually present in `_cookie_jar`

This test **fails** before the fix (function returned `False`, no cookies injected) and passes after.

```
163 passed in 90s  (162 existing + 1 new)
```

## Files changed

| File | Change |
|------|--------|
| `agent_reach/channels/xueqiu.py` | Replace `_cookie_jar.set()` with `_inject_cookie_string()` |
| `tests/test_channels.py` | Add regression test for the rookiepy path |