### PR TITLE
chore: tighten setup verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,16 +36,24 @@ We use the following tools to maintain code quality:
 Run all checks before submitting a PR:
 
 ```bash
-# Linting
+# Linting and import sorting
 ruff check agent_reach tests
 ruff format agent_reach tests
 
 # Type checking
 mypy agent_reach
 
-# Tests
-pytest
+# Unit tests
+pytest tests/
+
+# Clean-environment CLI smoke test
+bash test.sh
+
+# Package build
+python -m build
 ```
+
+`test.sh` intentionally verifies the supported installer/doctor/version/API contract. Agent Reach is not a `read`/`search` wrapper CLI; after installation, agents should call the upstream tools directly as documented in the generated skill.
 
 ## Adding New Channels
 

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Twitter/X — check if twitter-cli or bird CLI is available."""
 
-from .base import Channel
 from agent_reach.probe import probe_command
+
+from .base import Channel
 
 
 class TwitterChannel(Channel):

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -4,6 +4,7 @@
 import json
 import urllib.request
 from typing import Any
+
 from .base import Channel
 
 _UA = "agent-reach/1.0"

--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -2,6 +2,7 @@
 """Web — any URL via Jina Reader. Always available."""
 
 import urllib.request
+
 from .base import Channel
 
 _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -2,8 +2,10 @@
 """Xiaoyuzhou Podcast (小宇宙播客) — transcribe podcasts via Groq Whisper API."""
 
 import os
+
 from agent_reach.config import Config
 from agent_reach.probe import probe_command
+
 from .base import Channel
 
 

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -9,10 +9,10 @@ Usage:
     agent-reach setup
 """
 
-import sys
 import argparse
 import json
 import os
+import sys
 import time
 
 from agent_reach import __version__
@@ -171,6 +171,7 @@ def main():
 def _cmd_install(args):
     """One-shot deterministic installer."""
     import os
+
     from agent_reach.config import Config
     from agent_reach.doctor import check_all, format_report
 
@@ -223,9 +224,9 @@ def _cmd_install(args):
         env = _detect_environment()
 
     if env == "server":
-        print(f"Environment: Server/VPS (auto-detected)")
+        print("Environment: Server/VPS (auto-detected)")
     else:
-        print(f"Environment: Local computer (auto-detected)")
+        print("Environment: Local computer (auto-detected)")
 
     server_skipped_opencli_channels = set()
     if env == "server" and requested_channels:
@@ -236,11 +237,11 @@ def _cmd_install(args):
     # Apply explicit flags
     if args.proxy:
         if dry_run:
-            print(f"[dry-run] Would save network proxy")
+            print("[dry-run] Would save network proxy")
         else:
             config.set("proxy", args.proxy)
             config.set("bilibili_proxy", args.proxy)  # legacy key
-            print(f"✅ 代理已保存（Agent 访问受限网络时使用）")
+            print("✅ 代理已保存（Agent 访问受限网络时使用）")
 
     # ── Install core system dependencies (lightweight, always) ──
     print()
@@ -289,15 +290,15 @@ def _cmd_install(args):
         print("   it only happens once during install. Enter your password or click 'Allow'.)")
         try:
             from agent_reach.cookie_extract import configure_from_browser
-            results = configure_from_browser("chrome", config)
+            browser_results = configure_from_browser("chrome", config)
             found = False
-            for platform, success, message in results:
+            for platform, success, message in browser_results:
                 if success:
                     print(f"  ✅ {platform}: {message}")
                     found = True
             if not found:
-                results = configure_from_browser("firefox", config)
-                for platform, success, message in results:
+                browser_results = configure_from_browser("firefox", config)
+                for platform, success, message in browser_results:
                     if success:
                         print(f"  ✅ {platform}: {message}")
                         found = True
@@ -321,13 +322,13 @@ def _cmd_install(args):
     if not dry_run:
         print()
         print("Testing channels...")
