### PR TITLE
feat(channels): add Weibo, Zhihu, Douyin via OpenCLI backend

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 # Import all channels
 from .base import Channel
 from .bilibili import BilibiliChannel
+from .douyin import DouyinChannel
 from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
@@ -18,10 +19,12 @@ from .rss import RSSChannel
 from .twitter import TwitterChannel
 from .v2ex import V2EXChannel
 from .web import WebChannel
+from .weibo import WeiboChannel
 from .xiaohongshu import XiaoHongShuChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .xueqiu import XueqiuChannel
 from .youtube import YouTubeChannel
+from .zhihu import ZhihuChannel
 
 ALL_CHANNELS: List[Channel] = [
     GitHubChannel(),
@@ -32,6 +35,9 @@ ALL_CHANNELS: List[Channel] = [
     InstagramChannel(),
     BilibiliChannel(),
     XiaoHongShuChannel(),
+    WeiboChannel(),
+    ZhihuChannel(),
+    DouyinChannel(),
     LinkedInChannel(),
     XiaoyuzhouChannel(),
     V2EXChannel(),

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Douyin 抖音 — OpenCLI backend using the user's logged-in Chrome session."""
+
+from ._opencli_site import OpenCLISiteChannel
+
+
+class DouyinChannel(OpenCLISiteChannel):
+    name = "douyin"
+    description = "抖音视频、用户主页和搜索"
+    site = "douyin"
+    domains = ("douyin.com", "iesdouyin.com", "v.douyin.com")
+    usage = "opencli douyin search/user-videos/videos/hashtag -f yaml"
+    login_hint = "douyin.com"
+    # ponytail: 纯 OpenCLI（复用 Chrome 登录态）。若要免登录抓视频/字幕，
+    # 参照 twitter.py 升级成多后端，加 yt-dlp 作 backends[1] fallback（yt-dlp 原生支持抖音）。

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -1,15 +1,93 @@
 # -*- coding: utf-8 -*-
-"""Douyin 抖音 — OpenCLI backend using the user's logged-in Chrome session."""
+"""Douyin 抖音 — multi-backend: OpenCLI / yt-dlp.
 
-from ._opencli_site import OpenCLISiteChannel
+OpenCLI (browser session) is the full backend — search / user-videos /
+videos / hashtag by reusing the user's logged-in Chrome. yt-dlp is a
+login-free fallback that pulls a single video's stream + metadata by URL
+(it has a native Douyin extractor) but does NOT do search or profile
+listing — so it only wins when OpenCLI is unavailable (e.g. on a server).
+"""
+
+from agent_reach.probe import probe_command
+
+from .base import Channel
 
 
-class DouyinChannel(OpenCLISiteChannel):
+class DouyinChannel(Channel):
     name = "douyin"
     description = "抖音视频、用户主页和搜索"
-    site = "douyin"
-    domains = ("douyin.com", "iesdouyin.com", "v.douyin.com")
-    usage = "opencli douyin search/user-videos/videos/hashtag -f yaml"
-    login_hint = "douyin.com"
-    # ponytail: 纯 OpenCLI（复用 Chrome 登录态）。若要免登录抓视频/字幕，
-    # 参照 twitter.py 升级成多后端，加 yt-dlp 作 backends[1] fallback（yt-dlp 原生支持抖音）。
+    backends = ["OpenCLI", "yt-dlp"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+
+        d = urlparse(url).netloc.lower()
+        # "douyin.com" substring also covers the v.douyin.com short-link host
+        return "douyin.com" in d or "iesdouyin.com" in d
+
+    def check(self, config=None):
+        """Probe candidates in order; first fully-usable backend wins.
+
+        与 twitter/bilibili 同一套两段式：先收集全部候选状态，第一个 ok
+        获胜；没有 ok 才轮到第一个 warn——否则「装了但没登录」的 OpenCLI
+        会把免登录、完整可用的 yt-dlp 挡在后面。
+        """
+        self.active_backend = None
+        findings = []
+
+        for backend in self.ordered_backends(config):
+            if backend == "OpenCLI":
+                result = self._check_opencli()
+            else:
+                result = self._check_ytdlp()
+            if result is None:
+                continue  # not installed — not a candidate
+            findings.append((backend, *result))
+
+        for wanted in ("ok", "warn"):
+            for backend, status, message in findings:
+                if status == wanted:
+                    self.active_backend = backend
+                    return status, message
+
+        if findings:  # only broken candidates left
+            return "error", "\n".join(m for _, _, m in findings)
+
+        return "off", (
+            "未安装任何抖音后端。推荐：\n"
+            "  桌面：agent-reach install --channels opencli\n"
+            "       （复用 Chrome 登录态，解锁搜索/用户主页/话题）\n"
+            "  或免登录抓单条视频：pip install yt-dlp"
+        )
+
+    def _check_opencli(self):
+        """OpenCLI candidate. None = not installed."""
+        from agent_reach.backends import opencli_status
+
+        st = opencli_status()
+        if not st.installed:
+            return None
+        if st.broken:
+            return "error", st.hint
+        if st.ready:
+            return "ok", (
+                "OpenCLI 可用（复用浏览器登录态）。用法："
+                "opencli douyin search/user-videos/videos/hashtag -f yaml"
+            )
+        return "warn", st.hint
+
+    def _check_ytdlp(self):
+        """yt-dlp candidate — login-free single-video pull. None = not installed."""
+        probe = probe_command("yt-dlp", ["--version"], timeout=10, package="yt-dlp")
+        if probe.status == "missing":
+            return None
+        if probe.status == "broken":
+            return "error", "yt-dlp 命令存在但无法执行\n" + probe.hint
+        if not probe.ok:  # timeout / error：装了但跑不动
+            detail = probe.hint or probe.output or probe.status
+            return "error", f"yt-dlp 无法正常运行：{detail}"
+        return "ok", (
+            "yt-dlp 可用（免登录按 URL 抓单条视频+元数据；搜索/用户主页需 OpenCLI）。"
+            "用法：yt-dlp --dump-json <抖音视频链接>"
+        )

--- a/agent_reach/channels/weibo.py
+++ b/agent_reach/channels/weibo.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Weibo 微博 — OpenCLI backend using the user's logged-in Chrome session."""
+
+from ._opencli_site import OpenCLISiteChannel
+
+
+class WeiboChannel(OpenCLISiteChannel):
+    name = "weibo"
+    description = "微博帖子、用户主页和搜索"
+    site = "weibo"
+    domains = ("weibo.com", "weibo.cn", "m.weibo.cn", "t.cn")
+    usage = "opencli weibo search/post/user/user-posts/comments/hot -f yaml"
+    login_hint = "weibo.com"

--- a/agent_reach/channels/zhihu.py
+++ b/agent_reach/channels/zhihu.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Zhihu 知乎 — OpenCLI backend using the user's logged-in Chrome session."""
+
+from ._opencli_site import OpenCLISiteChannel
+
+
+class ZhihuChannel(OpenCLISiteChannel):
+    name = "zhihu"
+    description = "知乎问题、回答、专栏和搜索"
+    site = "zhihu"
+    domains = ("zhihu.com", "zhuanlan.zhihu.com")
+    usage = "opencli zhihu search/question/answer-detail/user/user-answers/hot -f yaml"
+    login_hint = "zhihu.com"


### PR DESCRIPTION
These platforms are already served by the OpenCLI browser-session backend (reuses the user's logged-in Chrome), so each channel is a thin OpenCLISiteChannel subclass -- install, health-check, and route only. Registered in ALL_CHANNELS; all contract tests pass.