### PR TITLE
fix: security hardening (cookie scoping + host-based routing) and reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### 🔒 Security / 安全
+
+- **Cookie 过度采集修复：** 安装期自动导入（`install --channels ...`）不再顺带抓取未请求平台的 Cookie —— 现在只导入 `--channels` 指定的渠道，提取与保存都严格限定在该范围。`configure --from-browser` 保持原有默认（不带 `--channels` 时导入全部），但会明确提示并支持用 `--channels` 缩小范围。
+  - Install-time auto-import no longer silently harvests cookies for platforms you didn't request — it is now scoped to `--channels`. `configure --from-browser` keeps its original default (imports all when `--channels` is omitted) but is now transparent about it and supports `--channels` scoping. New `resolve_cookie_targets()` maps channel names to cookie config keys (incl. `xiaohongshu → xhs`).
+- **仿冒域名路由修复：** 渠道 `can_handle()` 不再使用子串匹配（`"x.com" in url`），改用新的 `host_matches()` 主机名精确匹配。`notx.com`、`x.com.evil.test`、`x.com@evil.test`（userinfo 伪装）、端口等仿冒/欺骗手段均被拒绝，避免带凭证的渠道把用户 Cookie 附加到攻击者控制的 URL。
+  - All channel routing now uses exact host / real-subdomain matching via `agent_reach.utils.urls.host_matches`, closing lookalike-domain and userinfo-spoof routing.
+- **Cookie 域名匹配修复：** 浏览器 Cookie 提取此前用 `endswith` 匹配平台域名，`notxueqiu.com`、`evilxueqiu.com` 等仿冒域名的 Cookie 会被误纳入雪球 Cookie 字符串并保存。改用 `domain_covers()` 精确/子域匹配，杜绝攻击者 Cookie 注入。
+  - Browser cookie extraction matched platform domains with `endswith`, so cookies from lookalike hosts (`notxueqiu.com`) were swept into the saved Xueqiu cookie string. Now uses exact-or-subdomain matching (`domain_covers`).
+
+### 🐛 Fixes / 修复
+
+- **`doctor` 变为只读诊断：** 移除 `doctor` 运行时自动安装 skill 的副作用。skill 安装仅发生在 `install` 和 `skill --install`。
+  - `doctor` is now read-only diagnostics — it no longer installs the agent skill as a side effect.
+- **Exa/mcporter 配置固定到 home scope：** `mcporter config add exa` 现在带 `--scope home`，确保 Exa 配置写入用户主目录（`~/.mcporter`）而非当前工作目录的项目配置，跨目录持久可用。（`config list` 不支持 `--scope`，保持不变。）
+  - `mcporter config add exa` now pins to `--scope home` so Exa search persists for the agent regardless of cwd.
+
+### 🔧 Chore
+
+- `test.sh` 重写为安装冒烟测试（干净 venv 装本地副本，跑 version/doctor），不再调用已废弃的 `read`/`search` 子命令。
+  - `test.sh` rewritten as an install smoke test (fresh venv, local install, version/doctor) instead of calling the removed `read`/`search` subcommands.
+
+---
+
 ## [1.3.1] - 2026-03-27
 
 ### 🐛 Bug Fixes / 修复

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.5.0
 - `pip install -e .` — Dev install
 - `pytest tests/ -v` — All tests
 - `pytest tests/test_cli.py -v` — CLI tests only
-- `bash test.sh` — Full integration test (creates venv, installs, runs doctor + channel tests)
+- `bash test.sh` — Install smoke test (fresh venv, installs local copy, runs version/doctor). NOT unit tests — use pytest for those.
 - `python -m agent_reach.cli doctor` — Run diagnostics
 - `python -m agent_reach.cli install --env=auto` — Auto-configure
 

