### PR TITLE
[codex] narrow agent-reach skill web triggers

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -1,27 +1,34 @@
 ---
 name: agent-reach
 description: >
-  MUST USE when user wants to 调研/research/搜索/search/查/找/look up anything
-  on the internet — e.g. 全网调研 X / 帮我调研一下 X / 查一下 X / 搜搜 X /
-  看看大家怎么评价 X / X 上有什么讨论 / research this topic。
+  Use only when the user explicitly asks to use Agent Reach, asks for
+  multi-platform/social-platform collection, or mentions one of Agent Reach's
+  specialized platforms/backends.
 
-  Also MUST USE when user mentions any platform or shares any URL/链接:
+  Specialized platforms:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
   Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
-  雪球/股票行情, RSS feeds, or any web URL.
+  雪球/股票行情, RSS feeds.
 
   15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
+  NOT for: ordinary web search, web fetch/page reading, generic "deep research",
+  "deep investigation", "look this up", or arbitrary URLs. Use the agent's native
+  web search / web fetch tools for those unless a specialized platform above is
+  explicitly required.
+
   NOT for: 写报告/数据分析/翻译等内容加工（本 skill 只负责从互联网获取内容）；
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search(代码/专门搜索后备) / social(小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) /
+  career(LinkedIn/jobs) / dev(GitHub code search) / web(RSS/受限网页后备) /
+  video(YouTube/B站/播客字幕)。
 triggers:
-  - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
-  - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
+  - explicit: agent-reach/Agent Reach/use agent-reach/用 agent-reach
+  - multi_platform: 全网讨论/多平台/跨平台/社交平台/看看大家怎么评价/大家怎么说
   - social:
     - 小红书: xiaohongshu/xhs/小红书/红书
     - Twitter: twitter/推特/x.com/推文
@@ -31,8 +38,8 @@ triggers:
     - Facebook: facebook/fb/facebook groups
     - Instagram: instagram/ig
   - career: 招聘/职位/求职/linkedin/领英/找工作
-  - dev: github/代码/仓库/gh/issue/pr/分支/commit
-  - web: 网页/链接/文章/rss/读一下/打开这个
+  - dev: github code search/github search/gh search/repo search/代码搜索
+  - web: rss/feed/订阅源
   - video: youtube/视频/播客/字幕/小宇宙/转录/yt
   - finance: 雪球/股票/stock/xueqiu/行情/基金
 metadata:
@@ -42,7 +49,7 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+15 平台、多后端。**仅当任务明确需要下列专门平台/后端时使用本 skill。普通网页搜索、网页读取、deep research/deep investigation、任意 URL 阅读优先使用当前 agent 自带的 web search / web fetch。**
 
 ## 常驻规则（全程适用）
 
@@ -50,7 +57,7 @@ metadata:
    `agent-reach doctor --json`，按各平台 `active_backend` 字段选命令组。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
-4. **全网调研类任务**：组合多平台（Exa 搜索 + Twitter/Reddit 看讨论 + 小红书/B站看中文场景），并行收集再汇总。
+4. **多平台讨论类任务**：仅当用户明确需要社交/社区/平台讨论时，组合对应平台（Twitter/Reddit/小红书/B站/V2EX/Facebook/Instagram 等）并行收集再汇总。普通 deep research 不走本 skill。
 5. **替用户盯版本**：完成一次较大的调研/多平台任务后，顺手跑
    `agent-reach check-update`（很快，一个 API 调用）。有新版就在收尾汇报里附一句：
    「Agent Reach 有新版 vX.Y.Z，复制这句话给我即可更新：帮我更新 Agent Reach：
@@ -61,20 +68,20 @@ metadata:
 
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
-| 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
+| 代码/专门搜索 | search | [references/search.md](references/search.md) |
 | 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
