### PR TITLE
feat: add Keenable as zero-config web search channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ channels/
 ├── linkedin.py     → linkedin-mcp ▸ Jina Reader
 ├── rss.py          → feedparser
 ├── exa_search.py   → Exa via mcporter
+├── keenable_search.py → Keenable via mcporter（搜索 + 网页抓取）
 └── __init__.py     → 渠道注册（doctor 检测用）
 ```
 
@@ -210,7 +211,7 @@ channels/
 | Instagram | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | 官方 Graph API（Business/Creator + 审批） | instaloader 类路径不稳定；OpenCLI 复用真实浏览器会话 |
 | YouTube 字幕 + 搜索 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | — | 154K Star，YouTube 仍是最佳（注意：不再用于 B站） |
 | B站 | [bili-cli](https://github.com/public-clis/bilibili-cli) | OpenCLI ▸ 搜索 API | yt-dlp 被 B站风控 412 封死（2026-06 实测），bili-cli 无登录可搜可读 |
-| 搜全网 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI 语义搜索，MCP 接入免 Key |
+| 搜全网 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | [Keenable](https://keenable.ai) via mcporter | 两者都是 MCP 接入、免 Key；Keenable 额外提供网页抓取 |
 | GitHub | [gh CLI](https://cli.github.com) | — | 官方工具，认证后完整 API 能力 |
 | 读 RSS | [feedparser](https://github.com/kurtmckee/feedparser) | — | Python 生态标准选择 |
 | 小红书 | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)（服务器）▸ xhs-cli | OpenCLI 只用用户已有会话；其余后端用 Cookie-Editor 手工导出 |
@@ -284,7 +285,7 @@ Star 一下，下次需要的时候能找到。⭐
 
 ## 致谢
 
-[OpenCLI](https://github.com/jackwener/opencli) · [twitter-cli](https://github.com/public-clis/twitter-cli) · [rdt-cli](https://github.com/public-clis/rdt-cli) · [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) · [xhs-cli](https://github.com/jackwener/xiaohongshu-cli) · [bili-cli](https://github.com/public-clis/bilibili-cli) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [Jina Reader](https://github.com/jina-ai/reader) · [Exa](https://exa.ai) · [mcporter](https://github.com/nicobailon/mcporter) · [feedparser](https://github.com/kurtmckee/feedparser) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server)
+[OpenCLI](https://github.com/jackwener/opencli) · [twitter-cli](https://github.com/public-clis/twitter-cli) · [rdt-cli](https://github.com/public-clis/rdt-cli) · [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) · [xhs-cli](https://github.com/jackwener/xiaohongshu-cli) · [bili-cli](https://github.com/public-clis/bilibili-cli) · [yt-dlp](https://github.com/yt-dlp/yt-dlp) · [Jina Reader](https://github.com/jina-ai/reader) · [Exa](https://exa.ai) · [Keenable](https://keenable.ai) · [mcporter](https://github.com/nicobailon/mcporter) · [feedparser](https://github.com/kurtmckee/feedparser) · [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server)
 
 ## 联系
 

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -12,6 +12,7 @@ from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
 from .instagram import InstagramChannel
+from .keenable_search import KeenableSearchChannel
 from .linkedin import LinkedInChannel
 from .reddit import RedditChannel
 from .rss import RSSChannel
@@ -38,6 +39,7 @@ ALL_CHANNELS: List[Channel] = [
     XueqiuChannel(),
     RSSChannel(),
     ExaSearchChannel(),
+    KeenableSearchChannel(),
     WebChannel(),
 ]
 

--- a/agent_reach/channels/keenable_search.py
+++ b/agent_reach/channels/keenable_search.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 """Keenable Search — check if mcporter + Keenable MCP is available."""
 
-from agent_reach.probe import probe_command
+import shutil
 
 from .base import Channel
-
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+from .mcporter import McporterConfigError, inspect_mcporter_config
 
 
 class KeenableSearchChannel(Channel):
@@ -20,21 +18,27 @@ class KeenableSearchChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
-        if probe.status == "missing":
+        if not shutil.which("mcporter"):
             return "off", (
                 "需要 mcporter + Keenable MCP。安装：\n"
                 "  npm install -g mcporter\n"
-                "  mcporter config add keenable https://api.keenable.ai/mcp"
+                "  mcporter config add keenable https://api.keenable.ai/mcp --scope home"
             )
-        if probe.status == "broken":
-            return "error", _MCPORTER_BROKEN_HINT
-        if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "keenable" in probe.output.lower():
-            self.active_backend = self.backends[0]
-            return "ok", "全网搜索 + 网页抓取可用（免费，无需 API Key）"
+        try:
+            inspection = inspect_mcporter_config()
+        except McporterConfigError as exc:
+            return "error", f"mcporter 配置检查失败：{exc}"
+        if "keenable" in inspection.server_names:
+            return "warn", (
+                "Keenable 已写入 mcporter 配置，但 Doctor 未启动远端服务做"
+                "连通验证，不能仅凭配置宣称可用。"
+            )
+        if inspection.imports_unchecked:
+            return "warn", (
+                "mcporter 本地配置未发现 Keenable；配置还启用了 editor imports，"
+                "Doctor 为避免扩大凭据读取范围没有展开，当前未验证。"
+            )
         return "off", (
             "mcporter 已装但 Keenable 未配置。运行：\n"
-            "  mcporter config add keenable https://api.keenable.ai/mcp"
+            "  mcporter config add keenable https://api.keenable.ai/mcp --scope home"
         )

--- a/agent_reach/channels/keenable_search.py
+++ b/agent_reach/channels/keenable_search.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Keenable Search — check if mcporter + Keenable MCP is available."""
+
+from agent_reach.probe import probe_command
+
+from .base import Channel
+
+#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
+_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+
+
+class KeenableSearchChannel(Channel):
+    name = "keenable_search"
+    description = "全网搜索 + 网页抓取"
+    backends = ["Keenable via mcporter"]
+    tier = 0
+
+    def can_handle(self, url: str) -> bool:
+        return False  # Search-only channel
+
+    def check(self, config=None):
+        self.active_backend = None
+        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
+        if probe.status == "missing":
+            return "off", (
+                "需要 mcporter + Keenable MCP。安装：\n"
+                "  npm install -g mcporter\n"
+                "  mcporter config add keenable https://api.keenable.ai/mcp"
+            )
+        if probe.status == "broken":
+            return "error", _MCPORTER_BROKEN_HINT
+        if not probe.ok:  # timeout / error
+            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
+        if "keenable" in probe.output.lower():
+            self.active_backend = self.backends[0]
+            return "ok", "全网搜索 + 网页抓取可用（免费，无需 API Key）"
+        return "off", (
+            "mcporter 已装但 Keenable 未配置。运行：\n"
+            "  mcporter config add keenable https://api.keenable.ai/mcp"
+        )

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1101,6 +1101,22 @@ def _install_mcporter():
     except Exception:
         print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
+    # Configure Keenable MCP (free, no key needed; also does page fetch)
+    try:
+        r = subprocess.run(
+            ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
+        )
+        if "keenable" not in configured_server_names(r.stdout):
+            subprocess.run(
+                ["mcporter", "config", "add", "keenable", "https://api.keenable.ai/mcp", "--scope", "home"],
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10,
+            )
+            print("  ✅ Keenable search configured (free, no API key needed)")
+        else:
+            print("  ✅ Keenable search already configured")
+    except Exception:
+        print("  [!]  Could not configure Keenable. Run manually: mcporter config add keenable https://api.keenable.ai/mcp --scope home")
+
     # NOTE: xhs-cli is now optional, installed via --channels=xiaohongshu
 
 
@@ -1113,10 +1129,12 @@ def _install_mcporter_safe():
     if shutil.which("mcporter"):
         print("  ✅ mcporter already installed")
         print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
+        print("  To configure Keenable search: mcporter config add keenable https://api.keenable.ai/mcp --scope home")
     else:
         print("  -- mcporter not installed")
         print("  To install: npm install -g mcporter")
         print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
+        print("  And Keenable: mcporter config add keenable https://api.keenable.ai/mcp --scope home")
 
 
 def _detect_environment():

--- a/agent_reach/guides/setup-keenable.md
+++ b/agent_reach/guides/setup-keenable.md
@@ -1,0 +1,45 @@
+# Keenable Search 配置指南
+
+## 功能说明
+Keenable 是一个面向 AI Agent 的搜索 API。通过 MCP 接入，**免费、无需 API Key**（默认公共端点，按小时限流；设置 API Key 可解除限流）。配置后解锁：
+- 全网搜索（`search_web_pages`）
+- 网页抓取为干净 Markdown（`fetch_page_content`），可深读某条搜索结果
+- Reddit 搜索（通过 site:reddit.com）
+- Twitter 搜索（通过 site:x.com）
+
+## Agent 可自动完成的步骤
+
+`agent-reach install --env=auto` 会自动完成以下步骤，通常不需要手动操作。
+
+### 1. 安装 mcporter
+```bash
+npm install -g mcporter
+```
+
+### 2. 注册 Keenable MCP
+```bash
+mcporter config add keenable https://api.keenable.ai/mcp
+```
+
+### 3. 验证
+```bash
+agent-reach doctor | grep "Keenable"
+mcporter call 'keenable.search_web_pages(query: "test")'
+```
+
+## 需要用户手动做的步骤
+
+**无。** Keenable 通过 MCP 接入，默认免费、无需注册、无需 API Key。
+
+如果 `agent-reach install` 因为网络问题没有自动配置 Keenable，手动运行上面两条命令即可。
+
+## 常见问题
+
+**Q: 有搜索次数限制吗？**
+A: 公共端点（api.keenable.ai）默认按小时限流（1,000 次/小时），无需注册即可使用。需要更高额度可在 [keenable.ai/console](https://keenable.ai/console) 获取 API Key 解除限流。
+
+**Q: 和 Exa 有什么区别？**
+A: 两者都是免 Key 的 MCP 搜索后端，可互为备份。Keenable 额外提供网页抓取（返回干净 Markdown），适合搜索后深读页面。
+
+**Q: mcporter 是什么？**
+A: MCP 协议的命令行桥接工具，用来调用 MCP Server。Agent Reach 用它来连接 Exa、Keenable 和小红书。

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1643,6 +1643,99 @@ class TestExaSearchChannel:
         assert ch.active_backend is None
 
 
+class TestKeenableSearchChannel:
+    def test_mcporter_is_never_executed(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
+        from agent_reach.channels.keenable_search import KeenableSearchChannel
+        ch = KeenableSearchChannel()
+        status, msg = ch.check()
+        assert status == "off"
+        assert ch.active_backend is None
+
+    def test_configured_keenable_is_not_false_positive_active(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "keenable": {"baseUrl": "https://mcp.example.test"}
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+        from agent_reach.channels.keenable_search import KeenableSearchChannel
+        ch = KeenableSearchChannel()
+        status, msg = ch.check()
+        assert status == "warn"
+        assert "未启动" in msg
+        assert ch.active_backend is None
+
+    def test_config_metadata_containing_keenable_is_not_a_backend(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "unrelated": {
+                            "baseUrl": "https://example.test/keenable-project"
+                        }
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+        from agent_reach.channels.keenable_search import KeenableSearchChannel
+
+        ch = KeenableSearchChannel()
+        status, _ = ch.check()
+        assert status == "off"
+        assert ch.active_backend is None
+
+    def test_invalid_mcporter_json_is_reported_as_error_not_unconfigured(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text("not-json", encoding="utf-8")
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
+        from agent_reach.channels.keenable_search import KeenableSearchChannel
+
+        ch = KeenableSearchChannel()
+        status, message = ch.check()
+        assert status == "error"
+        assert "JSON" in message
+        assert ch.active_backend is None
+
+
 class TestXiaoyuzhouChannel:
     def test_reports_error_with_reinstall_hint_when_ffmpeg_broken(self, monkeypatch):
         """ffmpeg which 命中但 exec 失败（pip 假 ffmpeg 断链）→ error + 重装处方。"""


### PR DESCRIPTION
Adds Keenable as a search channel alongside Exa. Keenable runs a hosted MCP server, so it wires in the same way Exa does: `mcporter config add keenable https://api.keenable.ai/mcp`.

Tier 0, keyless by default (public endpoint rate-limited to 1,000 req/hour; an optional API key lifts the cap), so it stays within the zero-API-fees model. On top of search it exposes page fetch (`fetch_page_content`) returning clean markdown, useful for deep-reading a search result.

Positioned as a peer/fallback to Exa (both keyless MCP search), not a replacement.

Changes:
- `channels/keenable_search.py` — mcporter probe, mirrors `exa_search.py`
- registered in the channel list
- `guides/setup-keenable.md`
- `cli.py` — auto-configures the Keenable MCP endpoint alongside Exa during install
- README — channel tree, backend table, acknowledgements

Verified locally: channel registry loads, `keenable_search` reports tier 0, ruff clean on new code, full test suite passes (196 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)