### PR TITLE
Add Xquik as an optional Twitter read backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@
 
 # OpenAI Whisper (optional fallback when Groq is rate-limited) — https://platform.openai.com
 # OPENAI_API_KEY=sk-your_key_here
+
+# Xquik API (optional Twitter/X read backend): https://docs.xquik.com
+# XQUIK_API_KEY=xq_your_key_here

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 ```
 channels/
 ├── web.py          → Jina Reader
-├── twitter.py      → twitter-cli ▸ OpenCLI ▸ bird
+├── twitter.py      → twitter-cli ▸ OpenCLI ▸ Xquik API（可选）▸ bird
 ├── youtube.py      → yt-dlp
 ├── github.py       → gh CLI
 ├── bilibili.py     → bili-cli ▸ OpenCLI ▸ 搜索 API（yt-dlp 已被 B站风控封死，退役）

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Twitter/X — check if twitter-cli or bird CLI is available."""
+"""Twitter/X: inspect configured read backends without triggering cookie access."""
 
 import os
 import shutil
@@ -34,7 +34,7 @@ def twitter_cli_child_env(config=None) -> dict[str, str]:
 class TwitterChannel(Channel):
     name = "twitter"
     description = "Twitter/X 推文"
-    backends = ["twitter-cli", "OpenCLI", "bird CLI (legacy)"]
+    backends = ["twitter-cli", "OpenCLI", "Xquik API", "bird CLI (legacy)"]
     tier = 1
 
     def can_handle(self, url: str) -> bool:
@@ -55,6 +55,8 @@ class TwitterChannel(Channel):
                 result = self._check_twitter_cli(config)
             elif backend == "OpenCLI":
                 result = self._check_opencli()
+            elif backend == "Xquik API":
+                result = self._check_xquik_api(config)
             elif backend == "bird CLI (legacy)":
                 result = self._check_bird()
             else:
@@ -78,6 +80,17 @@ class TwitterChannel(Channel):
             "  pipx install twitter-cli\n"
             "或：\n"
             "  uv tool install twitter-cli"
+        )
+
+    def _check_xquik_api(self, config=None):
+        """Report explicit Xquik configuration without sending the API key."""
+        key = config.get("xquik_api_key") if config else None
+        key = key or os.environ.get("XQUIK_API_KEY")
+        if not key:
+            return None
+        return "warn", (
+            "Xquik API 密钥已配置；Doctor 不会发送或验证密钥。"
+            "请按 setup-twitter.md 中的只读示例手动验证。"
         )
 
     def _check_twitter_cli(self, config=None):

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -80,7 +80,7 @@ def main():
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
     p_conf.add_argument("key", nargs="?", default=None,
-                        choices=["proxy", "github-token", "groq-key", "openai-key",
+                        choices=["proxy", "github-token", "groq-key", "openai-key", "xquik-key",
                                  "twitter-cookies", "youtube-cookies",
                                  "xhs-cookies"],
                         help="What to configure (omit if using --from-browser)")
@@ -1320,6 +1320,10 @@ def _cmd_configure(args):
     elif args.key == "openai-key":
         config.set("openai_api_key", value)
         print(f"✅ OpenAI key configured!")
+
+    elif args.key == "xquik-key":
+        config.set("xquik_api_key", value)
+        print("✅ Xquik API key configured. Doctor will not send or validate it.")
 
 
 def _cmd_transcribe(args):

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -105,6 +105,7 @@ class Config:
     FEATURE_REQUIREMENTS = {
         "exa_search": ["exa_api_key"],
         "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
+        "twitter_xquik": ["xquik_api_key"],
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],
         "github_token": ["github_token"],

--- a/agent_reach/guides/setup-twitter.md
+++ b/agent_reach/guides/setup-twitter.md
@@ -82,6 +82,85 @@ export TWITTER_CT0="你的ct0"
 twitter search "test" -n 1
 ```
 
