### PR TITLE
fix(windows): use correct yt-dlp config path and resolve .CMD shims i…

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -634,8 +634,15 @@ def _install_system_deps():
 
     # ── yt-dlp JS runtime config (YouTube requires external JS runtime) ──
     if shutil.which("node"):
-        ytdlp_config_dir = os.path.expanduser("~/.config/yt-dlp")
-        ytdlp_config = os.path.join(ytdlp_config_dir, "config")
+        # Use the cross-platform helper so the config lands where yt-dlp
+        # actually reads it on every OS. The previous hardcoded
+        # ~/.config/yt-dlp path is Linux-only; on Windows yt-dlp reads
+        # %APPDATA%/yt-dlp/config, so install wrote to a location yt-dlp
+        # never consults and doctor (which uses this helper) reported the
+        # runtime as unconfigured. See utils/paths.get_ytdlp_config_path.
+        from agent_reach.utils.paths import get_ytdlp_config_path
+        ytdlp_config = str(get_ytdlp_config_path())
+        ytdlp_config_dir = os.path.dirname(ytdlp_config)
         needs_config = True
         if os.path.exists(ytdlp_config):
             with open(ytdlp_config, "r") as f:
@@ -918,20 +925,33 @@ def _install_mcporter():
 
     print("Setting up mcporter (search backend)...")
 
-    if shutil.which("mcporter"):
+    # Resolve command short names to their full path before subprocess.run.
+    # On Windows, npm/mcporter/npx are .CMD/.BAT shims; CreateProcess does
+    # not append PATHEXT, so subprocess.run(["npm", ...]) raises
+    # FileNotFoundError (WinError 2) even though shutil.which("npm") finds
+    # it. which() returns the path with the real extension, so executing
+    # that path directly works on every platform. Mirrors probe_command.
+    def _which(cmd):
+        return shutil.which(cmd)
+
+    npm_path = _which("npm") or _which("npx")
+    mcporter_path = _which("mcporter")
+
+    if mcporter_path:
         print("  ✅ mcporter already installed")
     else:
         # Check for npm/npx
-        if not shutil.which("npm") and not shutil.which("npx"):
+        if not npm_path:
             print("  [!]  mcporter requires Node.js. Install Node.js first:")
             print("     https://nodejs.org/ or: curl -fsSL https://fnm.vercel.app/install | bash")
             return
         try:
             subprocess.run(
-                ["npm", "install", "-g", "mcporter"],
+                [npm_path, "install", "-g", "mcporter"],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=120,
             )
-            if shutil.which("mcporter"):
+            mcporter_path = _which("mcporter")
+            if mcporter_path:
                 print("  ✅ mcporter installed")
             else:
                 print("  [X] mcporter install failed. Retry: npm install -g mcporter (check network/timeout), or try: npx mcporter@latest list")
@@ -943,11 +963,11 @@ def _install_mcporter():
     # Configure Exa MCP (free, no key needed)
     try:
         r = subprocess.run(
-            ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
+            [mcporter_path, "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
         )
         if "exa" not in r.stdout:
             subprocess.run(
-                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                [mcporter_path, "config", "add", "exa", "https://mcp.exa.ai/mcp"],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             print("  ✅ Exa search configured (free, no API key needed)")


### PR DESCRIPTION
1. **yt-dlp config written to wrong path.** `_install_system_deps` writes `--js-runtimes node` to
  `~/.config/yt-dlp/config` (a Linux path). On Windows yt-dlp reads `%APPDATA%/yt-dlp/config`, so the config is never
  applied. Result: `install` prints " yt-dlp configured" but `doctor` reports YouTube as `[!] 未配置 JS runtime` —
  they contradict because `doctor` already uses the cross-platform `get_ytdlp_config_path()` helper while `install`
  hardcodes the Linux path.

  2. **mcporter install fails with WinError 2.** `_install_mcporter` calls `subprocess.run(["npm", ...])` with a bare
  command name. On Windows `npm`/`mcporter`/`npx` are `.CMD` shims, and `CreateProcess` does not append PATHEXT, so this
  raises `FileNotFoundError` (WinError 2) even though `shutil.which("npm")` finds it.

  ## Fix

  Both reuse patterns that already exist elsewhere in the codebase:

  1. Call the existing `agent_reach.utils.paths.get_ytdlp_config_path()` instead of hardcoding `~/.config/yt-dlp` — the
  same helper `doctor`/`youtube.py` already use.

  2. Resolve command names via `shutil.which()` before `subprocess.run()`, mirroring `probe.py:probe_command()` and the
  existing undici install path (`npm_cmd = shutil.which("npm")`).

  ## Verification

  Tested on Windows 11 with Anaconda Python 3.11.7 + venv install:

  - After fix, `install` writes `--js-runtimes node` to `%APPDATA%/yt-dlp/config` (verified the file is created there
  and `~/.config/yt-dlp/config` is no longer touched).
  - `doctor` now reports ` YouTube 视频和字幕 — 可提取视频信息和字幕` (install and doctor agree).
  - `subprocess.run([shutil.which("npm"), "--version"])` succeeds (returns `11.13.0`); the bare `["npm", ...]` form
  raises `FileNotFoundError: WinError 2`. Same for `mcporter`.

  Change scope: `1 file changed, 28 insertions(+), 8 deletions(-)` — `agent_reach/cli.py` only.

  ## Notes

  - Did not touch the `_install_system_deps` Windows branch for `gh` (separate issue — gh CLI auto-install has no
  Windows path, only linux/darwin). Happy to send a follow-up PR if welcome.