-        results = check_all(config)
-        ok = sum(1 for r in results.values() if r["status"] == "ok")
-        total = len(results)
+        channel_results = check_all(config)
+        ok = sum(1 for r in channel_results.values() if r["status"] == "ok")
+        total = len(channel_results)
 
         # Final status
         print()
-        print(format_report(results))
+        print(format_report(channel_results))
         print()
 
         # ── Install agent skill ──
@@ -354,9 +355,9 @@ def _cmd_install(args):
 
 def _install_skill(force: bool = True):
     """Install Agent Reach as an agent skill (OpenClaw / Claude Code / .agents)."""
+    import importlib.resources
     import os
     import shutil
-    import importlib.resources
 
     def _is_english_locale(value: str) -> bool:
         normalized = value.strip().lower()
@@ -531,9 +532,9 @@ def _cmd_format(args):
 
 def _install_system_deps():
     """Install system-level dependencies: gh CLI, Node.js (for mcporter)."""
+    import platform
     import shutil
     import subprocess
-    import platform
     import tempfile
 
     print("Checking system dependencies...")
@@ -659,6 +660,7 @@ def _install_system_deps():
 def _install_xiaoyuzhou_deps():
     """Install Xiaoyuzhou podcast transcription script."""
     import shutil
+
     from agent_reach.config import Config
 
     config = Config()
@@ -1019,6 +1021,7 @@ def _detect_environment():
 def _cmd_configure(args):
     """Set a config value and test it, or auto-extract from browser."""
     import shutil
+
     from agent_reach.config import Config
 
     config = Config()
@@ -1121,15 +1124,15 @@ def _cmd_configure(args):
 
     elif args.key == "github-token":
         config.set("github_token", value)
-        print(f"✅ GitHub token configured!")
+        print("✅ GitHub token configured!")
 
     elif args.key == "groq-key":
         config.set("groq_api_key", value)
-        print(f"✅ Groq key configured!")
+        print("✅ Groq key configured!")
 
     elif args.key == "openai-key":
         config.set("openai_api_key", value)
-        print(f"✅ OpenAI key configured!")
+        print("✅ OpenAI key configured!")
 
 
 def _cmd_transcribe(args):
@@ -1476,10 +1479,11 @@ def _cmd_uninstall(args):
 def _cmd_doctor(args=None):
     from agent_reach.config import Config
     from agent_reach.doctor import check_all, format_report
+    rich_module: object | None
     try:
-        from rich import print as rprint
+        import rich as rich_module
     except ImportError:
-        rprint = print
+        rich_module = None
     config = Config()
     results = check_all(config)
 
@@ -1487,7 +1491,10 @@ def _cmd_doctor(args=None):
         print(json.dumps(results, ensure_ascii=False, indent=2))
         return
 
-    rprint(format_report(results))
+    if rich_module is not None:
+        getattr(rich_module, "print")(format_report(results))
+    else:
+        print(format_report(results))
 
     # Auto-install skill if not already present (fixes #154)
     _install_skill(force=False)
@@ -1545,7 +1552,7 @@ def _cmd_setup():
     print("  获取: https://github.com/settings/tokens (无需任何权限)")
     current = config.get("github_token")
     if current:
-        print(f"  当前状态: ✅ 已配置")
+        print("  当前状态: ✅ 已配置")
     else:
         key = input("  GITHUB_TOKEN (回车跳过): ").strip()
         if key:
@@ -1566,7 +1573,7 @@ def _cmd_setup():
     print("  免费额度，注册: https://console.groq.com")
     current = config.get("groq_api_key")
     if current:
-        print(f"  当前状态: ✅ 已配置")
+        print("  当前状态: ✅ 已配置")
     else:
         key = input("  GROQ_API_KEY (回车跳过): ").strip()
         if key:
@@ -1697,10 +1704,10 @@ def _is_newer_version(remote: str, local: str) -> bool:
         except ValueError:
             return None
 
-    r, l = parse(remote), parse(local)
-    if r is None or l is None:
+    remote_version, local_version = parse(remote), parse(local)
+    if remote_version is None or local_version is None:
         return remote != local  # unparseable — fall back to old behavior
