### PR TITLE
fix(deps): bump yt-dlp, requests, python-dotenv to patch disclosed CVEs

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,13 +2,13 @@
 # Usage:
 #   pip install -c constraints.txt -e .[dev]
 
-requests==2.32.5
+requests==2.34.2
 feedparser==6.0.12
-python-dotenv==1.2.1
+python-dotenv==1.2.2
 loguru==0.7.3
 PyYAML==6.0.3
 rich==14.3.2
-yt-dlp==2025.5.22
+yt-dlp==2026.6.9
 
 pytest==8.0.0
 ruff==0.15.1


### PR DESCRIPTION
Bumps three runtime dependencies pinned in `constraints.txt` to versions that
patch already-disclosed CVEs. Lockfile-only change, no application code edits.

## Dependency bumps

| Package | Pin (before) | Pin (after) | Advisories closed |
|---|---|---|---|
| `yt-dlp` | `2025.5.22` | `2026.6.9` | 5 advisories (4 HIGH, 1 MOD) |
| `requests` | `2.32.5` | `2.34.2` | 1 advisory (MOD) |
| `python-dotenv` | `1.2.1` | `1.2.2` | 1 advisory (MOD) |

## Advisories

**yt-dlp 2025.5.22 → 2026.6.9** (all fixed in 2026.6.9):
- [GHSA-69qj-pvh9-c5wg](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-69qj-pvh9-c5wg) HIGH — `--exec` arbitrary command injection on crafted metadata
- [GHSA-c6mh-fpjc-4pr3](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-c6mh-fpjc-4pr3) HIGH (CVE-2026-50023) — dangerous file type creation via insufficient filename sanitization
- [GHSA-g3gw-q23r-pgqm](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-g3gw-q23r-pgqm) HIGH (CVE-2026-26331) — `--netrc-cmd` arbitrary command injection
- [GHSA-vx4q-3cr2-7cg2](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-vx4q-3cr2-7cg2) HIGH (CVE-2026-50574) — arbitrary code execution via manifest downloads with aria2c
- [GHSA-f7j3-774f-rfhj](https://github.com/yt-dlp/yt-dlp/security/advisories/GHSA-f7j3-774f-rfhj) MODERATE (CVE-2026-50019) — file downloader cookie leak with curl

**requests 2.32.5 → 2.34.2** (fixed in 2.33.0):
- [GHSA-gc5v-m9x4-r6x2](https://github.com/psf/requests/security/advisories/GHSA-gc5v-m9x4-r6x2) MODERATE (CVE-2026-25645) — insecure temp file reuse in `extract_zipped_paths()`. Standard `requests` usage is not affected; bump for hygiene.

**python-dotenv 1.2.1 → 1.2.2**:
- [GHSA-mf9w-mj56-hr94](https://github.com/theskumar/python-dotenv/security/advisories/GHSA-mf9w-mj56-hr94) MODERATE (CVE-2026-28684) — symlink following in `set_key()` allows arbitrary file overwrite via cross-device rename fallback. `python-dotenv` is declared but not currently imported in Agent Reach, so not directly reachable — bump for hygiene and future-proofing.

## Scope notes

- `pyproject.toml` lower bounds (`yt-dlp>=2024.0`, `requests>=2.28`, `python-dotenv>=1.0`) already permit these versions, so no manifest edit is required.
- `pytest==8.0.0` is also affected by [GHSA-6w46-j5rx-g56g](https://github.com/pytest-dev/pytest/security/advisories/GHSA-6w46-j5rx-g56g) (CVE-2025-71176, MODERATE, local-only tmpdir handling). It is a dev-only dep, and bumping to 9.x is a major version jump — left out of this PR to keep the change low-risk; happy to follow up if you want it included.
- Detected via OSV.dev API queries against the `constraints.txt` pin set.

---
Filed by [Aeon](https://github.com/aeonframework/aeon).