### PR TITLE
fix(xueqiu): switch get_stock_quote to detail endpoint for pe_ttm/pb/eps

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -193,13 +193,13 @@ class XueqiuChannel(Channel):
 
         Returns a dict with keys:
           symbol, name, current, percent, chg, high, low, open, last_close,
-          volume, amount, market_capital, turnover_rate, pe_ttm, timestamp
+          volume, amount, market_capital, turnover_rate, pe_ttm, pe_forecast,
+          pb, eps, timestamp
         """
         data = _get_json(
-            f"https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol={symbol}"
+            f"https://stock.xueqiu.com/v5/stock/quote.json?symbol={symbol}&extend=detail"
         )
-        items = (data.get("data") or {}).get("items") or []
-        q = (items[0].get("quote") or {}) if items else {}
+        q = (data.get("data") or {}).get("quote") or {}
         return {
             "symbol": q.get("symbol", symbol),
             "name": q.get("name", ""),
@@ -215,6 +215,9 @@ class XueqiuChannel(Channel):
             "market_capital": q.get("market_capital"),
             "turnover_rate": q.get("turnover_rate"),
             "pe_ttm": q.get("pe_ttm"),
+            "pe_forecast": q.get("pe_forecast"),
+            "pb": q.get("pb"),
+            "eps": q.get("eps"),
             "timestamp": q.get("timestamp"),
         }
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -451,27 +451,26 @@ class TestXueqiuChannel:
 
         fake_data = {
             "data": {
-                "items": [
-                    {
-                        "quote": {
-                            "symbol": "SH600519",
-                            "name": "贵州茅台",
-                            "current": 1800.0,
-                            "percent": 1.5,
-                            "chg": 26.6,
-                            "high": 1810.0,
-                            "low": 1770.0,
-                            "open": 1775.0,
-                            "last_close": 1773.4,
-                            "volume": 12345678,
-                            "amount": 22000000000,
-                            "market_capital": 2260000000000,
-                            "turnover_rate": 0.098,
-                            "pe_ttm": 30.5,
-                            "timestamp": 1700000000000,
-                        }
-                    }
-                ]
+                "quote": {
+                    "symbol": "SH600519",
+                    "name": "贵州茅台",
+                    "current": 1800.0,
+                    "percent": 1.5,
+                    "chg": 26.6,
+                    "high": 1810.0,
+                    "low": 1770.0,
+                    "open": 1775.0,
+                    "last_close": 1773.4,
+                    "volume": 12345678,
+                    "amount": 22000000000,
+                    "market_capital": 2260000000000,
+                    "turnover_rate": 0.098,
+                    "pe_ttm": 30.5,
+                    "pe_forecast": 25.2,
+                    "pb": 8.5,
+                    "eps": 59.0,
+                    "timestamp": 1700000000000,
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #398 — `XueqiuChannel.get_stock_quote()` always returns `pe_ttm=None` because the batch endpoint (`batch/quote.json`) omits valuation fields.

## Root Cause

The method queried `batch/quote.json` which does not include `pe_ttm`, `pe_forecast`, `pb`, or `eps` in its response. The `q.get("pe_ttm")` call always returned `None`.

## Fix

- Switch from `batch/quote.json` to the detail endpoint `quote.json?symbol=&extend=detail`
- Access `data.quote` directly instead of `data.items[0].quote`
- Add `pe_forecast`, `pb`, and `eps` to the returned dict

## Changes

| File | Change |
|------|--------|
| `agent_reach/channels/xueqiu.py` | Switch endpoint + response parsing + 3 new fields |
| `tests/test_channels.py` | Update mock data structure to match detail endpoint |

## Test Results

```
196 tests: 184 passed, 11 skipped, 1 failed
```

The single failure (`test_youtube_warns_when_node_only_and_no_config`) is pre-existing on main and unrelated to this change. All Xueqiu tests pass.