### PR TITLE
fix: pin mcporter config add to --scope home

### DIFF
--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -25,7 +25,7 @@ class ExaSearchChannel(Channel):
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
                 "  npm install -g mcporter\n"
-                "  mcporter config add exa https://mcp.exa.ai/mcp"
+                "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
             )
         if probe.status == "broken":
             return "error", _MCPORTER_BROKEN_HINT
@@ -36,5 +36,5 @@ class ExaSearchChannel(Channel):
             return "ok", "全网语义搜索可用（免费，无需 API Key）"
         return "off", (
             "mcporter 已装但 Exa 未配置。运行：\n"
-            "  mcporter config add exa https://mcp.exa.ai/mcp"
+            "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
         )

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -26,7 +26,7 @@ class LinkedInChannel(Channel):
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
                 "  pip install linkedin-scraper-mcp\n"
-                "  mcporter config add linkedin http://localhost:3000/mcp\n"
+                "  mcporter config add linkedin http://localhost:3000/mcp --scope home\n"
                 "  详见 https://github.com/stickerdaniel/linkedin-mcp-server"
             )
         if probe.status == "broken":
@@ -39,5 +39,5 @@ class LinkedInChannel(Channel):
         return "off", (
             "mcporter 已装但 LinkedIn MCP 未配置。运行：\n"
             "  pip install linkedin-scraper-mcp\n"
-            "  mcporter config add linkedin http://localhost:3000/mcp"
+            "  mcporter config add linkedin http://localhost:3000/mcp --scope home"
         )

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -225,7 +225,7 @@ class XiaoHongShuChannel(Channel):
             )
         return "warn", (
             "xiaohongshu-mcp 服务在跑但 mcporter 未接入。运行：\n"
-            f"  mcporter config add xiaohongshu {_MCP_ENDPOINT}"
+            f"  mcporter config add xiaohongshu {_MCP_ENDPOINT} --scope home"
         )
 
     def _check_xhs_cli(self):

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -739,7 +739,7 @@ def _install_xhs_deps():
         print("    1. 下载 binary：https://github.com/xpzouying/xiaohongshu-mcp/releases")
         print("       （建议放到 ~/.agent-reach/tools/ 下）")
         print("    2. 启动服务（首次运行会下载约 150MB 浏览器，请等待完成）")
-        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp")
+        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp --scope home")
         print("    4. 验证：agent-reach doctor")
         return
 
@@ -947,14 +947,14 @@ def _install_mcporter():
         )
         if "exa" not in r.stdout:
             subprocess.run(
-                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp", "--scope", "home"],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             print("  ✅ Exa search configured (free, no API key needed)")
         else:
             print("  ✅ Exa search already configured")
     except Exception:
-        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
     # NOTE: xhs-cli is now optional, installed via --channels=xiaohongshu
 
@@ -967,11 +967,11 @@ def _install_mcporter_safe():
 
     if shutil.which("mcporter"):
         print("  ✅ mcporter already installed")
-        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
     else:
         print("  -- mcporter not installed")
         print("  To install: npm install -g mcporter")
-        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
 
 def _detect_environment():
@@ -1512,7 +1512,7 @@ def _cmd_setup():
     if not shutil.which("mcporter"):
         print("  当前状态: -- mcporter 未安装")
         print("  安装：npm install -g mcporter")
-        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
     else:
         try:
@@ -1526,17 +1526,17 @@ def _cmd_setup():
                 setup_now = input("  现在自动配置 Exa 吗？[Y/n]: ").strip().lower()
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
-                        ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                        ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp", "--scope", "home"],
                         capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                     )
                     if add_r.returncode == 0:
                         print("  ✅ Exa 已配置")
                     else:
                         print("  [!] 自动配置失败，请手动执行：")
-                        print("     mcporter config add exa https://mcp.exa.ai/mcp")
+                        print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         except Exception:
             print("  [!] 无法检查 Exa 配置，请手动执行：")
-            print("     mcporter config add exa https://mcp.exa.ai/mcp")
+            print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
 
     # Step 2: GitHub token

--- a/agent_reach/guides/setup-exa.md
+++ b/agent_reach/guides/setup-exa.md
@@ -17,7 +17,7 @@ npm install -g mcporter
 
 ### 2. 注册 Exa MCP
 ```bash
-mcporter config add exa https://mcp.exa.ai/mcp
+mcporter config add exa https://mcp.exa.ai/mcp --scope home
 ```
 
 ### 3. 验证