+## Windows Cookie 解密限制
+
+Windows 上的 Chrome 127+ 和新版 Edge 使用应用绑定加密。`twitter-cli`
+的自动浏览器读取可能因此报错：
+
+```text
+Unable to get key for cookie decryption
+```
+
+关闭浏览器通常无法解决此错误。不要反复尝试自动读取。按上面的
+Cookie-Editor 流程手动导出，再在当前 PowerShell 会话中设置：
+
+```powershell
+$env:TWITTER_AUTH_TOKEN = "你的auth_token"
+$env:TWITTER_CT0 = "你的ct0"
+twitter search "test" -n 1
+```
+
+Agent Reach 不会为 Twitter 自动读取浏览器 Cookie。
+
+## 可选：Xquik API
+
+如果不想使用浏览器 Cookie，可以把 Xquik 作为只读搜索与读取后端。
+先从 [Xquik dashboard](https://dashboard.xquik.com) 创建 API key。
+
+保存到 Agent Reach 后，`doctor` 只检查配置是否存在。它不会打印、
+发送或验证密钥：
+
+```bash
+agent-reach configure xquik-key "xq_your_key"
+```
+
+Agent Reach 不包装上游调用。运行下面的命令前，仍需在当前 Shell
+显式设置 `XQUIK_API_KEY`：
+
+```bash
+export XQUIK_API_KEY="xq_your_key"
+
+# 搜索公开推文
+curl --silent --show-error --fail-with-body --max-time 30 --get \
+  "https://xquik.com/api/v1/x/tweets/search" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29" \
+  --data-urlencode "q=agent research" \
+  --data "limit=10"
+
+# 读取单条公开推文
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/tweets/TWEET_ID" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+
+# 读取用户资料
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/users/USERNAME" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+
+# 读取用户最近的推文
+curl --silent --show-error --fail-with-body --max-time 30 --get \
+  "https://xquik.com/api/v1/x/users/USERNAME/tweets" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29" \
+  --data "limit=20"
+
+# 读取 X Article
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/articles/TWEET_ID" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+```
+
+分页时，把响应中的 `next_cursor` 作为下一次请求的 `cursor` 参数。
+公开文档见 [docs.xquik.com](https://docs.xquik.com)。配额取决于账号方案。
+请在 dashboard 查看当前额度。
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
 ## 代理配置
 
 > twitter-cli 支持通过环境变量设置代理：

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -126,12 +126,63 @@ twitter likes
 3. 换 OpenCLI 备选（桌面，复用浏览器登录态）：`opencli twitter search "query" -f yaml`
 4. 都不行就改用 `twitter feed` / `twitter user-posts @somebody` 等稳定命令绕路
 
+### 可选的 Xquik 只读后端
+
+用户显式提供 `XQUIK_API_KEY` 时，可以直接调用 Xquik 搜索或读取。
+Agent Reach 没有包装层，保存到配置文件的 key 不会自动导出到 Shell。
+
+```bash
+# 搜索公开推文
+curl --silent --show-error --fail-with-body --max-time 30 --get \
+  "https://xquik.com/api/v1/x/tweets/search" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29" \
+  --data-urlencode "q=agent research" \
+  --data "limit=10"
+
+# 读取单条公开推文
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/tweets/TWEET_ID" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+
+# 读取用户资料
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/users/USERNAME" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+
+# 读取用户最近的推文
+curl --silent --show-error --fail-with-body --max-time 30 --get \
+  "https://xquik.com/api/v1/x/users/USERNAME/tweets" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29" \
+  --data "limit=20"
+
+# 读取 X Article
+curl --silent --show-error --fail-with-body --max-time 30 \
+  "https://xquik.com/api/v1/x/articles/TWEET_ID" \
+  -H "x-api-key: $XQUIK_API_KEY" \
+  -H "xquik-api-contract: 2026-04-29"
+```
+
+只使用以上公开读取端点。不要把 key 写进日志或回复。`doctor` 只确认
+key 是否存在，不会发送或验证。分页时，把 `next_cursor` 作为下一次
+请求的 `cursor` 参数。配额以 Xquik dashboard 为准。
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
 ### 重要注意事项
 
 > **安装**: `pipx install twitter-cli`（确保 v0.8.5+）
 >
 > **认证**: 只用 Cookie-Editor 手工导出，再显式设置环境变量
 > `TWITTER_AUTH_TOKEN` + `TWITTER_CT0`；不要依赖自动浏览器读取。
+>
+> **Windows**: Chrome 127+ 和新版 Edge 的应用绑定加密可能导致
+> `Unable to get key for cookie decryption`。不要重试自动读取；
+> 使用 Cookie-Editor 手工导出。
 >
 > **IP 风控**: 不要在 VPS/数据中心 IP 上频繁调用，尤其是 followers/following，有封号风险。使用住宅代理或本地环境。
 >

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -240,7 +240,7 @@ Switching access paths means reordering the list, not rewriting code. `agent-rea
 ```
 channels/
 ├── web.py          → Jina Reader
-├── twitter.py      → twitter-cli ▸ OpenCLI ▸ bird
+├── twitter.py      → twitter-cli ▸ OpenCLI ▸ Xquik API (optional) ▸ bird
 ├── youtube.py      → yt-dlp
 ├── github.py       → gh CLI
 ├── bilibili.py     → bili-cli ▸ OpenCLI ▸ search API (yt-dlp retired, 412-blocked)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,11 @@ class TestConfig:
         tmp_config.set("exa_api_key", "test-key")
         assert tmp_config.is_configured("exa_search")
 
+    def test_xquik_feature_uses_dedicated_api_key(self, tmp_config):
+        assert not tmp_config.is_configured("twitter_xquik")
+        tmp_config.set("xquik_api_key", "xq-test-key")
+        assert tmp_config.is_configured("twitter_xquik")
+
     def test_get_configured_features(self, tmp_config):
         features = tmp_config.get_configured_features()
         assert isinstance(features, dict)
@@ -87,6 +92,7 @@ class TestConfig:
             "bilibili_sessdata": "bili-session-secret",
             "bilibili_csrf": "bili-csrf-secret",
             "twitter_auth_token": "twitter-auth-secret",
+            "xquik_api_key": "xquik-api-secret",
         }
         for key, value in secrets.items():
             tmp_config.set(key, value)

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -727,6 +727,30 @@ def test_configure_missing_value_exits_one(monkeypatch, capsys):
     assert "Missing value for github-token" in capsys.readouterr().out
 
 
+def test_xquik_key_configuration_never_echoes_secret(
+    monkeypatch,
+    capsys,
+):
+    """The dedicated CLI path stores the key without printing or validating it."""
+    import agent_reach.config as config_module
+
+    config = _MemoryConfig()
+    monkeypatch.setattr(config_module, "Config", lambda: config)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-reach", "configure", "xquik-key", "xq_secret_value"],
+    )
+
+    cli.main()
+
+    output = capsys.readouterr().out
+    assert config.get("xquik_api_key") == "xq_secret_value"
+    assert "Xquik API key configured" in output
+    assert "xq_secret_value" not in output
+
+
 def test_twitter_cookie_parse_failure_exits_one(monkeypatch, capsys):
     """Malformed Twitter cookie input must not produce a successful CLI status."""
     import agent_reach.config as config_module

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -111,11 +111,54 @@ def test_bird_without_explicit_env_is_warn(monkeypatch):
 
 def test_nothing_installed_returns_install_hint():
     channel = TwitterChannel()