-| GitHub/代码 | dev | [references/dev.md](references/dev.md) |
-| 网页/文章/RSS | web | [references/web.md](references/web.md) |
+| GitHub code search | dev | [references/dev.md](references/dev.md) |
+| RSS/受限网页后备 | web | [references/web.md](references/web.md) |
 | YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
 
 ## 零配置快速命令
 
 ```bash
-# Exa 网页搜索
+# Agent Reach 专门搜索后备；普通 web search 优先用当前 agent 自带工具
 mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 
-# 通用网页阅读
+# RSS/受限网页后备；普通 URL/web fetch 优先用当前 agent 自带工具
 curl -s "https://r.jina.ai/URL"
 
 # GitHub 搜索

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -1,11 +1,11 @@
 ---
 name: agent-reach
 description: >
-  MUST USE when user wants to research/search/look up/find anything on the
-  internet — e.g. "research this topic", "do a deep dive on X", "search the
-  web for X", "see what people say about X", "look this up".
+  Use only when the user explicitly asks to use Agent Reach, asks for
+  multi-platform/social-platform collection, or mentions one of Agent Reach's
+  specialized platforms/backends.
 
-  Also MUST USE when user mentions any platform or shares any URL/link:
+  Specialized platforms:
   Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
   Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
@@ -13,9 +13,30 @@ description: >
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
+  NOT for: ordinary web search, web fetch/page reading, generic "deep research",
+  "deep investigation", "look this up", or arbitrary URLs. Use the agent's native
+  web search / web fetch tools for those unless a specialized platform above is
+  explicitly required.
+
   NOT for: writing reports/analysis/translation (this skill only FETCHES
   internet content); posting/commenting/liking (write operations); platforms
   that already have a dedicated skill installed (prefer that skill).
+triggers:
+  - explicit: agent-reach/Agent Reach/use agent-reach
+  - multi_platform: multi-platform/social platforms/community discussion/what people say
+  - social:
+    - Twitter: twitter/x.com/tweets
+    - Reddit: reddit
+    - Facebook: facebook/fb/facebook groups
+    - Instagram: instagram/ig
+    - Bilibili: bilibili/bilibili video
+    - XiaoHongShu: xiaohongshu/xhs/rednote
+    - V2EX: v2ex
+  - career: linkedin/jobs/recruiting
+  - dev: github code search/github search/gh search/repo search
+  - web: rss/feed
+  - video: youtube/video/podcast/transcript/xiaoyuzhou
+  - finance: xueqiu/stocks/funds
 metadata:
   openclaw:
     homepage: https://github.com/Panniantong/Agent-Reach
@@ -23,8 +44,10 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
-these platforms — do not invent your own approach.**
+15 platforms, multiple backends each. **Use this skill only when the task
+explicitly needs the specialized platforms/backends below. For ordinary web
+search, web page reading, generic deep research/deep investigation, or arbitrary
+URLs, prefer the current agent's native web search / web fetch tools.**
 
 ## Standing rules (apply for the whole session)
 
@@ -35,9 +58,11 @@ these platforms — do not invent your own approach.**
    before starting.
 3. **On failure, follow the retry chains in references/** — never guess
    commands.
-4. **For broad research tasks**: combine platforms (Exa for web search +
-   Twitter/Reddit for discussions + XiaoHongShu/Bilibili for Chinese
-   perspectives), collect in parallel, then synthesize.
+4. **For multi-platform discussion tasks**: only when the user explicitly needs
+   social/community/platform discussion, combine the relevant platforms
+   (Twitter/Reddit/XiaoHongShu/Bilibili/V2EX/Facebook/Instagram, etc.), collect
+   in parallel, then synthesize. Ordinary deep research should not route through
+   this skill.
 5. **Watch versions for the user**: after finishing a substantial
    multi-platform task, run `agent-reach check-update` (fast, one API call).
    If a new version exists, append one line to your wrap-up: "Agent Reach
@@ -49,20 +74,20 @@ these platforms — do not invent your own approach.**
 
 | User intent | Category | Details |
 |---------|------|---------|
-| Web / code search | search | [references/search.md](references/search.md) |
+| Code / specialized search fallback | search | [references/search.md](references/search.md) |
 | XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
-| GitHub / code | dev | [references/dev.md](references/dev.md) |
-| Web pages / articles / RSS | web | [references/web.md](references/web.md) |
+| GitHub code search | dev | [references/dev.md](references/dev.md) |
+| RSS / restricted-page fallback | web | [references/web.md](references/web.md) |
 | YouTube / Bilibili / podcast transcripts | video | [references/video.md](references/video.md) |
 
 ## Zero-config quick commands
 
 ```bash
-# Exa web search
+# Agent Reach specialized search fallback; prefer native web search for ordinary web search
 mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
 
-# Read any web page
+# RSS/restricted-page fallback; prefer native web fetch for ordinary URLs/pages
 curl -s "https://r.jina.ai/URL"
 
 # GitHub search

--- a/agent_reach/skill/references/search.md
+++ b/agent_reach/skill/references/search.md
@@ -1,6 +1,8 @@
 # 搜索工具
 
-Exa AI 搜索引擎。
+Agent Reach 的专门搜索后备。普通 web search、deep research、deep investigation
+应优先使用当前 agent 自带的 web search；只有在 Agent Reach 已因专门平台/后端需求被
+明确选中，或原生搜索不可用时，才使用这里的命令。
 
 ## Exa AI 搜索
 
@@ -15,7 +17,7 @@ mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)
 
 | 场景 | 参数 |
 |-----|------|
-| 网页搜索 | `web_search_exa(query: "...", numResults: 5)` |
+| 专门网页搜索后备 | `web_search_exa(query: "...", numResults: 5)` |
 | 代码搜索 | `get_code_context_exa(query: "...", tokensNum: 3000)` |
 
 ### 特点