-    return r > l
+    return remote_version > local_version
 
 
 def _cmd_check_update():
@@ -1733,7 +1740,7 @@ def _cmd_check_update():
             print()
             print(_UPDATE_INSTRUCTIONS)
             return "update_available"
-        print(f"✅ 已是最新版本")
+        print("✅ 已是最新版本")
         return "up_to_date"
 
     release_err = _classify_github_response_error(resp)
@@ -1770,9 +1777,9 @@ def _cmd_watch():
 
     Only outputs problems. If everything is fine, outputs a single line.
     """
+    from agent_reach import __version__
     from agent_reach.config import Config
     from agent_reach.doctor import check_all
-    from agent_reach import __version__
 
     config = Config()
     issues = []
@@ -1811,8 +1818,8 @@ def _cmd_watch():
         print(f"Agent Reach: 全部正常 ({ok}/{total} 渠道可用，v{__version__} 已是最新)")
         return
 
-    print(f"Agent Reach 监控报告")
-    print(f"=" * 40)
+    print("Agent Reach 监控报告")
+    print("=" * 40)
     print(f"版本: v{__version__}  |  渠道: {ok}/{total}")
 
     if issues:

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -8,10 +8,10 @@ Usage:
     agent-reach configure --from-browser chrome
 """
 
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 # Platform cookie specs: (platform_name, domain_pattern, needed_cookies)
-PLATFORM_SPECS = [
+PLATFORM_SPECS: List[Dict[str, Any]] = [
     {
         "name": "Twitter/X",
         "domains": [".x.com", ".twitter.com"],

--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -5,8 +5,9 @@ Each channel knows how to check itself. Doctor just collects the results.
 """
 
 from typing import Dict
-from agent_reach.config import Config
+
 from agent_reach.channels import get_all_channels
+from agent_reach.config import Config
 
 
 def check_all(config: Config) -> Dict[str, dict]:
@@ -47,9 +48,13 @@ def _name_msg(r: dict, escape) -> str:
 def format_report(results: Dict[str, dict]) -> str:
     """Format results as a readable text report (with Rich markup)."""
     try:
-        from rich.markup import escape
+        from rich.markup import escape as rich_escape
+
+        def escape(text: str) -> str:
+            return rich_escape(text)
     except ImportError:
-        escape = lambda x: x
+        def escape(text: str) -> str:
+            return text
 
     lines = []
     lines.append("[bold cyan]Agent Reach 状态[/bold cyan]")
@@ -107,7 +112,6 @@ def format_report(results: Dict[str, dict]) -> str:
         )
 
     # Security check: config file permissions (Unix only)
-    import os
     import stat
     import sys
 

--- a/agent_reach/integrations/mcp_server.py
+++ b/agent_reach/integrations/mcp_server.py
@@ -18,7 +18,7 @@ from agent_reach.core import AgentReach
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
-    from mcp.types import Tool, TextContent
+    from mcp.types import TextContent, Tool
     HAS_MCP = True
 except ImportError:
     HAS_MCP = False

--- a/agent_reach/probe.py
+++ b/agent_reach/probe.py
@@ -73,6 +73,7 @@ def probe_command(
         # failures (timeout/error) are worth a second attempt
         if last.status in ("missing", "broken"):
             return last
+    assert last is not None
     return last
 
 

--- a/test.sh
+++ b/test.sh
@@ -1,92 +1,60 @@
-#!/bin/bash
-# Agent Reach 一键完整测试
-# 用法: bash test-agent-reach.sh
-# 在任何有 Python 3.10+ 的机器上跑就行
+#!/usr/bin/env bash
+# Agent Reach smoke test
+# Usage: bash test.sh
+# Creates a clean virtualenv, installs the current checkout, and verifies the
+# supported CLI contract: installer, doctor, version, and Python API.
 
-set -e
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'deactivate 2>/dev/null || true; rm -rf "$TEST_DIR"' EXIT
 
 echo "╔════════════════════════════════════════════╗"
-echo "║    👁️  Agent Reach 完整测试                ║"
+echo "║    👁️  Agent Reach smoke test             ║"
 echo "╚════════════════════════════════════════════╝"
-echo ""
+echo
 
-# ── 1. 准备干净环境 ──
-echo "📦 创建测试环境..."
-TEST_DIR=$(mktemp -d)
+echo "📦 Creating clean test environment..."
 python3 -m venv "$TEST_DIR/venv"
+# shellcheck disable=SC1091
 source "$TEST_DIR/venv/bin/activate"
+python -m pip install -q --upgrade pip
 
-# ── 2. 安装 ──
-echo "📥 从 GitHub 安装..."
-pip install -q https://github.com/Panniantong/agent-reach/archive/main.zip 2>&1 | tail -1
-echo ""
+echo "📥 Installing current checkout..."
+pip install -q -e "$ROOT_DIR[dev]"
 
-# ── 3. 自动配置 ──
-echo "⚙️  运行 install..."
-agent-reach install --env=auto 2>&1
-echo ""
+echo "🔢 Version..."
+agent-reach version
 
-# ── 4. 诊断 ──
-echo "🩺 运行 doctor..."
-agent-reach doctor 2>&1
-echo ""
+echo "⚙️  Installer dry-run..."
+agent-reach install --env=auto --dry-run >/tmp/agent-reach-install-dry-run.txt
+head -20 /tmp/agent-reach-install-dry-run.txt
 
-# ── 5. 逐个测试 ──
-PASS=0
-FAIL=0
-SKIP=0
+echo "🩺 Doctor JSON..."
+agent-reach doctor --json > "$TEST_DIR/doctor.json"
+python -m json.tool "$TEST_DIR/doctor.json" >/dev/null
+python - <<'PY' "$TEST_DIR/doctor.json"
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+required = {"github", "youtube", "web", "rss"}
+missing = sorted(required - set(data))
+if missing:
+    raise SystemExit(f"missing expected channels: {missing}")
+ok = sum(1 for item in data.values() if item.get("status") == "ok")
+print(f"doctor reported {ok}/{len(data)} channels active")
+PY
 
-test_it() {
-    local name="$1"
-    shift
-    echo -n "  $name ... "
-    output=$(eval "$@" 2>&1) || true
-    if echo "$output" | grep -q "📖\|🔗\|http"; then
-        echo "✅"
-        PASS=$((PASS+1))
-    elif echo "$output" | grep -q "⚠️\|not installed\|not configured"; then
-        echo "⏭️  (跳过 — 缺依赖)"
-        SKIP=$((SKIP+1))
-    else
-        echo "❌"
-        echo "    $(echo "$output" | head -2)"
-        FAIL=$((FAIL+1))
-    fi
-}
+echo "🐍 Python API..."
+python - <<'PY'
+from agent_reach import AgentReach
+report = AgentReach().doctor()
+assert isinstance(report, dict)
+assert "github" in report
+print(f"AgentReach().doctor() returned {len(report)} channels")
+PY
 
-echo "📖 阅读测试"
-test_it "网页" "agent-reach read 'https://example.com'"
-test_it "GitHub" "agent-reach read 'https://github.com/Panniantong/agent-reach'"
-test_it "YouTube" "agent-reach read 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
-test_it "B站" "agent-reach read 'https://www.bilibili.com/video/BV1d4411N7zD'"
-test_it "RSS" "agent-reach read 'https://hnrss.org/frontpage'"
-test_it "Twitter" "agent-reach read 'https://x.com/elonmusk/status/1893797839927353448'"
-test_it "Reddit" "agent-reach read 'https://www.reddit.com/r/LocalLLaMA/hot'"
+echo
 
-echo ""
-echo "🔍 搜索测试"
-test_it "全网搜索" "agent-reach search 'best AI agent framework' -n 2"
-test_it "GitHub搜索" "agent-reach search-github 'yt-dlp' -n 2"
-test_it "Twitter搜索" "agent-reach search-twitter 'AI agent' -n 2"
-test_it "Reddit搜索" "agent-reach search-reddit 'machine learning' -n 2"
-test_it "YouTube搜索" "agent-reach search-youtube 'AI tutorial' -n 2"
-test_it "B站搜索" "agent-reach search-bilibili 'AI' -n 2"
-test_it "小红书搜索" "agent-reach search-xhs 'AI' -n 2"
-
-echo ""
-echo "════════════════════════════════════════════"
-echo "  ✅ 通过: $PASS   ❌ 失败: $FAIL   ⏭️  跳过: $SKIP"
-echo "════════════════════════════════════════════"
-
-# ── 6. 清理 ──
-deactivate 2>/dev/null || true
-rm -rf "$TEST_DIR"
-
-if [ $FAIL -eq 0 ]; then
-    echo ""
-    echo "🎉 全部通过！"
-else
-    echo ""
-    echo "⚠️  有 $FAIL 个测试失败，请检查上面的输出"
-    exit 1
-fi
+echo "🎉 Smoke test passed"

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from agent_reach.probe import ProbeResult, probe_command, reinstall_hint
+from agent_reach.probe import probe_command, reinstall_hint
 
 
 def _make_executable(path, content):
@@ -25,7 +25,7 @@ def test_missing_command():
 @pytest.mark.skipif(sys.platform == "win32", reason="shebang semantics are POSIX-only")
 def test_broken_shebang_detected_as_broken(tmp_path, monkeypatch):
     """A stale venv shim: which() finds it, exec raises FileNotFoundError."""
-    script = _make_executable(
+    _make_executable(
         tmp_path / "stale-tool", "#!/nonexistent/venv/bin/python\nprint('hi')\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -38,7 +38,7 @@ def test_broken_shebang_detected_as_broken(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
-    script = _make_executable(
+    _make_executable(
         tmp_path / "healthy-tool", "#!/bin/sh\necho 'healthy-tool 1.2.3'\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -50,7 +50,7 @@ def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_nonzero_exit_classified_as_error(tmp_path, monkeypatch):
-    script = _make_executable(
+    _make_executable(
         tmp_path / "failing-tool", "#!/bin/sh\necho 'boom' >&2\nexit 3\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -62,7 +62,7 @@ def test_nonzero_exit_classified_as_error(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_exit_127_classified_as_broken(tmp_path, monkeypatch):
-    script = _make_executable(tmp_path / "wrapper-tool", "#!/bin/sh\nexit 127\n")
+    _make_executable(tmp_path / "wrapper-tool", "#!/bin/sh\nexit 127\n")
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
 
     r = probe_command("wrapper-tool", package="wrapper-pkg")
@@ -74,7 +74,7 @@ def test_exit_127_classified_as_broken(tmp_path, monkeypatch):
 def test_retries_help_transient_failures(tmp_path, monkeypatch):
     """First call fails (exit 1), second succeeds — retries=1 should return ok."""
     marker = tmp_path / "ran-once"
-    script = _make_executable(
+    _make_executable(
         tmp_path / "flaky-tool",
         f"#!/bin/sh\nif [ -f {marker} ]; then echo ok; exit 0; fi\ntouch {marker}\nexit 1\n",
     )

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from agent_reach.channels.twitter import TwitterChannel
 

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -13,9 +13,9 @@ reddit (#364), xueqiu (#365) and v2ex (#366).
 
 from unittest.mock import Mock, patch
 
-from agent_reach.probe import ProbeResult
 from agent_reach.channels import youtube as yt
 from agent_reach.channels.youtube import YouTubeChannel, _has_js_runtime_config
+from agent_reach.probe import ProbeResult
 
 
 def _which(*present):


### PR DESCRIPTION
## Summary
- replace stale wrapper-command integration test with a clean-environment smoke test for the supported installer/doctor/version/Python API contract
- document the verification checklist in CONTRIBUTING.md
- apply ruff import/style cleanup and small mypy fixes so lint, typing, tests, smoke test, and package build all pass

## Verification
- ruff check agent_reach tests
- mypy agent_reach
- python -m pytest tests/ -q
- bash test.sh
- python -m build