-    with patch("shutil.which", return_value=None):
+    with patch("shutil.which", return_value=None), patch.object(
+        TwitterChannel,
+        "_check_xquik_api",
+        return_value=None,
+    ):
         status, message = channel.check()
 
     assert status == "warn"
     assert "twitter-cli" in message
+    assert channel.active_backend is None
+
+
+def test_xquik_env_key_is_reported_without_validation(monkeypatch):
+    monkeypatch.setenv("XQUIK_API_KEY", "xq_secret_value")
+    channel = TwitterChannel()
+
+    status, message = channel._check_xquik_api()
+
+    assert status == "warn"
+    assert "不会发送或验证" in message
+    assert "xq_secret_value" not in message
+
+
+def test_xquik_config_key_is_routed_without_claiming_active_backend(
+    monkeypatch,
+):
+    monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+    config = {"xquik_api_key": "xq_configured_value"}
+    channel = TwitterChannel()
+
+    with patch.object(
+        TwitterChannel,
+        "_check_twitter_cli",
+        return_value=None,
+    ), patch.object(
+        TwitterChannel,
+        "_check_opencli",
+        return_value=None,
+    ), patch.object(
+        TwitterChannel,
+        "_check_bird",
+        return_value=None,
+    ):
+        status, message = channel.check(config)
+
+    assert status == "warn"
+    assert "Xquik API" in message
+    assert "xq_configured_value" not in message
     assert channel.active_backend is None
 
 