--- a/agent_reach/channels/_opencli_site.py
+++ b/agent_reach/channels/_opencli_site.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Shared channel helper for OpenCLI browser-session-only platforms."""
 
-from urllib.parse import urlparse
+from agent_reach.utils.urls import host_matches
 
 from .base import Channel
 
@@ -22,8 +22,7 @@ class OpenCLISiteChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        domain = urlparse(url).netloc.lower()
-        return any(domain == d or domain.endswith(f".{d}") for d in self.domains)
+        return host_matches(url, *self.domains)
 
     def check(self, config=None):
         from agent_reach.backends import opencli_status

--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -39,9 +39,8 @@ class BilibiliChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "bilibili.com" in d or "b23.tv" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "bilibili.com", "b23.tv")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -25,7 +25,7 @@ class ExaSearchChannel(Channel):
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
                 "  npm install -g mcporter\n"
-                "  mcporter config add exa https://mcp.exa.ai/mcp"
+                "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
             )
         if probe.status == "broken":
             return "error", _MCPORTER_BROKEN_HINT
@@ -36,5 +36,5 @@ class ExaSearchChannel(Channel):
             return "ok", "全网语义搜索可用（免费，无需 API Key）"
         return "off", (
             "mcporter 已装但 Exa 未配置。运行：\n"
-            "  mcporter config add exa https://mcp.exa.ai/mcp"
+            "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
         )

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -13,8 +13,8 @@ class GitHubChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "github.com" in urlparse(url).netloc.lower()
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "github.com")
 
     def check(self, config=None):
         # 真跑 gh auth status 探活。注意：未登录时 rc!=0 是正常业务态（warn），不是 error。

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -16,8 +16,8 @@ class LinkedInChannel(Channel):
     tier = 2
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "linkedin.com" in urlparse(url).netloc.lower()
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "linkedin.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -39,10 +39,8 @@ class RedditChannel(Channel):
     tier = 1  # no zero-config path exists — see module docstring
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-
-        d = urlparse(url).netloc.lower()
-        return "reddit.com" in d or "redd.it" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "reddit.com", "redd.it")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -12,9 +12,8 @@ class TwitterChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "x.com" in d or "twitter.com" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "x.com", "twitter.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -28,9 +28,8 @@ class V2EXChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "v2ex.com" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "v2ex.com")
 
     # ------------------------------------------------------------------ #
     # Health check

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -153,9 +153,8 @@ class XiaoHongShuChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaohongshu.com" in d or "xhslink.com" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "xiaohongshu.com", "xhslink.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -14,9 +14,8 @@ class XiaoyuzhouChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaoyuzhoufm.com" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "xiaoyuzhoufm.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -157,8 +157,8 @@ class XueqiuChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        d = urllib.parse.urlparse(url).netloc.lower()
-        return "xueqiu.com" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "xueqiu.com")
 
     # ------------------------------------------------------------------ #
     # Health check
@@ -178,7 +178,7 @@ class XueqiuChannel(Channel):
         except Exception as e:
             return "warn", (
                 f"Xueqiu API 连接失败：{e}。"
-                "请先登录雪球后运行：agent-reach configure --from-browser chrome"
+                "请先登录雪球后运行：agent-reach configure --from-browser chrome --channels xueqiu"
             )
 
     # ------------------------------------------------------------------ #

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -27,10 +27,8 @@ class YouTubeChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-
-        d = urlparse(url).netloc.lower()
-        return "youtube.com" in d or "youtu.be" in d
+        from agent_reach.utils.urls import host_matches
+        return host_matches(url, "youtube.com", "youtu.be")
 
     def check(self, config=None):
         # 真跑 yt-dlp --version 探活，区分未装 / venv 断链 / 跑不动

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -87,7 +87,12 @@ def main():
     p_conf.add_argument("value", nargs="*", help="The value(s) to set")
     p_conf.add_argument("--from-browser", metavar="BROWSER",
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
-                        help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
+                        help="Auto-extract cookies from browser (chrome/firefox/edge/brave/opera). "
+                             "Use --channels to scope which platforms to import (default: all).")
+    p_conf.add_argument("--channels", default="",
+                        help="Comma-separated cookie channels to import with --from-browser "
+                             "(twitter,xiaohongshu,bilibili,xueqiu), or 'all'. "
+                             "Omit to import all supported platforms.")
 
     # ── doctor ──
     p_doctor = sub.add_parser("doctor", help="Check platform availability")
@@ -207,7 +212,6 @@ def _cmd_install(args):
         # linkedin: manual setup, no auto-install
     }
     OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
-    COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili"}
 
     requested_channels = set()
     if args.channels:
@@ -280,23 +284,27 @@ def _cmd_install(args):
         print()
         print(f"[dry-run] Would install optional channels: {', '.join(sorted(requested_channels))}")
 
-    # ── Auto-import cookies (only if cookie-needing channels are requested) ──
-    needs_cookies = bool(requested_channels & COOKIE_CHANNELS)
+    # ── Auto-import cookies (only for the requested cookie channels) ──
+    from agent_reach.cookie_extract import (
+        configure_from_browser,
+        resolve_cookie_targets,
+    )
+    cookie_targets = resolve_cookie_targets(requested_channels)
+    needs_cookies = bool(cookie_targets)
     if env == "local" and needs_cookies and not safe_mode and not dry_run:
         print()
         print("Importing cookies from browser...")
         print("  (macOS may ask for your login password to access the Keychain — this is normal,")
         print("   it only happens once during install. Enter your password or click 'Allow'.)")
         try:
-            from agent_reach.cookie_extract import configure_from_browser
-            results = configure_from_browser("chrome", config)
+            results = configure_from_browser("chrome", config, cookie_targets)
             found = False
             for platform, success, message in results:
                 if success:
                     print(f"  ✅ {platform}: {message}")
                     found = True
             if not found:
-                results = configure_from_browser("firefox", config)
+                results = configure_from_browser("firefox", config, cookie_targets)
                 for platform, success, message in results:
                     if success:
                         print(f"  ✅ {platform}: {message}")
@@ -946,15 +954,18 @@ def _install_mcporter():
             ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
         )
         if "exa" not in r.stdout:
+            # --scope home pins Exa to ~/.mcporter so it persists for the agent
+            # regardless of cwd (a project mcporter.json would otherwise capture
+            # the default project scope). config list has no --scope flag.
             subprocess.run(
-                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp", "--scope", "home"],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             print("  ✅ Exa search configured (free, no API key needed)")
         else:
             print("  ✅ Exa search already configured")
     except Exception:
-        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
     # NOTE: xhs-cli is now optional, installed via --channels=xiaohongshu
 
@@ -967,11 +978,11 @@ def _install_mcporter_safe():
 
     if shutil.which("mcporter"):
         print("  ✅ mcporter already installed")
-        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
     else:
         print("  -- mcporter not installed")
         print("  To install: npm install -g mcporter")
-        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
 
 def _detect_environment():
@@ -1025,13 +1036,31 @@ def _cmd_configure(args):
 
     # ── Auto-extract from browser ──
     if args.from_browser:
-        from agent_reach.cookie_extract import configure_from_browser
+        from agent_reach.cookie_extract import (
+            configure_from_browser,
+            resolve_cookie_targets,
+        )
+
+        raw_channels = [c.strip() for c in (args.channels or "").split(",") if c.strip()]
+        if raw_channels:
+            cookie_targets = resolve_cookie_targets(raw_channels)
+            if not cookie_targets:
+                print(f"No cookie-based channels in --channels {args.channels}.")
+                print("   Cookie channels: twitter, xiaohongshu, bilibili, xueqiu (or 'all').")
+                return
+        else:
+            # No --channels: keep the original import-everything behavior so
+            # existing invocations don't break, but make it transparent and
+            # point at scoping.
+            cookie_targets = resolve_cookie_targets(["all"])
+            print("No --channels given — importing cookies for all supported platforms.")
+            print("   Tip: scope with --channels twitter (or bilibili, xiaohongshu, xueqiu).")
 
         browser = args.from_browser
-        print(f"Extracting cookies from {browser}...")
+        print(f"Extracting cookies from {browser} for: {', '.join(sorted(cookie_targets))}")
         print()
 
-        results = configure_from_browser(browser, config)
+        results = configure_from_browser(browser, config, cookie_targets)
 
         found_any = False
         for platform, success, message in results:
@@ -1489,8 +1518,9 @@ def _cmd_doctor(args=None):
 
     rprint(format_report(results))
 
-    # Auto-install skill if not already present (fixes #154)
-    _install_skill(force=False)
+    # doctor is read-only diagnostics — it never mutates the system. Skill
+    # installation happens in `agent-reach install` and `agent-reach skill
+    # --install`, not here.
 
 
 def _cmd_setup():
@@ -1512,7 +1542,7 @@ def _cmd_setup():
     if not shutil.which("mcporter"):
         print("  当前状态: -- mcporter 未安装")
         print("  安装：npm install -g mcporter")
-        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
     else:
         try:
@@ -1526,17 +1556,17 @@ def _cmd_setup():
                 setup_now = input("  现在自动配置 Exa 吗？[Y/n]: ").strip().lower()
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
-                        ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                        ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp", "--scope", "home"],
                         capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                     )
                     if add_r.returncode == 0:
                         print("  ✅ Exa 已配置")
                     else:
                         print("  [!] 自动配置失败，请手动执行：")
-                        print("     mcporter config add exa https://mcp.exa.ai/mcp")
+                        print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         except Exception:
             print("  [!] 无法检查 Exa 配置，请手动执行：")
-            print("     mcporter config add exa https://mcp.exa.ai/mcp")
+            print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
 
     # Step 2: GitHub token

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
-"""Auto-extract cookies from local browsers for all supported platforms.
+"""Auto-extract cookies from local browsers for the requested platforms.
 
-Supports: Chrome, Firefox, Edge, Brave, Opera
-Extracts: Twitter, XiaoHongShu, Bilibili cookies in one shot.
+Supports browsers: Chrome, Firefox, Edge, Brave, Opera
+Cookie platforms: Twitter/X, XiaoHongShu, Bilibili, Xueqiu. Extraction can be
+scoped to specific channels via config_keys / ``--channels``; the bare
+``configure --from-browser`` command imports all supported platforms by
+default (see resolve_cookie_targets / the CLI's soft-landing behavior).
 
 Usage:
-    agent-reach configure --from-browser chrome
+    agent-reach configure --from-browser chrome --channels twitter
+    agent-reach configure --from-browser chrome            # all platforms
 """
 
 from typing import Dict, List, Tuple
