### PR TITLE
feat: add Zhihu (知乎) platform support via OpenCLI

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
+  Instagram, V2EX, 知乎/Zhihu, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
   雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,7 +18,7 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/知乎/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -28,6 +28,7 @@ triggers:
     - B站: bilibili/b站/哔哩哔哩
     - V2EX: v2ex
     - Reddit: reddit
+    - 知乎: zhihu/知乎
     - Facebook: facebook/fb/facebook groups
     - Instagram: instagram/ig
   - career: 招聘/职位/求职/linkedin/领英/找工作
@@ -42,11 +43,11 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
-1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram）先跑
+1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/知乎/Facebook/Instagram）先跑
    `agent-reach doctor --json`，按各平台 `active_backend` 字段选命令组。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
@@ -62,7 +63,7 @@ metadata:
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
-| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
+| 小红书/推特/B站/V2EX/Reddit/知乎/Facebook/Instagram | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
@@ -93,6 +94,18 @@ bili search "query" --type video -n 5
 ## 需登录态的平台（按 doctor 的 active_backend 选命令）
 
 ```bash
+# 知乎热榜（无需登录）
+opencli zhihu hot --limit 10 -f yaml
+
+# 知乎搜索（需 Chrome 登录态，复用浏览器登录）
+opencli zhihu search "query" --limit 10 -f yaml
+
+# 知乎问题详情
+opencli zhihu question QUESTION_ID -f yaml
+
+# 知乎回答详情
+opencli zhihu answer-comments ANSWER_ID -f yaml
+
 # Twitter 搜索（twitter-cli 首选；失败重试链见 social.md）
 twitter search "query" -n 10
 
@@ -126,7 +139,7 @@ agent-reach doctor --json
 根据用户需求，阅读对应的详细文档：
 
 - [搜索工具](references/search.md) — Exa AI 搜索
-- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
+- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, 知乎, Facebook, Instagram（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -7,9 +7,9 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/link:
   Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
-  Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
+  Zhihu, Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -23,13 +23,13 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
 
 1. **Health-check before acting**: for multi-backend/login-backed platforms (XiaoHongShu /
-   Reddit / Bilibili / Twitter / Facebook / Instagram), run `agent-reach doctor --json` first and
+   Reddit / Bilibili / Twitter / Zhihu / Facebook / Instagram), run `agent-reach doctor --json` first and
    pick the command group matching each platform's `active_backend`.
 2. **Announce what you use**: say "using agent-reach, platform X via backend Y"
    before starting.
@@ -50,7 +50,7 @@ these platforms — do not invent your own approach.**
 | User intent | Category | Details |
 |---------|------|---------|
 | Web / code search | search | [references/search.md](references/search.md) |
-| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
+| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Zhihu / Facebook / Instagram | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
@@ -81,6 +81,18 @@ bili search "query" --type video -n 5
 ## Login-backed platforms (pick by doctor's active_backend)
 
 ```bash
+# Zhihu hot list (no login required)
+opencli zhihu hot --limit 10 -f yaml
+
+# Zhihu search (requires Chrome logged into zhihu.com)
+opencli zhihu search "query" --limit 10 -f yaml
+
+# Zhihu question details
+opencli zhihu question QUESTION_ID -f yaml
+
+# Zhihu answer comments
+opencli zhihu answer-comments ANSWER_ID -f yaml
+
 # Twitter search (twitter-cli preferred; retry chain in social.md)
 twitter search "query" -n 10
 
@@ -117,7 +129,7 @@ common cases; references hold per-backend command groups, caveats, retry
 chains — note: reference docs are written in Chinese, commands are universal):
 
 - [Search](references/search.md) — Exa AI search
-- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)
+- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Zhihu, Facebook, Instagram (multi-backend/login-backed groups)
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -1,6 +1,6 @@
 # 社交媒体 & 社区
 
-小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram。
+小红书、Twitter/X、B站、V2EX、Reddit、知乎、Facebook、Instagram。
 
 ## 小红书 / XiaoHongShu（多后端）
 