@@ -145,6 +188,10 @@ def test_verified_backend_result_wins_over_unverified_twitter_cli():
         TwitterChannel,
         "_check_opencli",
         return_value=("ok", "OpenCLI 可用"),
+    ), patch.object(
+        TwitterChannel,
+        "_check_xquik_api",
+        return_value=("warn", "Xquik API 未验证"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
         status, message = channel.check()
 
@@ -163,6 +210,10 @@ def test_all_warn_returns_first_warning_without_active_backend():
         TwitterChannel,
         "_check_opencli",
         return_value=("warn", "扩展未连接"),
+    ), patch.object(
+        TwitterChannel,
+        "_check_xquik_api",
+        return_value=("warn", "Xquik API 未验证"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
         status, message = channel.check()
 


### PR DESCRIPTION
## 概要

- 在当前 `main` 上重建 Xquik 的可选 Twitter/X 只读后端。
- 支持 `XQUIK_API_KEY`、`xquik_api_key` 与 `agent-reach configure xquik-key`。
- `doctor` 只报告配置存在。它不会发送、验证或打印密钥。
- 补全搜索、单条推文、用户资料、用户时间线与 X Article 示例。
- 使用 `xquik-api-contract: 2026-04-29` 与 `next_cursor` 分页。
- 保留当前 Cookie-Editor-only 安全策略和真实 `active_backend` 语义。

## 独立仓库修复

Closes #368.

Windows 上的 Chrome 127+ 与新版 Edge 使用应用绑定 Cookie 加密。自动浏览器读取可能报 `Unable to get key for cookie decryption`。文档现在说明该限制，并使用 Cookie-Editor 与当前 PowerShell 会话变量作为安全路径。

## Reviewer 问题

1. Xquik 是可选的 X 只读 API 后端。公开文档：https://docs.xquik.com。
2. 用户从 https://dashboard.xquik.com 创建 key。Agent Reach 支持环境变量或本地私有配置。
3. 配额取决于账号方案。当前额度以 dashboard 为准。本仓库不硬编码价格或额度。

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

## 架构与安全

- Agent Reach 仍然没有包装层。Agent 直接调用公开上游读取端点。
- `doctor` 不发网络请求，也不把未验证配置标记为 active。
- 没有恢复 `twitter status`、自动浏览器 Cookie 读取或 legacy 探测行为。
- Fork owner 已确认是 `kriptoburak`。

## 验证

- Python 3.10：432 passed
- Python 3.13：432 passed
- Python 3.14：432 passed
- Wheel build、内容 gate 与 clean-venv smoke install 通过
- 新增 Python 路径 Ruff 通过
- `cli.py` 的 17 个 Ruff findings 与 1 个 MyPy finding 和当前 upstream baseline 完全一致；本 PR 没有新增 finding
- `git diff --check` 通过
- 当前 upstream `main` 上只有 1 个 SSH-signed commit
