### PR TITLE
feat: add DuckDuckGo as zero-config search backend alongside Exa

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -8,7 +8,8 @@ from typing import List, Optional
 # Import all channels
 from .base import Channel
 from .bilibili import BilibiliChannel
-from .exa_search import ExaSearchChannel
+from .exa_search import ExaSearchChannel  # backward compat
+from .web_search import WebSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
 from .instagram import InstagramChannel
@@ -37,7 +38,7 @@ ALL_CHANNELS: List[Channel] = [
     V2EXChannel(),
     XueqiuChannel(),
     RSSChannel(),
-    ExaSearchChannel(),
+    WebSearchChannel(),
     WebChannel(),
 ]
 

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -1,40 +1,14 @@
 # -*- coding: utf-8 -*-
-"""Exa Search — check if mcporter + Exa MCP is available."""
+"""Deprecated re-export — use agent_reach.channels.web_search instead.
 
-from agent_reach.probe import probe_command
+Kept for backward compatibility with scripts that import ExaSearchChannel
+directly. The channel has been renamed to WebSearchChannel and now includes
+DuckDuckGo as a zero-config fallback backend.
+"""
 
-from .base import Channel
+from agent_reach.channels.web_search import WebSearchChannel
 
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+# Backward-compatible alias
+ExaSearchChannel = WebSearchChannel
 
-
-class ExaSearchChannel(Channel):
-    name = "exa_search"
-    description = "全网语义搜索"
-    backends = ["Exa via mcporter"]
-    tier = 0
-
-    def can_handle(self, url: str) -> bool:
-        return False  # Search-only channel
-
-    def check(self, config=None):
-        self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
-        if probe.status == "missing":
-            return "off", (
-                "需要 mcporter + Exa MCP。安装：\n"
-                "  npm install -g mcporter\n"
-                "  mcporter config add exa https://mcp.exa.ai/mcp"
-            )
-        if probe.status == "broken":
-            return "error", _MCPORTER_BROKEN_HINT
-        if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "exa" in probe.output.lower():
-            self.active_backend = self.backends[0]
-            return "ok", "全网语义搜索可用（免费，无需 API Key）"
-        return "off", (
-            "mcporter 已装但 Exa 未配置。运行：\n"
-            "  mcporter config add exa https://mcp.exa.ai/mcp"
-        )
+__all__ = ["ExaSearchChannel", "WebSearchChannel"]

