### PR TITLE
fix(config): atomic, symlink-safe YAML writes (audit #378, P2-09)

### DIFF
--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -6,12 +6,59 @@ Auto-creates directory on first use.
 """
 
 import os
+import stat
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
 
 from agent_reach.utils.paths import make_private_dir
+
+
+def _atomic_write_yaml(target: Path, data: dict) -> None:
+    """Write ``data`` as YAML to ``target`` atomically and symlink-safely.
+
+    Writes to a sibling temp file (created mode 0o600 by
+    ``tempfile.mkstemp``, so credentials are never briefly world-readable)
+    in the SAME directory as the target, then ``os.replace()``s it into
+    place. This fixes two hazards of a naive ``O_TRUNC`` write:
+
+    - Torn writes / corruption on failure: ``os.replace`` is atomic, so a
+      crash or exception mid-write leaves the previous config untouched.
+    - Symlink swap: a symlink planted at the target path is REPLACED by the
+      new regular file (``os.replace`` renames the directory entry; it does
+      not follow the link) instead of being written through to an
+      attacker-chosen target.
+
+    On any exception the temp file is removed and the prior file is left
+    intact; the exception then propagates.
+    """
+    # mkstemp creates the file mode 0o600 on every platform (owner-only), so
+    # there is no race window where credentials are world-readable.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass  # fsync is best-effort; some filesystems don't support it
+        if os.name != "nt":
+            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        os.replace(tmp_path, target)
+    except BaseException:
+        # Crash or write failure: remove the orphaned temp file so it can't
+        # leak credentials, and leave the previous config untouched.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 class Config:
@@ -23,7 +70,10 @@ class Config:
     # Feature → required config keys
     FEATURE_REQUIREMENTS = {
         "exa_search": ["exa_api_key"],
-        "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
+        "twitter_xreach": [
+            "twitter_auth_token",
+            "twitter_ct0",
+        ],  # legacy key name; used by twitter-cli
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],
         "github_token": ["github_token"],
@@ -49,28 +99,14 @@ class Config:
             self.data = {}
 
     def save(self):
-        """Save config to YAML file."""
+        """Save config to YAML file.
+
+        Atomic and symlink-safe — see :func:`_atomic_write_yaml`. The
+        previous config is left untouched if the write fails, and a symlink
+        planted at the config path is replaced rather than followed.
+        """
         self._ensure_dir()
-        # Create file with restricted permissions from the start to avoid
-        # a race window where credentials are briefly world-readable.
-        try:
-            import stat
-            fd = os.open(
-                str(self.config_path),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                stat.S_IRUSR | stat.S_IWUSR,  # 0o600
-            )
-            if os.name != "nt":
-                os.chmod(self.config_path, stat.S_IRUSR | stat.S_IWUSR)
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                yaml.dump(self.data, f, default_flow_style=False, allow_unicode=True)
-        except OSError:
-            # Fallback for Windows or other edge cases where os.open flags
-            # are not fully supported.
-            with open(self.config_path, "w", encoding="utf-8") as f:
-                yaml.dump(self.data, f, default_flow_style=False, allow_unicode=True)
-            if os.name != "nt":
-                os.chmod(self.config_path, 0o600)
+        _atomic_write_yaml(self.config_path, self.data)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a config value. Also checks environment variables (uppercase)."""
@@ -100,10 +136,7 @@ class Config:
 
     def get_configured_features(self) -> dict:
         """Return status of all optional features."""
-        return {
-            feature: self.is_configured(feature)
-            for feature in self.FEATURE_REQUIREMENTS
-        }
+        return {feature: self.is_configured(feature) for feature in self.FEATURE_REQUIREMENTS}
 
     def to_dict(self) -> dict:
         """Return config as dict (masks sensitive values)."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,6 +92,7 @@ class TestConfig:
     def test_save_creates_file_with_restricted_permissions(self, tmp_path):
         import stat
         import sys
+
         config_file = tmp_path / "secure_config.yaml"
         config = Config(config_path=config_file)
         config.set("secret_key", "my-secret")
@@ -133,3 +134,92 @@ class TestConfig:
             assert not (mode & stat.S_IXGRP), "group execute should not be set"
             assert not (mode & stat.S_IROTH), "other read should not be set"
             assert not (mode & stat.S_IXOTH), "other execute should not be set"
+
+    def test_save_does_not_follow_symlink_at_config_path(self, tmp_path):
+        """A symlink planted at the config path must be replaced, not followed.
+
+        Otherwise save() would write through the link and clobber an
+        attacker-chosen target file with the user's credentials.
+        """
+        import os
+
+        import yaml
+
+        victim = tmp_path / "victim.yaml"
+        victim.write_text("secret: victim-data\n", encoding="utf-8")
+
+        config_file = tmp_path / "config.yaml"
+        try:
+            os.symlink(victim, config_file)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        # load() reads through the symlink -> victim's {"secret": "victim-data"}.
+        config = Config(config_path=config_file)
+        config.set("exa_api_key", "new-secret")
+
+        # The victim file must be untouched: save() replaced the symlink,
+        # it did not write through it.
+        assert yaml.safe_load(victim.read_text(encoding="utf-8")) == {"secret": "victim-data"}, (
+            "save() wrote through the symlink into the victim file"
+        )
+
+        # The config path is now a regular file holding the new data.
+        assert not os.path.islink(config_file), "config path is still a symlink"
+        saved = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert saved["exa_api_key"] == "new-secret"
+
+    def test_save_preserves_previous_config_on_write_failure(self, tmp_path, monkeypatch):
+        """A failed write must not truncate or corrupt the existing config.
+
+        The old O_TRUNC write emptied the file before the YAML dump ran,
+        so any failure mid-write left credentials unreadable. The atomic
+        temp-then-rename write leaves the previous file untouched.
+        """
+        config_file = tmp_path / "config.yaml"
+        config = Config(config_path=config_file)
+        config.set("keep_key", "keep_value")  # establishes a valid prior file
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated write failure")
+
+        monkeypatch.setattr("agent_reach.config.yaml.dump", boom)
+
+        with pytest.raises(RuntimeError):
+            config.set("new_key", "new_value")
+
+        monkeypatch.undo()  # restore yaml.dump so Config can reload
+
+        reloaded = Config(config_path=config_file)
+        assert reloaded.get("keep_key") == "keep_value", "prior config was corrupted"
+        assert reloaded.get("new_key") is None
+
+        # No orphaned temp file should litter the config directory.
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "config.yaml"]
+        assert leftovers == [], f"temp file left behind: {leftovers}"
+
+    def test_save_writes_temp_in_same_directory_as_target(self, tmp_path, monkeypatch):
+        """The temp file must live in the target's directory.
+
+        os.replace() is only atomic across the same filesystem; a temp
+        in the system temp dir could span a mount boundary and fall back
+        to a non-atomic copy.
+        """
+        import tempfile as _tempfile
+
+        config_file = tmp_path / "sub" / "config.yaml"
+        config = Config(config_path=config_file)
+
+        captured = {}
+        real_mkstemp = _tempfile.mkstemp
+
+        def spy(*args, **kwargs):
+            captured["dir"] = kwargs.get("dir")
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr("agent_reach.config.tempfile.mkstemp", spy)
+
+        config.set("k", "v")
+        assert captured["dir"] == str(config_file.parent), (
+            "temp file must live in the target directory for an atomic same-FS rename"
+        )


### PR DESCRIPTION
## Summary

Hardens `Config.save()` against two hazards identified in the security audit (#378, finding **P2-09 — Config writes are not symlink-safe or atomic**). No behavior change for normal saves; the existing `0o600` permission handling is preserved.

## Problem

`Config.save()` wrote directly to the config path with `O_CREAT | O_TRUNC`:

1. **Corruption on failure.** The file was truncated *before* the YAML dump ran, so any crash or exception mid-write left `~/.agent-reach/config.yaml` empty/partial — credentials unreadable. A transient failure (disk full, interrupted) thus destroyed the prior config.
2. **Symlink swap.** `os.open` followed a symlink at the config path, so a planted symlink `~/.agent-reach/config.yaml → <victim>` would cause a save to **overwrite the victim file** with the user's secrets (cookies, tokens).

Repro for #2:
```python
victim.write_text("secret: victim-data\n")
os.symlink(victim, config_path)          # planted by attacker
Config(config_path=config_path).set("exa_api_key", "new-secret")
# old behavior: victim.yaml now contains the user's exa_api_key
```

## Fix

New module-level `_atomic_write_yaml(target, data)`:
- `tempfile.mkstemp` creates a sibling temp file **in the target's own directory** (so `os.replace` is same-filesystem and never falls back to a non-atomic copy), mode `0o600` on every platform — no race window where credentials are world-readable.
- Write YAML → `flush` → `fsync` (best-effort) → `chmod 0o600` → `os.replace(tmp, target)`.
- `os.replace` renames the directory entry; it does **not** follow a symlink at the target, so a planted symlink is *replaced* by the new regular file rather than written through.
- On any exception the orphaned temp is removed and the **previous config is left untouched**; the exception propagates.

`Config.save()` now delegates to this helper. The Windows `os.open`-flags fallback is no longer needed — `mkstemp` + `os.replace` are fully cross-platform.

## Tests (`tests/test_config.py`)

- `test_save_does_not_follow_symlink_at_config_path` — a planted symlink is replaced; the victim file is untouched (skipped on platforms without symlink support).
- `test_save_preserves_previous_config_on_write_failure` — a write that fails mid-stream leaves the prior config intact and leaves no temp file behind.
- `test_save_writes_temp_in_same_directory_as_target` — the temp is created in the target's directory (guarantees a same-FS atomic rename).

All three fail on `main` for the right reasons (victim gets written / prior config gets truncated) and pass with this change.

## Verification

- `pytest -q` → **199 passed** (196 + 3 new)
- `ruff check` / `ruff format --check` on the two changed files: clean
- `mypy agent_reach/config.py`: no new errors (pre-existing baseline errors in unrelated files are unchanged)

## Scope

This addresses **only** P2-09 from #378. It does not close #378 (the audit has 15 findings; others are covered by separate PRs or out of scope here). Version left untouched for the maintainer to cut a release; no changelog entry added — happy to add one under `[Unreleased]` if preferred.