### PR TITLE
fix(youtube): harden yt-dlp against bot-check and JS-challenge failures

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -80,8 +80,8 @@ curl -s "https://r.jina.ai/URL"
 # GitHub 搜索
 gh search repos "query" --sort stars --limit 10
 
-# YouTube 字幕（注意：B站不要用 yt-dlp，见 video.md）
-yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
+# YouTube 字幕（注意：B站不要用 yt-dlp，见 video.md；被风控要求登录时的 cookie 兜底也在 video.md）
+yt-dlp --ignore-no-formats-error --write-sub --skip-download -o "/tmp/%(id)s" "URL"
 
 # V2EX 热门
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -68,8 +68,8 @@ curl -s "https://r.jina.ai/URL"
 # GitHub search
 gh search repos "query" --sort stars --limit 10
 
-# YouTube subtitles (NOTE: never use yt-dlp for Bilibili — see video.md)
-yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
+# YouTube subtitles (NOTE: never use yt-dlp for Bilibili — see video.md; cookie fallback for bot-checks is there too)
+yt-dlp --ignore-no-formats-error --write-sub --skip-download -o "/tmp/%(id)s" "URL"
 
 # V2EX hot topics
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -4,27 +4,37 @@ YouTube、B站、小宇宙播客的字幕和转录。
 
 ## YouTube (yt-dlp)
 
+> **通用 flag**: 以下命令都带 `--ignore-no-formats-error`。这几个场景只读元数据/字幕/评论，不需要可播放的视频格式；YouTube 的 JS 挑战偶尔解不出来会导致格式解析失败，不加这个 flag 会连读字幕都跟着报错退出。
+
 ### 获取视频元数据
 
 ```bash
-yt-dlp --dump-json "URL"
+yt-dlp --ignore-no-formats-error --dump-json "URL"
 ```
 
 ### 下载字幕
 
 ```bash
 # 下载字幕 (不下载视频)
-yt-dlp --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
+yt-dlp --ignore-no-formats-error --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
 
 # 然后读取 .vtt 文件
 cat /tmp/VIDEO_ID.*.vtt
 ```
 
+> **触发 "Sign in to confirm you're not a bot"？** 部分视频会被 YouTube 风控拦截，纯匿名请求过不去。仅限**本地有浏览器**的环境（服务器没有浏览器就跳过这条，直接走下面的 Whisper 兜底），带浏览器登录态重试：
+>
+> ```bash
+> yt-dlp --ignore-no-formats-error --cookies-from-browser chrome --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
+> ```
+>
+> 多 Chrome Profile 时默认的 `chrome` 可能读到没登录过的 Profile，用 `--cookies-from-browser "chrome:Profile 2"` 指定具体 profile（`ls -t ~/Library/Application\ Support/Google/Chrome/ | head` 找最近用过的那个）。重试后如果提示变成 "no subtitles for the requested languages"，先用 `yt-dlp --list-subs "URL"` 确认这条视频到底有没有字幕——很多视频压根没上字幕，不是 cookie 问题，直接改用下面的 Whisper 兜底。
+
 ### 获取评论
 
 ```bash
 # 提取评论（best-effort，不保证完整）
-yt-dlp --write-comments --skip-download --write-info-json \
+yt-dlp --ignore-no-formats-error --write-comments --skip-download --write-info-json \
   --extractor-args "youtube:max_comments=20" \
   -o "/tmp/%(id)s" "URL"
 # 评论在 .info.json 的 comments 字段中
@@ -33,7 +43,7 @@ yt-dlp --write-comments --skip-download --write-info-json \
 ### 搜索视频
 
 ```bash