@@ -273,3 +273,72 @@ opencli instagram saved --limit 20 -f yaml
 ```
 
 > 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 instagram.com。`instagram search` 是用户搜索；读帖子需要先确定 username，再用 `instagram user USERNAME`。若出现 429 / login required，先让用户在 Chrome 里重新登录并降低频率。
+
+## 知乎 / Zhihu (OpenCLI)
+
+知乎通过 OpenCLI 使用 Chrome 浏览器登录态访问。
+
+### 前置条件
+
+> **桌面推荐**: 安装 OpenCLI（`npm install -g @jackwener/opencli`）和 Chrome 扩展
+> （https://chromewebstore.google.com/detail/opencli/ildkmabpimmkaediidaifkhjpohdnifk）。
+
+### 只读命令（热榜无需登录，搜索需登录）
+
+```bash
+# 知乎热榜（无需登录）
+opencli zhihu hot --limit 10 -f yaml
+
+# 知乎搜索（需 Chrome 已登录 zhihu.com）
+opencli zhihu search "query" --limit 10 -f yaml
+
+# 知乎问题详情（含回答列表）
+opencli zhihu question QUESTION_ID -f yaml
+
+# 知乎回答完整内容
+opencli zhihu answer-detail ANSWER_ID -f yaml
+
+# 知乎回答评论列表
+opencli zhihu answer-comments ANSWER_ID -f yaml
+
+# 知乎首页推荐（需登录）
+opencli zhihu recommend -f yaml
+
+# 知乎收藏夹列表（需登录）
+opencli zhihu collections -f yaml
+
+# 知乎收藏夹内容（需登录）
+opencli zhihu collection COLLECTION_ID --limit 10 -f yaml
+
+# 导出知乎文章为 Markdown
+opencli zhihu download -f yaml
+```
+
+### 写操作（需登录，谨慎使用）
+
+```bash
+# 点赞回答/文章
+opencli zhihu like ANSWER_URL
+
+# 收藏回答/文章
+opencli zhihu favorite ANSWER_URL
+
+# 关注用户/问题
+opencli zhihu follow TARGET_URL
+
+# 发表评论
+opencli zhihu comment ANSWER_URL --text "评论内容"
+
+# 回答问题
+opencli zhihu answer QUESTION_URL --text "回答内容"
+```
+
+### 注意事项
+
+> **认证**: 知乎 `search`、`recommend`、个人收藏夹等需要 Chrome 已登录 zhihu.com。热榜 `hot` 无需登录即可使用。
+>
+> **search 失败时**: 确认 Chrome 已登录知乎，重试。如果仍然 `AUTH_REQUIRED`，在 Chrome 里重新打开 zhihu.com 登录一次。
+>
+> **频率控制**: 写操作（点赞/评论/回答/关注）会触发风控，间隔至少 3-5 秒。建议只读为主，写操作用户手动确认后再执行。
+>
+> **输出格式**: 建议用 `-f yaml` 或 `-f json` 获得结构化输出，对 AI agent 更友好。


### PR DESCRIPTION
## Summary

Add Zhihu (知乎) to agent-reach's supported platforms, leveraging OpenCLI's built-in zhihu adapter.

## What works

- `opencli zhihu hot` — hot list, **no login required** (verified working)
- `opencli zhihu search query` — search, requires Chrome logged into zhihu.com
- `opencli zhihu question <id>` — question details with answers
- `opencli zhihu answer-detail <id>` — full answer content
- `opencli zhihu answer-comments <id>` — answer comments

## Changes

| File | Changes |
|------|---------|
| `agent_reach/skill/SKILL.md` | Add Zhihu to platform list (15→16), triggers, routing table, quick commands, references |
| `agent_reach/skill/SKILL_en.md` | Same additions in English |
| `agent_reach/skill/references/social.md` | Full Zhihu command reference with read/write ops, auth notes, rate limiting guidance |

## Verification

```bash
opencli zhihu hot --limit 3 -f yaml
# Returns hot list with rank, title, heat, answers, url — works without login

opencli zhihu search 大模型 --limit 3 -f yaml
# Returns AUTH_REQUIRED (77) — requires zhihu.com login in Chrome, as documented
```

All changes are documentation-only (skill routing), no code changes. The underlying `opencli zhihu` adapter is already built and shipped in OpenCLI.