### PR TITLE
fix(skill): flatten SKILL.md metadata for OpenCode compatibility (#439)

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -36,8 +36,7 @@ triggers:
   - video: youtube/视频/播客/字幕/小宇宙/转录/yt
   - finance: 雪球/股票/stock/xueqiu/行情/基金
 metadata:
-  openclaw:
-    homepage: https://github.com/Panniantong/Agent-Reach
+  openclaw.homepage: https://github.com/Panniantong/Agent-Reach
 ---
 
 # Agent Reach — 互联网能力路由器

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -17,8 +17,7 @@ description: >
   internet content); posting/commenting/liking (write operations); platforms
   that already have a dedicated skill installed (prefer that skill).
 metadata:
-  openclaw:
-    homepage: https://github.com/Panniantong/Agent-Reach
+  openclaw.homepage: https://github.com/Panniantong/Agent-Reach
 ---
 
 # Agent Reach — internet capability router

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -110,8 +110,12 @@ def test_youtube_warns_when_node_only_and_no_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr("shutil.which", fake_which)
     monkeypatch.setattr("subprocess.run", _fake_run_ok)  # yt-dlp probe really executes now
-    # Point to a non-existent config file
-    monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / ".config/yt-dlp/config"))
+    # Point to a non-existent config file — must mock the config-path helper
+    # because os.path.expanduser is not called on every platform (Win / APPDATA).
+    monkeypatch.setattr(
+        "agent_reach.channels.youtube.get_ytdlp_config_path",
+        lambda: tmp_path / "nonexistent" / "config",
+    )
 
     ch = YouTubeChannel()
     status, message = ch.check()


### PR DESCRIPTION
## Summary

Fixes #439 — "Unknown text label when installed on Opencode".

### Root Cause

Both `SKILL.md` and `SKILL_en.md` had a nested `metadata` structure:
```yaml
metadata:
  openclaw:
    homepage: https://github.com/Panniantong/Agent-Reach
```

OpenCode expects `metadata` to be `Record<string, string>` (flat key-value pairs). The nested structure causes OpenCode frontmatter parsing to fail, resulting in the skill name rendering as "Unknown" in the OpenCode TUI.

### Changes

1. **`agent_reach/skill/SKILL.md`**: Flatten `metadata.openclaw.homepage` to a dot-notation key
2. **`agent_reach/skill/SKILL_en.md`**: Same fix
3. **`tests/test_channel_contracts.py`**: Fix `test_youtube_warns_when_node_only_and_no_config` which used `os.path.expanduser` mock that is not called on Windows (where `APPDATA` is used instead). Changed to mock `get_ytdlp_config_path` directly for cross-platform correctness.

### Test Results

```
====================== 185 passed, 11 skipped in 48.29s =======================
```

All tests pass cleanly.