+
+from agent_reach.utils.urls import domain_covers
 
 # Platform cookie specs: (platform_name, domain_pattern, needed_cookies)
 PLATFORM_SPECS = [
@@ -39,10 +45,48 @@ PLATFORM_SPECS = [
 ]
 
 
-def extract_all(browser: str = "chrome") -> Dict[str, dict]:
+# CLI channel name → cookie config_key. Only these channels use browser
+# cookies; everything else (reddit, youtube, ...) never needs an import.
+COOKIE_CHANNEL_ALIASES = {
+    "twitter": "twitter",
+    "xiaohongshu": "xhs",
+    "xhs": "xhs",
+    "bilibili": "bilibili",
+    "xueqiu": "xueqiu",
+}
+
+# Every cookie platform (config_key), in PLATFORM_SPECS order.
+ALL_COOKIE_KEYS = [spec["config_key"] for spec in PLATFORM_SPECS]
+
+
+def resolve_cookie_targets(channels) -> set:
+    """Map requested channel names to the cookie config_keys to import.
+
+    Accepts CLI channel names (``xiaohongshu``), config_keys (``xhs``), or the
+    special token ``all``. Non-cookie channels (reddit, youtube, ...) are
+    dropped so a broad ``--channels`` never silently harvests extra cookies.
     """
-    Extract cookies for all supported platforms from the specified browser.
-    
+    targets = set()
+    for ch in channels:
+        c = str(ch).strip().lower()
+        if c == "all":
+            return set(ALL_COOKIE_KEYS)
+        key = COOKIE_CHANNEL_ALIASES.get(c)
+        if key:
+            targets.add(key)
+    return targets
+
+
+def extract_all(browser: str = "chrome", config_keys=None) -> Dict[str, dict]:
+    """
+    Extract cookies for the requested platforms from the specified browser.
+
+    config_keys: optional iterable of cookie config_keys to limit extraction
+    to (e.g. {"twitter"}). When None, every supported platform is extracted.
+    Note: the browser backend still loads the full cookie jar; scoping here
+    filters it so only the requested platforms' cookies are *extracted and
+    returned* — unrelated platforms are never persisted to config.
+
     Returns:
         {
             "twitter": {"auth_token": "xxx", "ct0": "yyy"},
@@ -113,17 +157,21 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
 
     results = {}
 
-    for spec in PLATFORM_SPECS:
+    if config_keys is not None:
+        wanted = set(config_keys)
+        specs = [s for s in PLATFORM_SPECS if s["config_key"] in wanted]
+    else:
+        specs = PLATFORM_SPECS
+
+    for spec in specs:
         platform_cookies = {}
         all_cookies_for_domain = []
 
         for cookie in cookie_jar:
-            # Check if cookie belongs to this platform
-            domain_match = any(
-                cookie.domain.endswith(d) or cookie.domain == d.lstrip(".")
-                for d in spec["domains"]
-            )
-            if not domain_match:
+            # Check if cookie belongs to this platform. Exact-or-dot-boundary
+            # matching (not substring) so lookalike hosts like notxueqiu.com
+            # can't sneak attacker cookies into the saved cookie string.
+            if not domain_covers(cookie.domain, *spec["domains"]):
                 continue
 
             all_cookies_for_domain.append(cookie)
@@ -229,16 +277,26 @@ def _sync_bird_env(auth_token: str, ct0: str) -> None:
 _sync_bird_credentials = _sync_bird_env
 
 
-def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
+def configure_from_browser(browser: str, config, config_keys) -> List[Tuple[str, bool, str]]:
     """
-    Extract cookies and configure all found platforms.
-    
+    Extract cookies for the requested platforms and configure the ones found.
+
+    config_keys: iterable of cookie config_keys to import (e.g. {"twitter"}).
+    This is required — extraction and persistence are scoped to it so
+    unrelated platforms' cookies are never extracted or saved to config.
+
     Returns list of (platform_name, success, message) tuples.
     """
     results_list = []
 
+    wanted = set(config_keys)
+    if not wanted:
+        return [("All platforms", False,
+                 "No cookie channels selected. Pass --channels "
+                 "(e.g. --channels twitter) or --channels all.")]
+
     try:
-        extracted = extract_all(browser)
+        extracted = extract_all(browser, config_keys=wanted)
     except Exception as e:
         return [("Browser", False, str(e))]
 

--- a/agent_reach/guides/setup-exa.md
+++ b/agent_reach/guides/setup-exa.md
@@ -17,7 +17,7 @@ npm install -g mcporter
 
 ### 2. 注册 Exa MCP
 ```bash
-mcporter config add exa https://mcp.exa.ai/mcp
+mcporter config add exa https://mcp.exa.ai/mcp --scope home
 ```
 
 ### 3. 验证

--- a/agent_reach/utils/urls.py
+++ b/agent_reach/utils/urls.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""URL host-matching helper shared by channel can_handle() methods.
+
+Channels must route on the *host* of a URL, never on a substring of the raw
+URL or netloc. Substring checks such as ``"x.com" in url`` match lookalike
+and spoofed hosts — ``notx.com``, ``x.com.evil.test``, ``x.com@evil.test`` —
+which would make a credentialed channel attach the user's auth cookies to an
+attacker-controlled request. host_matches() accepts only an exact host or a
+real subdomain of one of the allowed hosts.
+"""
+
+from urllib.parse import urlparse
+
+
+def domain_covers(host: str, *allowed_hosts: str) -> bool:
+    """Return True if bare *host* is exactly, or a subdomain of, an allowed host.
+
+    Operates on already-extracted host strings (e.g. a cookie's ``domain``,
+    which may carry a leading dot like ``.xueqiu.com``). Leading/trailing dots
+    are stripped on both sides and matching is exact-or-dot-boundary, so
+    lookalikes such as ``notxueqiu.com`` or ``xueqiu.com.evil.test`` are
+    rejected while real subdomains (``stock.xueqiu.com``) are accepted.
+    """
+    if not host:
+        return False
+    h = host.lower().strip(".")
+    if not h:
+        return False
+    for allowed in allowed_hosts:
+        a = allowed.lower().strip(".")
+        if a and (h == a or h.endswith("." + a)):
+            return True
+    return False
+
+
+def host_matches(url: str, *allowed_hosts: str) -> bool:
+    """Return True if *url*'s host is one of *allowed_hosts* or a subdomain.
+
+    Uses urlparse().hostname, which lowercases the host and strips any
+    userinfo (``user@``) and ``:port`` — so spoofing tricks that fool a
+    substring or netloc check are rejected. Host comparison is delegated to
+    domain_covers (exact-or-dot-boundary).
+    """
+    try:
+        host = urlparse(url).hostname
+    except ValueError:
+        return False
+    return domain_covers(host or "", *allowed_hosts)

--- a/docs/install.md
+++ b/docs/install.md
@@ -143,7 +143,7 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 > 3. 点击插件 → Export → Header String
 > 4. 把导出的字符串发给 Agent
 >
-> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
+> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（默认导入全部：Twitter + 小红书 + B站 + 雪球）。只想导入某个平台时加 `--channels`，例如 `--channels xueqiu`。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
 
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
@@ -229,10 +229,10 @@ agent-reach install --channels facebook,instagram
 > "雪球需要登录后的 Cookie。请先在 Chrome 里登录 xueqiu.com，然后运行："
 
 ```bash
-agent-reach configure --from-browser chrome
+agent-reach configure --from-browser chrome --channels xueqiu
 ```
 
-> Cookie 会随其他平台一起自动提取。
+> `--channels xueqiu` 只导入雪球 Cookie；省略 `--channels` 则默认导入全部平台。
 
 **小宇宙播客 / Xiaoyuzhou Podcast (Groq Whisper):**
 > "小宇宙播客转文字已默认安装，只需要一个免费的 Groq API Key。"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@
 **解决方案：** 在 Chrome 里登录 xueqiu.com，然后运行：
 
 ```bash
-agent-reach configure --from-browser chrome
+agent-reach configure --from-browser chrome --channels xueqiu
 ```
 
 再次运行 `agent-reach doctor` 确认恢复 ✅。Cookie 过期后重新运行即可。

--- a/test.sh
+++ b/test.sh
@@ -1,92 +1,68 @@
 #!/bin/bash
-# Agent Reach 一键完整测试
-# 用法: bash test-agent-reach.sh
-# 在任何有 Python 3.10+ 的机器上跑就行
+# Agent Reach 安装冒烟测试 / install smoke test
+# 用法: bash test.sh
+#
+# 需要 Python 3.10+。在一个干净的临时 venv 里安装本仓库的本地工作副本，
+# 验证打包 + 入口命令 + doctor 能真正跑起来（pip editable 装法测不到这些）。
+# 注意：Agent Reach 是安装器/诊断器，不是 wrapper —— 装好后 Agent 直接调用上游
+# 工具，没有 `agent-reach read/search` 之类子命令。确定性单元测试请跑
+# `pytest tests/ -v`。
 
-set -e
+set -euo pipefail
+
+# 脚本所在目录 = 仓库根，用于安装本地工作副本
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "╔════════════════════════════════════════════╗"
-echo "║    👁️  Agent Reach 完整测试                ║"
+echo "║    👁️  Agent Reach 安装冒烟测试            ║"
 echo "╚════════════════════════════════════════════╝"
 echo ""
 
-# ── 1. 准备干净环境 ──
-echo "📦 创建测试环境..."
+# ── 1. 干净的临时环境 ──
+echo "📦 创建临时 venv..."
 TEST_DIR=$(mktemp -d)
+cleanup() { deactivate 2>/dev/null || true; rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
 python3 -m venv "$TEST_DIR/venv"
+# shellcheck disable=SC1091
 source "$TEST_DIR/venv/bin/activate"
 
-# ── 2. 安装 ──
-echo "📥 从 GitHub 安装..."
-pip install -q https://github.com/Panniantong/agent-reach/archive/main.zip 2>&1 | tail -1
+# ── 2. 从本地工作副本安装 ──
+echo "📥 安装本地工作副本..."
+pip install -q "$SCRIPT_DIR" 2>&1 | tail -1
 echo ""
 
-# ── 3. 自动配置 ──
-echo "⚙️  运行 install..."
-agent-reach install --env=auto 2>&1
-echo ""
-
-# ── 4. 诊断 ──
-echo "🩺 运行 doctor..."
-agent-reach doctor 2>&1
-echo ""
-
-# ── 5. 逐个测试 ──
-PASS=0
+# ── 3. 冒烟检查：入口命令存在并可执行 ──
 FAIL=0
-SKIP=0
-
-test_it() {
-    local name="$1"
-    shift
+check() {
+    local name="$1"; shift
     echo -n "  $name ... "
-    output=$(eval "$@" 2>&1) || true
-    if echo "$output" | grep -q "📖\|🔗\|http"; then
+    if "$@" >/dev/null 2>&1; then
         echo "✅"
-        PASS=$((PASS+1))
-    elif echo "$output" | grep -q "⚠️\|not installed\|not configured"; then
-        echo "⏭️  (跳过 — 缺依赖)"
-        SKIP=$((SKIP+1))
     else
         echo "❌"
-        echo "    $(echo "$output" | head -2)"
-        FAIL=$((FAIL+1))
+        FAIL=$((FAIL + 1))
     fi
 }
 
-echo "📖 阅读测试"
-test_it "网页" "agent-reach read 'https://example.com'"
-test_it "GitHub" "agent-reach read 'https://github.com/Panniantong/agent-reach'"
-test_it "YouTube" "agent-reach read 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
-test_it "B站" "agent-reach read 'https://www.bilibili.com/video/BV1d4411N7zD'"
-test_it "RSS" "agent-reach read 'https://hnrss.org/frontpage'"
-test_it "Twitter" "agent-reach read 'https://x.com/elonmusk/status/1893797839927353448'"
-test_it "Reddit" "agent-reach read 'https://www.reddit.com/r/LocalLLaMA/hot'"
+echo "🔎 入口命令冒烟检查"
+check "version"      agent-reach version
+check "--help"       agent-reach --help
+check "doctor"       agent-reach doctor
+check "install dry"  agent-reach install --dry-run
 
 echo ""
-echo "🔍 搜索测试"
-test_it "全网搜索" "agent-reach search 'best AI agent framework' -n 2"
-test_it "GitHub搜索" "agent-reach search-github 'yt-dlp' -n 2"
-test_it "Twitter搜索" "agent-reach search-twitter 'AI agent' -n 2"
-test_it "Reddit搜索" "agent-reach search-reddit 'machine learning' -n 2"
-test_it "YouTube搜索" "agent-reach search-youtube 'AI tutorial' -n 2"
-test_it "B站搜索" "agent-reach search-bilibili 'AI' -n 2"
-test_it "小红书搜索" "agent-reach search-xhs 'AI' -n 2"
+echo "🩺 doctor 完整输出："
+agent-reach doctor 2>&1 || true
 
 echo ""
 echo "════════════════════════════════════════════"
-echo "  ✅ 通过: $PASS   ❌ 失败: $FAIL   ⏭️  跳过: $SKIP"
-echo "════════════════════════════════════════════"
-
-# ── 6. 清理 ──
-deactivate 2>/dev/null || true
-rm -rf "$TEST_DIR"
-
-if [ $FAIL -eq 0 ]; then
-    echo ""
-    echo "🎉 全部通过！"
+if [ "$FAIL" -eq 0 ]; then
+    echo "  🎉 安装冒烟测试通过"
+    echo "  提示：确定性单元测试请跑 pytest tests/ -v"
+    echo "════════════════════════════════════════════"
 else
-    echo ""
-    echo "⚠️  有 $FAIL 个测试失败，请检查上面的输出"
+    echo "  ⚠️  有 $FAIL 项冒烟检查失败，请检查上面的输出"
+    echo "════════════════════════════════════════════"
     exit 1
 fi

--- a/tests/test_channel_routing_safety.py
+++ b/tests/test_channel_routing_safety.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""can_handle() must reject lookalike / spoofed hosts.
+
+Every credentialed channel routes on its platform host. A lookalike host such
+as ``x.com.evil.test`` or a userinfo spoof ``x.com@evil.test`` must NOT be
+claimed by the platform channel — otherwise the channel would attach the
+user's auth cookies to an attacker-controlled request.
+"""
+
+import pytest
+
+from agent_reach.channels.bilibili import BilibiliChannel
+from agent_reach.channels.github import GitHubChannel
+from agent_reach.channels.linkedin import LinkedInChannel
+from agent_reach.channels.reddit import RedditChannel
+from agent_reach.channels.twitter import TwitterChannel
+from agent_reach.channels.v2ex import V2EXChannel
+from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
+from agent_reach.channels.xiaoyuzhou import XiaoyuzhouChannel
+from agent_reach.channels.xueqiu import XueqiuChannel
+from agent_reach.channels.youtube import YouTubeChannel
+
+# (channel factory, an accepted URL, its host used for the lookalike)
+CASES = [
+    (TwitterChannel, "https://x.com/jack", "x.com"),
+    (TwitterChannel, "https://twitter.com/jack", "twitter.com"),
+    (YouTubeChannel, "https://www.youtube.com/watch?v=x", "youtube.com"),
+    (RedditChannel, "https://www.reddit.com/r/python/", "reddit.com"),
+    (BilibiliChannel, "https://www.bilibili.com/video/BV1", "bilibili.com"),
+    (LinkedInChannel, "https://www.linkedin.com/in/x", "linkedin.com"),
+    (XiaoHongShuChannel, "https://www.xiaohongshu.com/explore/x", "xiaohongshu.com"),
+    (XueqiuChannel, "https://xueqiu.com/S/SH600519", "xueqiu.com"),
+    (GitHubChannel, "https://github.com/user/repo", "github.com"),
+    (V2EXChannel, "https://www.v2ex.com/t/1", "v2ex.com"),
+    (XiaoyuzhouChannel, "https://www.xiaoyuzhoufm.com/episode/x", "xiaoyuzhoufm.com"),
+]
+
+
+@pytest.mark.parametrize("factory,good_url,host", CASES)
+def test_accepts_legit_host(factory, good_url, host):
+    assert factory().can_handle(good_url)
+
+
+@pytest.mark.parametrize("factory,good_url,host", CASES)
+def test_rejects_suffix_lookalike(factory, good_url, host):
+    assert not factory().can_handle(f"https://{host}.evil.test/foo")
+
+
+@pytest.mark.parametrize("factory,good_url,host", CASES)
+def test_rejects_prefix_lookalike(factory, good_url, host):
+    assert not factory().can_handle(f"https://not{host}/foo")
+
+
+@pytest.mark.parametrize("factory,good_url,host", CASES)
+def test_rejects_userinfo_spoof(factory, good_url, host):
+    assert not factory().can_handle(f"https://{host}@evil.test/foo")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,30 +36,20 @@ class TestCLI:
         assert "Agent Reach" in captured.out
         assert "✅" in captured.out
 
-    def test_doctor_preserves_existing_skill_install(self, monkeypatch, tmp_path, capsys):
-        skill_dir = tmp_path / ".agents" / "skills" / "agent-reach"
-        skill_dir.mkdir(parents=True)
-        skill_file = skill_dir / "SKILL.md"
-        custom_content = "# custom Agent Reach skill\n"
-        skill_file.write_text(custom_content, encoding="utf-8")
+    def test_doctor_is_read_only_no_skill_install(self, monkeypatch, capsys):
+        """doctor is read-only diagnostics: it must never install the skill."""
+        called = {"install": False}
 
-        monkeypatch.setattr(
-            cli.os.path,
-            "expanduser",
-            lambda p: p.replace("~", str(tmp_path)),
-        )
-        config_dir = tmp_path / ".agent-reach"
-        monkeypatch.setattr(Config, "CONFIG_DIR", config_dir)
-        monkeypatch.setattr(Config, "CONFIG_FILE", config_dir / "config.yaml")
+        def _spy(*a, **k):
+            called["install"] = True
+
+        monkeypatch.setattr(cli, "_install_skill", _spy)
         monkeypatch.setattr("agent_reach.doctor.check_all", lambda config: {})
         monkeypatch.setattr("agent_reach.doctor.format_report", lambda results: "report")
 
         cli._cmd_doctor(Namespace(json=False))
 
-        assert skill_file.read_text(encoding="utf-8") == custom_content
-        out = capsys.readouterr().out
-        assert "preserving existing files" in out
-        assert f"Skill installed for Agent: {skill_dir}" not in out
+        assert called["install"] is False
 
     def test_transcribe_command_prints_text(self, capsys):
         with patch("agent_reach.transcribe.transcribe", return_value="hello transcript"):
@@ -75,6 +65,62 @@ class TestCLI:
                 main()
         assert out_file.read_text(encoding="utf-8").strip() == "saved text"
         assert "Transcript written" in capsys.readouterr().out
+
+    def test_configure_from_browser_without_channels_imports_all(self, monkeypatch, capsys):
+        """Softer landing: omitting --channels keeps the original import-all flow,
+        so existing `configure --from-browser chrome` invocations don't break."""
+        captured = {}
+
+        def _spy(browser, config, config_keys):
+            captured["targets"] = set(config_keys)
+            return [("Twitter/X", True, "auth_token + ct0")]
+
+        monkeypatch.setattr("agent_reach.cookie_extract.configure_from_browser", _spy)
+        cli._cmd_configure(
+            Namespace(from_browser="chrome", channels="", key=None, value=[])
+        )
+        assert captured["targets"] == {"twitter", "xhs", "bilibili", "xueqiu"}
+
+    def test_configure_from_browser_scopes_to_requested_channels(self, monkeypatch, capsys):
+        """--channels twitter must pass only {'twitter'} targets to the importer."""
+        captured = {}
+
+        def _spy(browser, config, config_keys):
+            captured["browser"] = browser
+            captured["targets"] = set(config_keys)
+            return [("Twitter/X", True, "auth_token + ct0")]
+
+        monkeypatch.setattr("agent_reach.cookie_extract.configure_from_browser", _spy)
+        cli._cmd_configure(
+            Namespace(from_browser="chrome", channels="twitter", key=None, value=[])
+        )
+        assert captured["targets"] == {"twitter"}
+        assert captured["browser"] == "chrome"
+
+    def test_install_mcporter_pins_exa_add_to_home_scope(self, monkeypatch):
+        """config add must target home scope so Exa persists for the agent,
+        not the cwd's project config. config list must NOT get --scope
+        (mcporter's config list does not support that flag)."""
+        calls = []
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        cli._install_mcporter()
+
+        add_cmds = [c for c in calls if "config" in c and "add" in c]
+        assert add_cmds, "expected a 'mcporter config add' call"
+        for c in add_cmds:
+            assert "--scope" in c and c[c.index("--scope") + 1] == "home"
+
+        list_cmds = [c for c in calls if c[:3] == ["mcporter", "config", "list"]]
+        assert list_cmds, "expected a 'mcporter config list' call"
+        for c in list_cmds:
+            assert "--scope" not in c
 
     def test_parse_twitter_cookie_input_separate_values(self):
         auth_token, ct0 = cli._parse_twitter_cookie_input("token123 ct0abc")

--- a/tests/test_cookie_extract_scope.py
+++ b/tests/test_cookie_extract_scope.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Browser cookie import must be scoped to the requested channels.
+
+Regression for cookie overcollection: `configure --from-browser` (and the
+install-time auto-import) previously harvested and persisted cookies for
+EVERY supported platform regardless of which channels the user asked for.
+Importing --channels twitter must not read or save XHS/Bilibili/Xueqiu
+cookies.
+"""
+
+import sys
+import types
+
+import pytest
+
+import agent_reach.cookie_extract as ce
+
+
+@pytest.fixture
+def fake_browser(monkeypatch):
+    """Inject a fake rookiepy whose chrome() returns cookies for all 4 platforms."""
+    cookies = [
+        {"name": "auth_token", "value": "TW_AUTH", "domain": ".x.com"},
+        {"name": "ct0", "value": "TW_CT0", "domain": ".x.com"},
+        {"name": "web_session", "value": "XHS_SESS", "domain": ".xiaohongshu.com"},
+        {"name": "a1", "value": "XHS_A1", "domain": ".xiaohongshu.com"},
+        {"name": "SESSDATA", "value": "BILI_SESS", "domain": ".bilibili.com"},
+        {"name": "bili_jct", "value": "BILI_JCT", "domain": ".bilibili.com"},
+        {"name": "xq_a_token", "value": "XQ_TOKEN", "domain": ".xueqiu.com"},
+    ]
+    def jar():
+        return list(cookies)
+
+    fake = types.SimpleNamespace(
+        chrome=jar, firefox=jar, edge=jar, brave=jar, opera=jar
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake)
+    # Silence best-effort file syncs so tests don't touch the real home dir.
+    monkeypatch.setattr(ce, "_sync_xfetch_session", lambda *a, **k: None)
+    monkeypatch.setattr(ce, "_sync_bird_env", lambda *a, **k: None)
+    return fake
+
+
+class FakeConfig:
+    def __init__(self):
+        self.data = {}
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+
+class TestResolveCookieTargets:
+    def test_maps_xiaohongshu_alias_to_xhs(self):
+        assert ce.resolve_cookie_targets({"xiaohongshu"}) == {"xhs"}
+
+    def test_direct_config_keys_pass_through(self):
+        assert ce.resolve_cookie_targets({"twitter", "bilibili"}) == {"twitter", "bilibili"}
+
+    def test_all_expands_to_every_cookie_platform(self):
+        assert ce.resolve_cookie_targets({"all"}) == {"twitter", "xhs", "bilibili", "xueqiu"}
+
+    def test_non_cookie_channels_are_dropped(self):
+        assert ce.resolve_cookie_targets({"twitter", "reddit", "youtube"}) == {"twitter"}
+
+    def test_empty_selection(self):
+        assert ce.resolve_cookie_targets(set()) == set()
+
+
+class TestExtractAllScope:
+    def test_only_requested_platform_extracted(self, fake_browser):
+        result = ce.extract_all("chrome", config_keys={"twitter"})
+        assert set(result) == {"twitter"}
+
+    def test_no_scope_extracts_everything(self, fake_browser):
+        result = ce.extract_all("chrome")
+        assert {"twitter", "xhs", "bilibili", "xueqiu"} <= set(result)
+
+    def test_lookalike_cookie_domain_not_swept_in(self, monkeypatch):
+        """A cookie from a lookalike host (notxueqiu.com) must not be pulled
+        into the Xueqiu cookie string."""
+        cookies = [
+            {"name": "xq_a_token", "value": "REAL", "domain": ".xueqiu.com"},
+            {"name": "session", "value": "SUB", "domain": "stock.xueqiu.com"},
+            {"name": "evil", "value": "ATTACKER", "domain": "notxueqiu.com"},
+        ]
+        fake = types.SimpleNamespace(
+            chrome=lambda: list(cookies), firefox=lambda: list(cookies),
+            edge=lambda: list(cookies), brave=lambda: list(cookies),
+            opera=lambda: list(cookies),
+        )
+        monkeypatch.setitem(sys.modules, "rookiepy", fake)
+        result = ce.extract_all("chrome", config_keys={"xueqiu"})
+        cookie_str = result["xueqiu"]["cookie_string"]
+        assert "xq_a_token=REAL" in cookie_str
+        assert "session=SUB" in cookie_str  # real subdomain kept
+        assert "evil" not in cookie_str     # lookalike rejected
+
+
+class TestConfigureFromBrowserScope:
+    def test_twitter_only_does_not_save_other_platforms(self, fake_browser):
+        cfg = FakeConfig()
+        ce.configure_from_browser("chrome", cfg, {"twitter"})
+        assert cfg.data.get("twitter_auth_token") == "TW_AUTH"
+        assert cfg.data.get("twitter_ct0") == "TW_CT0"
+        # Overcollection guard: nothing else may be persisted.
+        assert "xhs_cookie" not in cfg.data
+        assert "bilibili_sessdata" not in cfg.data
+        assert "xueqiu_cookie" not in cfg.data
+
+    def test_empty_targets_saves_nothing(self, fake_browser):
+        cfg = FakeConfig()
+        ce.configure_from_browser("chrome", cfg, set())
+        assert cfg.data == {}

--- a/tests/test_url_host.py
+++ b/tests/test_url_host.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Tests for the shared host_matches() URL-safety helper.
+
+can_handle() routing must not be fooled by lookalike domains. A substring
+check (`"x.com" in netloc`) matches attacker-controlled hosts like
+`notx.com`, `x.com.evil.test`, or `x.com@evil.test`, which would cause a
+credentialed channel to attach the user's auth cookies to an attacker URL.
+host_matches() must accept only the exact host or a real subdomain.
+"""
+
+from agent_reach.utils.urls import domain_covers, host_matches
+
+
+class TestHostMatchesAccepts:
+    def test_exact_host(self):
+        assert host_matches("https://x.com/foo", "x.com")
+
+    def test_www_subdomain(self):
+        assert host_matches("https://www.x.com/foo", "x.com")
+
+    def test_deep_subdomain(self):
+        assert host_matches("https://a.b.youtube.com/watch", "youtube.com")
+
+    def test_mobile_subdomain(self):
+        assert host_matches("https://mobile.twitter.com/user", "twitter.com")
+
+    def test_case_insensitive(self):
+        assert host_matches("HTTPS://X.COM/Foo", "x.com")
+
+    def test_port_is_stripped(self):
+        assert host_matches("https://x.com:443/foo", "x.com")
+
+    def test_trailing_dot_fqdn(self):
+        assert host_matches("https://x.com./foo", "x.com")
+
+    def test_any_of_multiple_allowed_hosts(self):
+        assert host_matches("https://youtu.be/abc", "youtube.com", "youtu.be")
+
+
+class TestHostMatchesRejects:
+    def test_prefix_lookalike(self):
+        assert not host_matches("https://notx.com/foo", "x.com")
+
+    def test_suffix_lookalike(self):
+        assert not host_matches("https://x.com.evil.test/foo", "x.com")
+
+    def test_userinfo_spoof(self):
+        # Real host is evil.test; x.com is only the userinfo part.
+        assert not host_matches("https://x.com@evil.test/foo", "x.com")
+
+    def test_userinfo_and_port_spoof(self):
+        assert not host_matches("https://x.com:443@evil.test/foo", "x.com")
+
+    def test_host_only_in_path(self):
+        assert not host_matches("https://evil.test/x.com", "x.com")
+
+    def test_unrelated_host(self):
+        assert not host_matches("https://github.com/user/repo", "x.com", "twitter.com")
+
+    def test_empty_url(self):
+        assert not host_matches("", "x.com")
+
+    def test_no_host(self):
+        assert not host_matches("not a url", "x.com")
+
+    def test_substring_of_allowed(self):
+        # allowed host longer than the actual host must not match
+        assert not host_matches("https://com/foo", "x.com")
+
+
+class TestDomainCovers:
+    """Bare host/cookie-domain matcher — no URL parsing, handles leading dots."""
+
+    def test_exact(self):
+        assert domain_covers("xueqiu.com", "xueqiu.com")
+
+    def test_leading_dot_cookie_domain(self):
+        assert domain_covers(".xueqiu.com", "xueqiu.com")
+
+    def test_subdomain(self):
+        assert domain_covers("stock.xueqiu.com", ".xueqiu.com")
+
+    def test_prefix_lookalike_rejected(self):
+        assert not domain_covers("notxueqiu.com", "xueqiu.com")
+        assert not domain_covers("evilxueqiu.com", ".xueqiu.com")
+
+    def test_suffix_lookalike_rejected(self):
+        assert not domain_covers("xueqiu.com.evil.test", "xueqiu.com")
+
+    def test_empty(self):
+        assert not domain_covers("", "xueqiu.com")
+
+    def test_any_of_multiple(self):
+        assert domain_covers(".x.com", "twitter.com", "x.com")


### PR DESCRIPTION
## Summary

Hardens local credential handling and channel routing, plus a few reliability fixes. All changes include regression tests; the full suite passes (277).

> ⚠️ **On disclosure:** this includes security fixes. SECURITY.md points to GitHub's private "Report a vulnerability" form, but private vulnerability reporting is currently disabled on this repo and no other contact is listed, so I couldn't report privately first. You may want to enable private vulnerability reporting for the future. Descriptions below are kept factual rather than a step-by-step exploit.

### Security

- **Host-based channel routing.** `can_handle()` matched platforms with a substring check (e.g. `"x.com" in netloc`), so lookalike/spoofed hosts (`notx.com`, `x.com.evil.test`, `https://x.com@evil.test/`) were accepted. A credentialed channel could then attach the user's auth cookies to an attacker-controlled host. Now uses exact-host / real-subdomain matching via a new `host_matches()` / `domain_covers()` helper (`agent_reach/utils/urls.py`); all channels updated.
- **Scoped cookie import (#446).** `install --channels twitter` (and browser auto-import) harvested and saved cookies for *all* platforms regardless of what was requested. Import is now scoped to the requested `--channels`. `configure --from-browser` keeps its documented import-all default, now transparent and scopable via `--channels`.
- **Xueqiu cookie-domain matching.** Cookie matching used `domain.endswith("xueqiu.com")`, so `notxueqiu.com` / `evilxueqiu.com` cookies were swept into the saved Xueqiu cookie string. Now exact-or-subdomain (`domain_covers`).

### Reliability

- **`doctor` is now read-only** — it no longer installs the agent skill as a side effect (that stays in `install` / `skill --install`).
- **`mcporter config add exa` pinned to `--scope home`** so Exa config persists regardless of cwd. `config list` is left unchanged — it has no `--scope` flag; passing one silently returns no results (verified against mcporter 0.12.3).
- **`test.sh` rewritten** as an install smoke test (fresh venv + local install + `version`/`doctor`), replacing calls to `read`/`search` subcommands that no longer exist.

### Tests

- New: `tests/test_url_host.py`, `tests/test_channel_routing_safety.py`, `tests/test_cookie_extract_scope.py`, plus CLI tests for the doctor / mcporter / configure changes.
- `pytest tests/ -v` → **277 passed**.

Version bump intentionally omitted — left for the maintainer to cut a release; changelog entries are under `[Unreleased]`.