--- a/agent_reach/channels/web_search.py
+++ b/agent_reach/channels/web_search.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Web Search — multi-backend: Exa via mcporter / DuckDuckGo.
+
+Exa provides higher-quality semantic search (especially for English/tech
+content) but requires mcporter (npm). DuckDuckGo is free, zero-config,
+and works everywhere — a reliable fallback when Exa isn't set up, and
+an alternative path to content from platforms that are hard to access
+directly (login-walled, geo-blocked, etc.).
+
+Backend routing: Exa first (quality), DuckDuckGo second (zero-config).
+"""
+
+import shutil
+import subprocess
+import sys
+
+from agent_reach.probe import probe_command
+from agent_reach.utils.process import utf8_subprocess_env
+
+from .base import Channel
+
+#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
+_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+
+def _ddg_cli_available() -> bool:
+    """True if the `ddgs` CLI (from duckduckgo-search) is on PATH and runnable."""
+    ddgs = shutil.which("ddgs")
+    if not ddgs:
+        return False
+    try:
+        r = subprocess.run(
+            [ddgs, "--version"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            env=utf8_subprocess_env(),
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _ddg_python_available() -> bool:
+    """True if duckduckgo_search can be imported (no CLI but package installed)."""
+    try:
+        subprocess.run(
+            [sys.executable, "-c", "from duckduckgo_search import DDGS; print('ok')"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            env=utf8_subprocess_env(),
+        )
+        return True
+    except Exception:
+        return False
+
+
+class WebSearchChannel(Channel):
+    name = "web_search"
+    description = "全网搜索"
+    backends = ["Exa via mcporter", "DuckDuckGo"]
+    tier = 0  # DuckDuckGo provides a zero-config path
+
+    def can_handle(self, url: str) -> bool:
+        return False  # Search-only channel
+
+    def check(self, config=None):
+        """Probe candidates in order; first fully-usable backend wins."""
+        self.active_backend = None
+        findings = []
+
+        for backend in self.ordered_backends(config):
+            if backend.startswith("Exa"):
+                result = self._check_exa()
+            else:
+                result = self._check_ddg()
+            if result is None:
+                continue
+            findings.append((backend, *result))
+
+        broken_notes = [m for _, s, m in findings if s == "error"]
+
+        for wanted in ("ok", "warn"):
+            for backend, status, message in findings:
+                if status == wanted:
+                    self.active_backend = backend
+                    if broken_notes:
+                        message += "\n[备选后端异常] " + "；".join(broken_notes)
+                    return status, message
+
+        if findings:
+            return "error", "\n".join(m for _, _, m in findings)
+
+        return "off", (
+            "没有可用的搜索后端。推荐安装（二选一）：\n"
+            "  pip install duckduckgo-search  ← 免费，零配置，装好即用\n"
+            "  或：npm install -g mcporter && mcporter config add exa https://mcp.exa.ai/mcp"
+        )
+
+    def _check_exa(self):
+        """Exa via mcporter candidate. None = mcporter not installed."""
+        probe = probe_command(
+            "mcporter", ["config", "list"], timeout=10, package="mcporter"
+        )
+        if probe.status == "missing":
+            return None
+        if probe.status == "broken":
+            return "error", _MCPORTER_BROKEN_HINT
+        if not probe.ok:
+            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
+        if "exa" in probe.output.lower():
+            return "ok", "全网语义搜索可用（Exa，免费，无需 API Key）"
+        return "warn", (
+            "mcporter 已装但 Exa 未配置。运行：\n"
+            "  mcporter config add exa https://mcp.exa.ai/mcp"
+        )
+
+    def _check_ddg(self):
+        """DuckDuckGo candidate. None = not installed."""
+        if _ddg_cli_available():
+            return "ok", (
+                "DuckDuckGo 搜索可用（ddgs CLI，免费，零配置）。用法：\n"
+                '  ddgs text "query" -n 5'
+            )
+        if _ddg_python_available():
+            return "ok", (
+                "DuckDuckGo 搜索可用（Python 包，免费，零配置）。用法：\n"
+                '  python -c "from duckduckgo_search import DDGS; '
+                'print(list(DDGS().text(\'query\', max_results=5)))"'
+            )
+        return None  # Not installed

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -22,7 +22,7 @@ class Config:
 
     # Feature → required config keys
     FEATURE_REQUIREMENTS = {
-        "exa_search": ["exa_api_key"],
+        "web_search": [],
         "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -50,7 +50,7 @@ metadata:
    `agent-reach doctor --json`，按各平台 `active_backend` 字段选命令组。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
-4. **全网调研类任务**：组合多平台（Exa 搜索 + Twitter/Reddit 看讨论 + 小红书/B站看中文场景），并行收集再汇总。
+4. **全网调研类任务**：组合多平台（DuckDuckGo/Exa 搜索 + Twitter/Reddit 看讨论 + 小红书/B站看中文场景），并行收集再汇总。
 5. **替用户盯版本**：完成一次较大的调研/多平台任务后，顺手跑
    `agent-reach check-update`（很快，一个 API 调用）。有新版就在收尾汇报里附一句：
    「Agent Reach 有新版 vX.Y.Z，复制这句话给我即可更新：帮我更新 Agent Reach：
@@ -71,7 +71,10 @@ metadata:
 ## 零配置快速命令
 
 ```bash
-# Exa 网页搜索
+# DuckDuckGo 网页搜索（免费，零配置——装好即用）
+ddgs text "query" -n 5
+
+# Exa 网页搜索（需要 mcporter，质量更高）
 mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 
 # 通用网页阅读
@@ -125,7 +128,7 @@ agent-reach doctor --json
 
 根据用户需求，阅读对应的详细文档：
 
-- [搜索工具](references/search.md) — Exa AI 搜索
+- [搜索工具](references/search.md) — DuckDuckGo + Exa AI 搜索
 - [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI

--- a/agent_reach/skill/references/search.md
+++ b/agent_reach/skill/references/search.md
@@ -1,10 +1,35 @@
 # 搜索工具
 
-Exa AI 搜索引擎。
+Agent Reach 提供多个搜索后端，按 `agent-reach doctor --json` 的 `active_backend` 字段选择命令。
 
-## Exa AI 搜索
+## DuckDuckGo 搜索（免费，零配置）
 
-高质量 AI 搜索引擎，擅长技术和代码搜索。
+装好即用，无需 API Key，无需登录。中文和英文搜索都支持。
+
+```bash
+# CLI 方式（推荐）
+ddgs text "query" -n 5
+
+# Python 方式（无 CLI 时）
+python -c "from duckduckgo_search import DDGS; print(list(DDGS().text('query', max_results=5)))"
+```
+
+安装：
+```bash
+pip install duckduckgo-search   # 或 pipx install duckduckgo-search
+```
+
+### 特点
+
+- 完全免费，无需注册或 API Key
+- 中英文搜索都支持
+- 结果来自 DuckDuckGo 搜索引擎
+- 适合作为 Exa 不可用时的零配置替代
+- 可用作查登录墙/地理墙后内容的备选路径
+
+## Exa AI 搜索（高质量，需 mcporter）
+
+高质量 AI 语义搜索引擎，擅长技术和代码搜索。需要先装 mcporter。
 
 ```bash
 mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
@@ -24,10 +49,23 @@ mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)
 - 支持代码上下文搜索
 - 结果质量高
 
+## 后端切换
+
+如果想强制使用某个后端，设置环境变量或 config：
+
+```bash
+# 强制用 DuckDuckGo
+export WEB_SEARCH_BACKEND="DuckDuckGo"
+
+# 强制用 Exa
+export WEB_SEARCH_BACKEND="Exa via mcporter"
+```
+
 ## 与其他搜索工具对比
 
-| 工具 | 来源 | 适用场景 |
-|-----|------|---------|
-| Exa | agent-reach | 英文/技术/代码搜索 |
-| 智谱搜索 | my-mcp-tools | 中文搜索 |
-| GitHub 搜索 | agent-reach (dev.md) | 仓库/代码搜索 |
+| 工具 | 来源 | 适用场景 | 配置难度 |
+|-----|------|---------|---------|
+| DuckDuckGo | agent-reach | 通用搜索（中英文），零配置 | ✅ 零配置 |
+| Exa | agent-reach | 英文/技术/代码搜索 | 需 mcporter |
+| 智谱搜索 | my-mcp-tools | 中文搜索 | 需 API Key |
+| GitHub 搜索 | agent-reach (dev.md) | 仓库/代码搜索 | 需 gh CLI |

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1242,6 +1242,8 @@ class TestLinkedInChannel:
 
 
 class TestExaSearchChannel:
+    """Backward-compat: ExaSearchChannel still works via deprecated import."""
+
     def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
         """mcporter which 命中但 exec 失败 → error + npm 重装处方。"""
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
@@ -1269,6 +1271,67 @@ class TestExaSearchChannel:
         status, msg = ch.check()
         assert status == "ok"
         assert ch.active_backend == "Exa via mcporter"
+
+
+class TestWebSearchChannel:
+    """Tests for the new multi-backend WebSearchChannel."""
+
+    def test_web_search_channel_registered(self):
+        from agent_reach.channels import get_channel
+        ch = get_channel("web_search")
+        assert ch is not None
+        assert ch.name == "web_search"
+        assert "DuckDuckGo" in ch.backends
+        assert "Exa via mcporter" in ch.backends
+        assert ch.tier == 0
+
+    def test_exa_backend_ok_when_mcporter_has_exa(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, "exa  https://mcp.exa.ai/mcp", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.web_search import WebSearchChannel
+        ch = WebSearchChannel()
+        status, msg = ch.check()
+        assert status == "ok"
+        assert ch.active_backend == "Exa via mcporter"
+
+    def test_ddg_backend_reports_ok_when_installed(self, monkeypatch):
+        """When mcporter is missing but ddgs is available → DuckDuckGo wins."""
+        # mcporter not found
+        monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/ddgs" if x == "ddgs" else None)
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, "ddgs v7.0", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.web_search import WebSearchChannel
+        ch = WebSearchChannel()
+        status, msg = ch.check()
+        assert status == "ok"
+        assert ch.active_backend == "DuckDuckGo"
+
+    def test_off_when_no_backend_available(self, monkeypatch):
+        """When both backends are missing → off with install instructions."""
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError(cmd[0])
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.web_search import WebSearchChannel
+        ch = WebSearchChannel()
+        status, msg = ch.check()
+        assert status == "off"
+        assert "duckduckgo-search" in msg.lower()
+
+    def test_cannot_handle_urls(self):
+        from agent_reach.channels.web_search import WebSearchChannel
+        ch = WebSearchChannel()
+        assert ch.can_handle("https://example.com") is False
+        assert ch.can_handle("https://google.com/search?q=test") is False
 
 
 class TestXiaoyuzhouChannel:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,15 +52,16 @@ class TestConfig:
         assert tmp_config.get("to_delete") is None
 
     def test_is_configured(self, tmp_config):
-        assert not tmp_config.is_configured("exa_search")
-        tmp_config.set("exa_api_key", "test-key")
-        assert tmp_config.is_configured("exa_search")
+        # web_search is zero-config (no requirements) → always configured
+        assert tmp_config.is_configured("web_search")
 
     def test_get_configured_features(self, tmp_config):
         features = tmp_config.get_configured_features()
         assert isinstance(features, dict)
-        assert "exa_search" in features
-        assert all(v is False for v in features.values())
+        assert "web_search" in features
+        # web_search is zero-config → True; all others False
+        assert features["web_search"] is True
+        assert all(v is False for k, v in features.items() if k != "web_search")
 
     def test_to_dict_masks_sensitive(self, tmp_config):
         tmp_config.set("exa_api_key", "super-secret-key-12345")


### PR DESCRIPTION
## 改动

给 Agent-Reach 加入了 **DuckDuckGo** 作为第二个搜索后端，与 Exa 组成多后端路由。

### 设计

- **双后端路由**：`Exa via mcporter` → `DuckDuckGo`，先探 Exa（质量更高），不可用时自动降级到 DuckDuckGo
- **DuckDuckGo 零配置**：`pip install duckduckgo-search` 装好即用，无需 API Key、无需登录
- **作为备选路径**：当某些网站登录不进去/被封时，可以通过搜索引擎来找内容——搜索本身就是一种后备路由
- **tier=0**：DuckDuckGo 让搜索频道从 tier 1 降到 tier 0（装好即用）
- **向后兼容**：`ExaSearchChannel` 保留为 `WebSearchChannel` 别名，旧代码不受影响

### 文件

| 文件 | 改动 |
|------|------|
| `channels/web_search.py` | 新文件，多后端搜索 channel |
| `channels/exa_search.py` | 改为兼容 re-export |
| `channels/__init__.py` | 注册 WebSearchChannel |
| `config.py` | web_search 零配置 |
| `skill/SKILL.md` | 加入 ddgs 命令 |
| `skill/references/search.md` | 重写，双后端文档 |
| 测试 | 新增 5 个 WebSearchChannel 测试，190 passed |

### 用法

```bash
# 零配置装好即用
pip install duckduckgo-search
ddgs text "搜索关键词" -n 5

# 或走 Exa（质量更高，需 mcporter）
mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)