@@ -28,6 +30,7 @@ mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)
 
 | 工具 | 来源 | 适用场景 |
 |-----|------|---------|
-| Exa | agent-reach | 英文/技术/代码搜索 |
+| 原生 web search | 当前 agent | 普通网页搜索、deep research、deep investigation |
+| Exa | agent-reach | Agent Reach 已加载后的英文/技术/代码搜索后备 |
 | 智谱搜索 | my-mcp-tools | 中文搜索 |
 | GitHub 搜索 | agent-reach (dev.md) | 仓库/代码搜索 |

--- a/agent_reach/skill/references/web.md
+++ b/agent_reach/skill/references/web.md
@@ -1,8 +1,10 @@
 # 网页阅读
 
-通用网页、RSS。
+RSS 和受限网页后备。普通 URL 阅读、web fetch、网页摘要应优先使用当前 agent
+自带的 web fetch；只有在 Agent Reach 已因专门平台/后端需求被明确选中，或原生
+fetch 不可用时，才使用这里的后备命令。
 
-## 通用网页 (Jina Reader)
+## 受限网页后备 (Jina Reader)
 
 ```bash
 # 读取任意网页内容
@@ -12,7 +14,7 @@ curl -s "https://r.jina.ai/URL"
 curl -s "https://r.jina.ai/https://example.com/article"
 ```
 
-**适用场景**: 大多数网页可以直接用 Jina Reader 读取。
+**适用场景**: 原生 web fetch 不可用、输出格式需要后备控制，或用户明确要求走 Agent Reach。
 
 ## Web Reader (MCP)
 
@@ -27,7 +29,7 @@ mcporter call 'web-reader.webReader(url: "https://example.com", retain_images: t
 mcporter call 'web-reader.webReader(url: "https://example.com", return_format: "text")'
 ```
 
-**适用场景**: 需要更精确控制输出格式时使用。
+**适用场景**: 原生 web fetch 不可用，且需要更精确控制输出格式时使用。
 
 ## RSS (feedparser)
 
@@ -45,6 +47,7 @@ for e in feedparser.parse('FEED_URL').entries[:5]:
 
 | 场景 | 推荐工具 |
 |-----|---------|
-| 通用网页 | Jina Reader (`curl r.jina.ai`) |
-| 需要图片/格式控制 | web-reader MCP |
+| 普通 URL/web fetch | 当前 agent 自带 web fetch |
+| 受限网页后备 | Jina Reader (`curl r.jina.ai`) |
+| 需要图片/格式控制的后备读取 | web-reader MCP |
 | RSS 订阅 | feedparser |


### PR DESCRIPTION
## Summary
- narrow Agent Reach skill activation so generic deep research, web search, web fetch, and arbitrary URLs prefer the agent native web tools
- keep Agent Reach routing for explicit Agent Reach requests and specialized platform/social collection
- update both Chinese and English skill templates plus search/web references so installed skills do not steer agents back to Exa/Jina for ordinary web tasks

## Behavior impact
This is an intentional routing behavior change for generic web-only requests. After this PR, prompts such as "deep research X", "deep investigation X", "look this up", or a plain URL should use the host agent native web search / web fetch tools by default instead of Agent Reach.

Existing Agent Reach platform workflows remain covered when the user explicitly asks for Agent Reach or asks for supported platform/social collection, including Twitter/X, Reddit, Facebook, Instagram, XiaoHongShu, Bilibili, V2EX, LinkedIn/jobs, YouTube/podcasts, GitHub code search, Xueqiu, and RSS.

If a user still wants Agent Reach for a generic search fallback, they can say so explicitly, for example "use Agent Reach" or ask for multi-platform/social discussion.

## Why
The previous skill frontmatter said Agent Reach was MUST USE for any research/search/look-up task and any URL. In skill-aware agents such as Claude Code and Codex, that can hijack ordinary web research away from the agent native web search/fetch tools even when no Agent Reach-specific platform is needed.

## Validation
- `uv run --extra dev python -m pytest tests/test_skill_command.py tests/test_cli.py` -> 27 passed
- `uv run --extra dev python -m pytest` -> 196 passed
- `rg -n "MUST USE|look up anything|look up/find anything|any web URL|shares any URL|shares any URL/link|research:|search: 搜|Web / code search|Web pages / articles|网页搜索/代码搜索|网页/文章/RSS|全网调研类任务|For broad research tasks|do a deep dive|search the web for|Read any web page|通用网页" agent_reach/skill` -> no matches
- Fresh Codex smoke, generic request: `Please do deep research on AI SEO market size.` -> `agent-reach=no`
- Fresh Codex smoke, explicit request: `Use agent-reach to search Twitter and Reddit ...` -> `agent-reach=yes`
