### PR TITLE
Fix Xueqiu stock quote endpoint to return pe_ttm

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -196,7 +196,7 @@ class XueqiuChannel(Channel):
           volume, amount, market_capital, turnover_rate, pe_ttm, timestamp
         """
         data = _get_json(
-            f"https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol={symbol}"
+            f"https://stock.xueqiu.com/v5/stock/quote.json?symbol={symbol}&extend=detail"
         )
         items = (data.get("data") or {}).get("items") or []
         q = (items[0].get("quote") or {}) if items else {}

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -485,13 +485,22 @@ class TestXueqiuChannel:
             def read(self):
                 return json.dumps(fake_data).encode()
 
-        monkeypatch.setattr(xueqiu_mod._opener, "open", lambda req, timeout=None: FakeResponse())
+        captured = {}
+
+        def fake_open(req, timeout=None):
+            captured["url"] = req.full_url
+            return FakeResponse()
+
+        monkeypatch.setattr(xueqiu_mod._opener, "open", fake_open)
         quote = XueqiuChannel().get_stock_quote("SH600519")
+        assert "quote.json" in captured["url"]
+        assert "extend=detail" in captured["url"]
         assert quote["symbol"] == "SH600519"
         assert quote["name"] == "贵州茅台"
         assert quote["current"] == 1800.0
         assert quote["percent"] == 1.5
         assert quote["volume"] == 12345678
+        assert quote["pe_ttm"] == 30.5
 
     # ------------------------------------------------------------------ #
     # search_stock


### PR DESCRIPTION
## Summary

This PR fixes the Xueqiu stock quote endpoint so that `pe_ttm` and other valuation fields are returned correctly.

## Changes

- Switched from the batch quote endpoint to the detail quote endpoint:
  - `batch/quote.json`
  - → `quote.json?extend=detail`
- Updated the unit test to:
  - verify the correct endpoint is used,
  - verify `extend=detail` is included in the request,
  - verify `pe_ttm` is returned correctly.

## Testing

- Ran the targeted Xueqiu unit test.
- Ran the full test suite.

```
196 passed in 10.60s
```