### PR TITLE
fix(xueqiu): switch get_stock_quote to detail endpoint for pe_ttm

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -196,10 +196,9 @@ class XueqiuChannel(Channel):
           volume, amount, market_capital, turnover_rate, pe_ttm, timestamp
         """
         data = _get_json(
-            f"https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol={symbol}"
+            f"https://stock.xueqiu.com/v5/stock/quote.json?symbol={symbol}&extend=detail"
         )
-        items = (data.get("data") or {}).get("items") or []
-        q = (items[0].get("quote") or {}) if items else {}
+        q = (data.get("data") or {}).get("quote") or {}
         return {
             "symbol": q.get("symbol", symbol),
             "name": q.get("name", ""),

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -451,27 +451,23 @@ class TestXueqiuChannel:
 
         fake_data = {
             "data": {
-                "items": [
-                    {
-                        "quote": {
-                            "symbol": "SH600519",
-                            "name": "贵州茅台",
-                            "current": 1800.0,
-                            "percent": 1.5,
-                            "chg": 26.6,
-                            "high": 1810.0,
-                            "low": 1770.0,
-                            "open": 1775.0,
-                            "last_close": 1773.4,
-                            "volume": 12345678,
-                            "amount": 22000000000,
-                            "market_capital": 2260000000000,
-                            "turnover_rate": 0.098,
-                            "pe_ttm": 30.5,
-                            "timestamp": 1700000000000,
-                        }
-                    }
-                ]
+                "quote": {
+                    "symbol": "SH600519",
+                    "name": "贵州茅台",
+                    "current": 1800.0,
+                    "percent": 1.5,
+                    "chg": 26.6,
+                    "high": 1810.0,
+                    "low": 1770.0,
+                    "open": 1775.0,
+                    "last_close": 1773.4,
+                    "volume": 12345678,
+                    "amount": 22000000000,
+                    "market_capital": 2260000000000,
+                    "turnover_rate": 0.098,
+                    "pe_ttm": 30.5,
+                    "timestamp": 1700000000000,
+                }
             }
         }
 


### PR DESCRIPTION
## Fix for #398

XueqiuChannel.get_stock_quote() always returned pe_ttm=None because it used the batch endpoint (`batch/quote.json`) which does not include valuation fields.

### Changes
- Switch from `batch/quote.json` to `quote.json?extend=detail` which includes pe_ttm, pe_forecast, pb, eps
- Adjust response parsing: detail endpoint uses `data.quote` instead of `data.items[0].quote`
- Update test mock data to match the new endpoint response format

### Test results
- 184 passed, 11 skipped, 1 pre-existing failure (test_youtube_warns_when_node_only_and_no_config, unrelated)

Fixes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)