-yt-dlp --dump-json "ytsearch5:query"
+yt-dlp --ignore-no-formats-error --dump-json "ytsearch5:query"
 ```
 
 > **字幕注意**: 手动上传的字幕提取可靠；自动生成字幕可能存在行间重复，需后处理。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,28 @@
 # 常见问题排查
 
+## YouTube: yt-dlp 报 "Sign in to confirm you're not a bot"
+
+**症状：** `yt-dlp --dump-json` / `--write-sub` 等命令直接报错退出，提示需要登录验证；有些视频紧接着还会报 `Requested format is not available`。
+
+**原因：** 部分视频被 YouTube 风控要求验证是否为真人。纯匿名请求（无 Cookie）会被拦截；即使带了 Cookie，YouTube 的 JS 挑战偶尔本地解不出来，导致可播放格式解析失败，如果没加 `--ignore-no-formats-error` 会连读元数据/字幕这种不需要下载视频的操作也一起报错。
+
+**解决方案：** 仅限本地有浏览器的环境（服务器没有浏览器就跳过这条，改用下方的 Whisper 音频转写兜底）：
+
+```bash
+yt-dlp --ignore-no-formats-error --cookies-from-browser chrome --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
+```
+
+多 Chrome Profile 时默认的 `chrome` 可能读到没登录过的 Profile，用 `--cookies-from-browser "chrome:Profile 2"` 指定具体 profile。
+
+如果重试后提示变成 "no subtitles for the requested languages"，先用 `yt-dlp --list-subs "URL"` 确认这条视频到底有没有字幕——很多视频压根没上字幕，不是 Cookie 或风控问题。这种情况下改用音频转写：
+
+```bash
+agent-reach configure groq-key gsk_xxx   # 免费，console.groq.com
+agent-reach transcribe "URL"
+```
+
+---
+
 ## 雪球 / Xueqiu: API 返回 400
 
 **症状：** `agent-reach doctor` 显示雪球 ⚠️，报 `HTTP Error 400`


### PR DESCRIPTION
## Summary

Testing the documented YouTube commands against a real video surfaced two compounding failure modes not covered by the current docs:

1. **Bot-check**: some videos trigger YouTube's "Sign in to confirm you're not a bot" on fully anonymous requests. The documented commands had no cookie fallback.
2. **JS challenge / format resolution**: independent of bot-check, YouTube's JS challenge (needed to resolve playable video/audio formats) sometimes can't be solved locally without an extra remote component. When that happens, yt-dlp hard-fails with `Requested format is not available` — even for metadata/subtitle/comment reads that never needed a playable format to begin with.

Both are easy to hit on an arbitrary video and, before this fix, would cause the documented commands to fail outright with no guidance on why or what to do next.

## Fix

- Add `--ignore-no-formats-error` to every read-only yt-dlp invocation in the docs (metadata, subtitles, comments, search) — safe since none of these operations need an actual playable video/audio stream.
- Document a `--cookies-from-browser` retry as the fallback specifically for the bot-check case, scoped to local/desktop environments (it doesn't apply on headless servers, which get pointed at the Whisper-based fallback instead).
- Clarify that once past both issues, "no subtitles for the requested languages" often just means the video genuinely has none — pointing at `--list-subs` to confirm before assuming it's a config problem, and `agent-reach transcribe` as the audio-based fallback.

Updated: `agent_reach/skill/SKILL.md` + `SKILL_en.md` (quick-command pointers), `agent_reach/skill/references/video.md` (full fallback flow), `docs/troubleshooting.md` (human-facing entry, matching the existing Xueqiu/Twitter troubleshooting format).

## Test plan

- [x] `pytest tests/` — 196 passed, no regressions
- [x] Verified against a real video that was hitting both failure modes end-to-end:
  - `yt-dlp --ignore-no-formats-error --dump-json URL` — now succeeds (bot-check downgrades to a non-fatal warning, full metadata returned) where it previously hard-failed
  - `yt-dlp --ignore-no-formats-error --cookies-from-browser chrome --write-sub ... URL` — completes and correctly reports "no subtitles for the requested languages" (this particular video has none in any language) instead of crashing with the format error