### PR TITLE
fix(opencli): diagnose OPENCLI_DAEMON_PORT conflict instead of blaming node

### DIFF
--- a/agent_reach/backends/opencli.py
+++ b/agent_reach/backends/opencli.py
@@ -28,6 +28,19 @@ OPENCLI_EXTENSION_URL = (
     f"https://chromewebstore.google.com/detail/opencli/{OPENCLI_EXTENSION_ID}"
 )
 
+#: Deprecated env var. Newer opencli (>=1.8) hard-exits (EX_CONFIG / 78) the
+#: moment OPENCLI_DAEMON_PORT is set — even to the correct default port — and
+#: the guard runs before `--version`, so every probe fails. The OpenCLIApp
+#: desktop build still injects it, so a fresh macOS app install is DOA until
+#: the var is unset. Detect this so we prescribe `unset` instead of a useless
+#: "reinstall node" — nothing is actually broken.
+_DAEMON_PORT_ENV = "OPENCLI_DAEMON_PORT"
+
+
+def _is_daemon_port_conflict(probe) -> bool:
+    """True when a failed probe was rejected for the deprecated port env var."""
+    return _DAEMON_PORT_ENV in (probe.output or "")
+
 #: Chrome-family profile roots that contain <Profile>/Extensions/<id>/
 _CHROME_PROFILE_ROOTS = (
     "~/Library/Application Support/Google/Chrome",  # macOS Chrome
@@ -59,6 +72,7 @@ def _extension_installed_on_disk() -> bool:
 class OpenCLIStatus:
     installed: bool = False
     broken: bool = False
+    env_conflict: bool = False
     daemon_running: bool = False
     extension_connected: bool = False
     extension_installed: bool = False
@@ -84,6 +98,18 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
     )
     if version_probe.status == "missing":
         return OpenCLIStatus(installed=False)
+    if _is_daemon_port_conflict(version_probe):
+        return OpenCLIStatus(
+            installed=True,
+            broken=True,
+            env_conflict=True,
+            hint=(
+                f"opencli 已安装，但环境变量 {_DAEMON_PORT_ENV} 已被设置，"
+                "新版 opencli 会直接拒绝启动（常见于旧版 OpenCLIApp 桌面端注入）。\n"
+                f"  取消设置后即可使用：unset {_DAEMON_PORT_ENV}\n"
+                "  （node 环境正常，无需重装）"
+            ),
+        )
     if not version_probe.ok:
         return OpenCLIStatus(
             installed=True,
@@ -125,6 +151,8 @@ def opencli_summary(st: OpenCLIStatus) -> str:
     """One-line state description for channel messages / install output."""
     if not st.installed:
         return "OpenCLI 未安装"
+    if st.env_conflict:
+        return f"OpenCLI 无法启动（{_DAEMON_PORT_ENV} 环境变量冲突，需 unset）"
     if st.broken:
         return "OpenCLI 无法执行（node 环境损坏）"
     if st.extension_connected:

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -39,6 +39,23 @@ def test_broken_node_env_gives_npm_hint():
     assert not st.ready
 
 
+def test_daemon_port_env_conflict_gives_unset_hint():
+    """opencli >=1.8 hard-exits (EX_CONFIG/78) when OPENCLI_DAEMON_PORT is set —
+    even before `--version` — so probing fails. It must be diagnosed as an env
+    conflict (unset the var), NOT as a broken node install (reinstall)."""
+    rejection = (
+        "error: OPENCLI_DAEMON_PORT is no longer supported (received 19825). "
+        "The OpenCLI Chrome extension can only connect to localhost:19825. "
+        "Unset OPENCLI_DAEMON_PORT and rerun opencli."
+    )
+    st, _ = _status_with(ProbeResult("error", output=rejection))
+    assert st.installed and st.broken and st.env_conflict
+    assert "unset OPENCLI_DAEMON_PORT" in st.hint
+    assert "npm install" not in st.hint  # must not misprescribe a reinstall
+    assert not st.ready
+    assert "OPENCLI_DAEMON_PORT" in opencli_summary(st)
+
+
 def test_daemon_running_extension_connected_is_ready():
     daemon_out = "Daemon: running (PID 37389)\nVersion: v1.8.3\nExtension: connected\n"
     st, _ = _status_with(


### PR DESCRIPTION
## Problem

On machines with the **OpenCLIApp** desktop build, every OpenCLI-backed channel (Reddit / Facebook / Instagram / XiaoHongShu / Bilibili) is reported as broken with a misleading fix:

> `opencli 命令存在但无法执行（node 环境损坏），重装：npm install -g @jackwener/opencli`

The node environment is **fine**. The real cause: `opencli >=1.8` hard-exits with `EX_CONFIG` (78) the moment `OPENCLI_DAEMON_PORT` is set — *even to the correct default port* — and the guard runs *before* `--version`, so every probe (including `--version`) fails. The OpenCLIApp desktop build still injects `OPENCLI_DAEMON_PORT=19825` into the CLI's environment, so a fresh macOS app install is effectively dead-on-arrival, and `npm install` does nothing to fix it.

## Fix

Detect the rejection from the probe output and prescribe the actual remedy (`unset OPENCLI_DAEMON_PORT`), noting node is fine — instead of a useless reinstall.

- Adds `env_conflict` to `OpenCLIStatus` + a dedicated `opencli_summary` line
- Correct, actionable hint (`unset OPENCLI_DAEMON_PORT`) rather than "reinstall node"
- Regression test; full suite green (197 passed)

## Verification

Reproduced live against the real OpenCLIApp shim: exit code `78`, output contains `OPENCLI_DAEMON_PORT is no longer supported (received 19825)`. The patched probe now returns `env_conflict=True` and the summary/hint direct the user to `unset OPENCLI_DAEMON_PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)