--- a/agent_reach/guides/setup-xiaohongshu.md
+++ b/agent_reach/guides/setup-xiaohongshu.md
@@ -79,7 +79,7 @@ docker run -d \
   -p 18060:18060 \
   xpzouying/xiaohongshu-mcp
 
-mcporter config add xiaohongshu http://localhost:18060/mcp
+mcporter config add xiaohongshu http://localhost:18060/mcp --scope home
 ```
 
 xhs-cli 是当前推荐方案，不需要 Docker，安装更简单。

--- a/docs/install.md
+++ b/docs/install.md
@@ -195,7 +195,7 @@ agent-reach install --channels opencli
 > 1. 从 https://github.com/xpzouying/xiaohongshu-mcp/releases 下载对应平台 binary 到 `~/.agent-reach/tools/`
 > 2. 启动服务（首次运行会自动下载约 150MB 无头浏览器，耐心等完成）
 > 3. 让用户扫码登录（agent 调 `get_login_qrcode` 工具取二维码）
-> 4. 接入：`mcporter config add xiaohongshu http://localhost:18060/mcp`
+> 4. 接入：`mcporter config add xiaohongshu http://localhost:18060/mcp --scope home`
 > 5. 调用时务必带 `--timeout 120000`
 >
 > **存量用户（xhs-cli）：** 已装好的 xhs-cli 继续作为备选后端工作（上游 2026-03 起停更，不推荐新装）。`xhs login` 自动提取浏览器 Cookie；失败时用 Cookie-Editor 导出后：
@@ -297,7 +297,7 @@ pip install linkedin-scraper-mcp
 > **登录后启动 MCP 服务：**
 > ```bash
 > linkedin-scraper-mcp --transport streamable-http --port 8001
-> mcporter config add linkedin http://localhost:8001/mcp
+> mcporter config add linkedin http://localhost:8001/mcp --scope home
 > ```
 >
 > 详见 https://github.com/stickerdaniel/linkedin-mcp-server


### PR DESCRIPTION
## Summary

`mcporter config add` defaults to `--scope project`, which resolves relative to the current working directory rather than a stable global location. Every call site in Agent Reach that runs this command (the `install --env=auto` flow, the interactive `setup` wizard, and all the doctor-hint / documentation strings for Exa, XiaoHongShu, and LinkedIn) omits an explicit scope.

Practical effect: a server registered during `agent-reach install` (e.g. Exa search) only resolves correctly while mcporter is invoked from the exact directory the installer happened to run in. Run `agent-reach doctor` from a different project folder, or in a fresh terminal/session elsewhere, and `mcporter config list` no longer finds the entry — the channel silently reports as unconfigured even though install previously reported success.

This is easy to hit by accident: I ran into it because I'd cloned Agent Reach's own source into my working directory, and the repo happens to ship an example `config/mcporter.json` fixture — `mcporter config add` silently wrote into that tracked file instead of a real global config, since project-scope resolution found it first. But the same failure mode applies to any user who simply runs `agent-reach install` from one folder and later uses the tool from another.

## Fix

Add `--scope home` to every `mcporter config add` invocation and instruction string, so registrations always land in `~/.mcporter/mcporter.json` regardless of cwd:

- `agent_reach/cli.py` — both the automated install path and the interactive `setup` wizard's actual `subprocess.run` calls, plus all printed manual-fallback instructions
- `agent_reach/channels/exa_search.py`, `xiaohongshu.py`, `linkedin.py` — doctor hint strings shown to users/agents when a channel isn't configured
- `docs/install.md`, `agent_reach/guides/setup-exa.md`, `agent_reach/guides/setup-xiaohongshu.md` — copy-pasteable instructions

## Test plan

- [x] `pytest tests/` — 196 passed, no regressions (the one existing assertion on this string, `tests/test_channels.py:1018`, is a substring check and still holds)
- [x] `ruff check` on all touched files — no new lint errors introduced (pre-existing unrelated lint debt elsewhere in `cli.py` untouched)
- [x] Manually verified: `mcporter config add exa https://mcp.exa.ai/mcp --scope home` writes to `~/.mcporter/mcporter.json`, and `mcporter config list --json` resolves it correctly from an unrelated directory (previously returned empty)