### PR TITLE
feat(i18n): translate user-facing CLI output to English

### DIFF
--- a/agent_reach/backends/opencli.py
+++ b/agent_reach/backends/opencli.py
@@ -89,7 +89,7 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
             installed=True,
             broken=True,
             hint=(
-                "opencli 命令存在但无法执行（node 环境损坏），重装：\n"
+                "opencli command exists but cannot execute (broken node environment), reinstall:\n"
                 f"  npm install -g {OPENCLI_PACKAGE}"
             ),
         )
@@ -114,9 +114,9 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
         st.extension_installed = _extension_installed_on_disk()
         if not st.extension_installed:
             st.hint = (
-                "OpenCLI 已安装，但 Chrome 扩展未安装。\n"
-                f"  1. 安装扩展（需手动点一次）：{OPENCLI_EXTENSION_URL}\n"
-                "  2. 保持 Chrome 打开，运行 `opencli doctor` 验证"
+                "OpenCLI is installed, but the Chrome extension is not.\n"
+                f"  1. Install the extension (one manual click required): {OPENCLI_EXTENSION_URL}\n"
+                "  2. Keep Chrome open and run `opencli doctor` to verify"
             )
     return st
 
@@ -124,13 +124,13 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
 def opencli_summary(st: OpenCLIStatus) -> str:
     """One-line state description for channel messages / install output."""
     if not st.installed:
-        return "OpenCLI 未安装"
+        return "OpenCLI not installed"
     if st.broken:
-        return "OpenCLI 无法执行（node 环境损坏）"
+        return "OpenCLI cannot execute (broken node environment)"
     if st.extension_connected:
-        return f"OpenCLI 可用（浏览器登录态，v{st.version}）"
+        return f"OpenCLI available (browser session, v{st.version})"
     if st.ready:
-        return "OpenCLI 可用（扩展睡眠中，调用时自动唤醒）"
+        return "OpenCLI available (extension sleeping, wakes automatically on call)"
     if st.daemon_running:
-        return "OpenCLI 已安装，等待 Chrome 扩展安装"
-    return "OpenCLI 已安装（daemon 未运行，使用时自动启动；需 Chrome 扩展）"
+        return "OpenCLI installed, waiting for Chrome extension install"
+    return "OpenCLI installed (daemon not running, starts automatically on use; requires Chrome extension)"

--- a/agent_reach/channels/_opencli_site.py
+++ b/agent_reach/channels/_opencli_site.py
@@ -32,9 +32,9 @@ class OpenCLISiteChannel(Channel):
         st = opencli_status()
         if not st.installed:
             return "off", (
-                f"未安装 {self.description} 后端。安装：\n"
+                f"{self.description} backend not installed. Install:\n"
                 "  agent-reach install --channels opencli\n"
-                f"然后在 Chrome 里登录 {self.login_hint}"
+                f"then log into {self.login_hint} in Chrome"
             )
         if st.broken:
             return "error", st.hint
@@ -42,7 +42,7 @@ class OpenCLISiteChannel(Channel):
         self.active_backend = "OpenCLI"
         if st.ready:
             return "ok", (
-                f"OpenCLI 可用（复用浏览器登录态）。用法：{self.usage}。"
-                f"若提示登录，请先在 Chrome 里登录 {self.login_hint}"
+                f"OpenCLI available (reuses browser login session). Usage: {self.usage}. "
+                f"If it asks you to log in, log into {self.login_hint} in Chrome first"
             )
         return "warn", st.hint

--- a/agent_reach/channels/base.py
+++ b/agent_reach/channels/base.py
@@ -30,7 +30,7 @@ class Channel(ABC):
     """Base class for all channels."""
 
     name: str = ""                    # e.g. "youtube"
-    description: str = ""             # e.g. "YouTube 视频和字幕"
+    description: str = ""             # e.g. "YouTube videos and subtitles"
     backends: List[str] = []          # ordered candidates — backends[0] = preferred
     tier: int = 0                     # 0=zero-config, 1=needs free key, 2=needs setup
 
@@ -66,5 +66,5 @@ class Channel(ABC):
         Subclasses with external backends must really probe them (see
         agent_reach.probe.probe_command) and set self.active_backend.
         """
-        self.active_backend = self.backends[0] if self.backends else "内置"
-        return "ok", f"{'、'.join(self.backends) if self.backends else '内置'}"
+        self.active_backend = self.backends[0] if self.backends else "built-in"
+        return "ok", f"{', '.join(self.backends) if self.backends else 'built-in'}"

--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -34,8 +34,8 @@ def _search_api_ok() -> bool:
 
 class BilibiliChannel(Channel):
     name = "bilibili"
-    description = "B站视频、字幕和搜索"
-    backends = ["bili-cli", "OpenCLI", "B站搜索 API"]
+    description = "Bilibili videos, subtitles, and search"
+    backends = ["bili-cli", "OpenCLI", "Bilibili search API"]
     tier = 1
 
     def can_handle(self, url: str) -> bool:
@@ -59,7 +59,7 @@ class BilibiliChannel(Channel):
                 continue
             findings.append((backend, *result))
 
-        # 有后端断链时，即使别的候选兜底成功也要把处方带出来
+        # If any backend is broken, surface the fix even when another fallback candidate succeeds
         broken_notes = [m for _, s, m in findings if s == "error"]
 
         for wanted in ("ok", "warn"):
@@ -67,16 +67,16 @@ class BilibiliChannel(Channel):
                 if status == wanted:
                     self.active_backend = backend
                     if broken_notes:
-                        message += "\n[备选后端异常] " + "；".join(broken_notes)
+                        message += "\n[fallback backend issue] " + "; ".join(broken_notes)
                     return status, message
 
         if findings:
             return "error", "\n".join(m for _, _, m in findings)
 
         return "off", (
-            "没有可用的 B站后端（搜索 API 也不可达，可能是网络问题）。推荐：\n"
-            "  pipx install bilibili-cli（搜索/热门/视频详情，无需登录）\n"
-            "  或桌面装 OpenCLI（额外解锁字幕）：agent-reach install --channels opencli"
+            "No Bilibili backend available (search API also unreachable, possibly a network issue). Recommended:\n"
+            "  pipx install bilibili-cli (search/hot/video details, no login needed)\n"
+            "  or install OpenCLI on desktop (also unlocks subtitles): agent-reach install --channels opencli"
         )
 
     def _check_bili_cli(self):
@@ -85,12 +85,12 @@ class BilibiliChannel(Channel):
         if probe.status == "missing":
             return None
         if probe.status == "broken":
-            return "error", "bili 命令存在但无法执行\n" + probe.hint
+            return "error", "bili command exists but cannot execute\n" + probe.hint
         if not probe.ok:
-            return "warn", f"bili-cli 探测失败（{probe.status}），运行 `bili status` 查看详情"
+            return "warn", f"bili-cli probe failed ({probe.status}); run `bili status` for details"
         return "ok", (
-            "bili-cli 可用（搜索/热门/排行/视频详情/音频，无需登录；"
-            "字幕需 OpenCLI。上游 2026-03 起停更）"
+            "bili-cli available (search/hot/ranking/video details/audio, no login needed; "
+            "subtitles need OpenCLI. Upstream unmaintained since 2026-03)"
         )
 
     def _check_opencli(self):
@@ -104,7 +104,7 @@ class BilibiliChannel(Channel):
             return "error", st.hint
         if st.ready:
             return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
+                "OpenCLI available (reuses browser login session). Usage: "
                 "opencli bilibili search/video/subtitle/ranking -f yaml"
             )
         return "warn", st.hint
@@ -114,6 +114,6 @@ class BilibiliChannel(Channel):
         if not _search_api_ok():
             return None
         return "ok", (
-            "B站搜索 API 可达（仅搜索，curl 直连）。"
-            "完整功能建议安装 bili-cli：pipx install bilibili-cli"
+            "Bilibili search API reachable (search only, direct curl). "
+            "For full functionality, install bili-cli: pipx install bilibili-cli"
         )

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -5,13 +5,13 @@ from agent_reach.probe import probe_command
 
 from .base import Channel
 
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+#: mcporter is an npm package, so its broken-install hint differs from the default pipx/uv one
+_MCPORTER_BROKEN_HINT = "mcporter cannot execute (broken node environment), reinstall:\n  npm install -g mcporter"
 
 
 class ExaSearchChannel(Channel):
     name = "exa_search"
-    description = "全网语义搜索"
+    description = "Web-wide semantic search"
     backends = ["Exa via mcporter"]
     tier = 0
 
@@ -23,18 +23,18 @@ class ExaSearchChannel(Channel):
         probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
         if probe.status == "missing":
             return "off", (
-                "需要 mcporter + Exa MCP。安装：\n"
+                "Requires mcporter + Exa MCP. Install:\n"
                 "  npm install -g mcporter\n"
                 "  mcporter config add exa https://mcp.exa.ai/mcp"
             )
         if probe.status == "broken":
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
+            return "error", f"mcporter execution error: {probe.hint or probe.output or probe.status}"
         if "exa" in probe.output.lower():
             self.active_backend = self.backends[0]
-            return "ok", "全网语义搜索可用（免费，无需 API Key）"
+            return "ok", "Web-wide semantic search available (free, no API key needed)"
         return "off", (
-            "mcporter 已装但 Exa 未配置。运行：\n"
+            "mcporter is installed but Exa is not configured. Run:\n"
             "  mcporter config add exa https://mcp.exa.ai/mcp"
         )

--- a/agent_reach/channels/facebook.py
+++ b/agent_reach/channels/facebook.py
@@ -6,7 +6,7 @@ from ._opencli_site import OpenCLISiteChannel
 
 class FacebookChannel(OpenCLISiteChannel):
     name = "facebook"
-    description = "Facebook 帖子、主页和群组"
+    description = "Facebook posts, profiles, and groups"
     site = "facebook"
     domains = ("facebook.com", "fb.com", "fb.watch")
     usage = "opencli facebook search/profile/feed/groups -f yaml"

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -8,7 +8,7 @@ from .base import Channel
 
 class GitHubChannel(Channel):
     name = "github"
-    description = "GitHub 仓库和代码"
+    description = "GitHub repos and code"
     backends = ["gh CLI"]
     tier = 0
 
@@ -17,26 +17,26 @@ class GitHubChannel(Channel):
         return "github.com" in urlparse(url).netloc.lower()
 
     def check(self, config=None):
-        # 真跑 gh auth status 探活。注意：未登录时 rc!=0 是正常业务态（warn），不是 error。
+        # Actually run gh auth status as a live probe. Note: rc!=0 when not logged in is a normal business state (warn), not an error.
         probe = probe_command("gh", ["auth", "status"], timeout=10, package="gh")
         if probe.status == "missing":
             self.active_backend = None
-            return "warn", "gh CLI 未安装。安装：https://cli.github.com"
+            return "warn", "gh CLI not installed. Install: https://cli.github.com"
         if probe.status == "broken":
-            # gh 是二进制安装（brew/官方包），不是 pip 包——处方不用 pipx/uv 文案
+            # gh is installed as a binary (brew/official package), not a pip package — hint doesn't use pipx/uv wording
             self.active_backend = None
             return "error", (
-                "gh 命令存在但无法执行——安装已损坏。重装即可修复：\n"
+                "gh command exists but cannot execute — the install is broken. Reinstalling fixes it:\n"
                 "  brew reinstall gh\n"
-                "或从 https://cli.github.com 重新安装 gh CLI"
+                "or reinstall gh CLI from https://cli.github.com"
             )
         if probe.status == "timeout":
-            # gh 本体能启动（工具是活的），只是状态检查超时
+            # gh itself can start (the tool is alive), just the status check timed out
             self.active_backend = "gh CLI"
-            return "warn", "gh CLI 状态检查超时，运行 gh auth status 查看详情"
+            return "warn", "gh CLI status check timed out; run gh auth status for details"
         if probe.ok:
             self.active_backend = "gh CLI"
-            return "ok", "完整可用（读取、搜索、Fork、Issue、PR 等）"
-        # rc != 0：gh 活着但未认证（gh auth status 的正常业务态）
+            return "ok", "Fully available (read, search, fork, issues, PRs, etc.)"
+        # rc != 0: gh is alive but not authenticated (gh auth status's normal business state)
         self.active_backend = "gh CLI"
-        return "warn", "gh CLI 已安装但未认证。运行 gh auth login 可解锁完整功能"
+        return "warn", "gh CLI is installed but not authenticated. Run gh auth login to unlock full functionality"

--- a/agent_reach/channels/instagram.py
+++ b/agent_reach/channels/instagram.py
@@ -6,7 +6,7 @@ from ._opencli_site import OpenCLISiteChannel
 
 class InstagramChannel(OpenCLISiteChannel):
     name = "instagram"
-    description = "Instagram 用户、主页和指定用户帖子"
+    description = "Instagram users, profiles, and specific users' posts"
     site = "instagram"
     domains = ("instagram.com", "instagr.am")
     usage = "opencli instagram search/profile/user/explore -f yaml"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -5,13 +5,13 @@ from agent_reach.probe import probe_command
 
 from .base import Channel
 
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+#: mcporter is an npm package, so its broken-install hint differs from the default pipx/uv one
+_MCPORTER_BROKEN_HINT = "mcporter cannot execute (broken node environment), reinstall:\n  npm install -g mcporter"
 
 
 class LinkedInChannel(Channel):
     name = "linkedin"
-    description = "LinkedIn 职业社交"
+    description = "LinkedIn professional networking"
     backends = ["linkedin-scraper-mcp", "Jina Reader"]
     tier = 2
 
@@ -24,20 +24,20 @@ class LinkedInChannel(Channel):
         probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
         if probe.status == "missing":
             return "off", (
-                "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
+                "Basic content can be read via Jina Reader. Full functionality requires:\n"
                 "  pip install linkedin-scraper-mcp\n"
                 "  mcporter config add linkedin http://localhost:3000/mcp\n"
-                "  详见 https://github.com/stickerdaniel/linkedin-mcp-server"
+                "  see https://github.com/stickerdaniel/linkedin-mcp-server"
             )
         if probe.status == "broken":
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
+            return "error", f"mcporter execution error: {probe.hint or probe.output or probe.status}"
         if "linkedin" in probe.output.lower():
             self.active_backend = "linkedin-scraper-mcp"
-            return "ok", "完整可用（Profile、公司、职位搜索）"
+            return "ok", "Fully available (profile, company, job search)"
         return "off", (
-            "mcporter 已装但 LinkedIn MCP 未配置。运行：\n"
+            "mcporter is installed but LinkedIn MCP is not configured. Run:\n"
             "  pip install linkedin-scraper-mcp\n"
             "  mcporter config add linkedin http://localhost:3000/mcp"
         )

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -21,20 +21,20 @@ _CREDENTIAL_FILE = "~/.config/rdt-cli/credential.json"
 # Pinned to the 0.4.2 state — PyPI still only has 0.4.1 (upstream issue #10).
 _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66"
 
-#: shell 对"找到但不可执行/找不到"使用的退出码（对齐 agent_reach.probe）
+#: Exit codes the shell uses for "found but not executable / not found" (aligned with agent_reach.probe)
 _BROKEN_EXIT_CODES = (126, 127)
 
-#: rdt 应从固定 git 源安装（PyPI 落后），断链处方与 probe 默认的 pipx/uv 不同
+#: rdt should be installed from a pinned git source (PyPI lags behind), so its broken-install hint differs from probe's default pipx/uv one
 _RDT_BROKEN_HINT = (
-    "rdt 命令存在但无法执行——通常是系统 Python 升级后 venv 解释器丢失。\n"
-    "PyPI 版本落后，推荐用固定 git 源强制重装：\n"
+    "rdt command exists but cannot execute — usually the venv interpreter went missing after a system Python upgrade.\n"
+    "The PyPI release lags behind; a force-reinstall from the pinned git source is recommended:\n"
     f"  pipx install --force '{_RDT_GIT_SOURCE}'"
 )
 
 
 class RedditChannel(Channel):
     name = "reddit"
-    description = "Reddit 帖子和评论"
+    description = "Reddit posts and comments"
     backends = ["OpenCLI", "rdt-cli"]
     tier = 1  # no zero-config path exists — see module docstring
 
@@ -68,13 +68,13 @@ class RedditChannel(Channel):
             return "error", "\n".join(m for _, _, m in findings)
 
         return "off", (
-            "未安装任何 Reddit 后端。注意：Reddit 没有零配置路径"
-            "（匿名 .json 已被封，官方 API 需人工审批），必须用登录态。推荐：\n"
-            "  桌面：agent-reach install --channels opencli\n"
-            "       （复用 Chrome 登录态，登录过 reddit.com 即可用）\n"
-            f"  服务器/存量：pipx install '{_RDT_GIT_SOURCE}'\n"
-            "       然后 `rdt login` 或手动写入 Cookie（见 doctor 提示）\n"
-            "中国大陆访问 Reddit 需要代理"
+            "No Reddit backend installed. Note: Reddit has no zero-config path "
+            "(anonymous .json is blocked, the official API requires manual approval) — a logged-in session is required. Recommended:\n"
+            "  Desktop: agent-reach install --channels opencli\n"
+            "       (reuses your Chrome login session; works once you've logged into reddit.com)\n"
+            f"  Server/legacy: pipx install '{_RDT_GIT_SOURCE}'\n"
+            "       then run `rdt login` or manually write cookies (see doctor hints)\n"
+            "Accessing Reddit from mainland China requires a proxy"
         )
 
     def _check_opencli(self):
@@ -88,7 +88,7 @@ class RedditChannel(Channel):
             return "error", st.hint
         if st.ready:
             return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
+                "OpenCLI available (reuses browser login session). Usage: "
                 "opencli reddit search/read/subreddit/hot -f yaml"
             )
         return "warn", st.hint
@@ -99,10 +99,11 @@ class RedditChannel(Channel):
         if not rdt:
             return None
 
-        # 不走 probe_command：实测 `rdt status --json` 成功时（rc=0）也会向 stderr
-        # 打网络重试日志，probe 把 stdout+stderr 合并后 JSON 解析必炸。
-        # 故保留手写 subprocess（stdout 单独捕获），但异常分类对齐 probe 语义：
-        # exec 失败/126/127 → broken（venv 断链处方），TimeoutExpired → 超时。
+        # Not using probe_command: live testing shows `rdt status --json` writes network
+        # retry logs to stderr even on success (rc=0), and probe merges stdout+stderr before
+        # JSON parsing, which would break. So we keep a hand-rolled subprocess call (stdout
+        # captured separately), but align exception classification with probe's semantics:
+        # exec failure/126/127 -> broken (venv broken-install hint), TimeoutExpired -> timeout.
         try:
             r = subprocess.run(
                 [rdt, "status", "--json"],
@@ -113,9 +114,9 @@ class RedditChannel(Channel):
                 env=utf8_subprocess_env(),
             )
         except subprocess.TimeoutExpired:
-            return "error", "rdt 响应超时（>10s），Reddit 状态未知。稍后重试或运行 `rdt status` 查看详情"
+            return "error", "rdt timed out (>10s), Reddit status unknown. Retry later or run `rdt status` for details"
         except OSError:
-            # 含 FileNotFoundError：which 命中但 exec 失败 = venv 断链（probe 的 broken）
+            # Includes FileNotFoundError: which() found it but exec failed = broken venv (probe's "broken")
             return "error", _RDT_BROKEN_HINT
 
         if r.returncode in _BROKEN_EXIT_CODES:
@@ -123,16 +124,16 @@ class RedditChannel(Channel):
 
         if r.returncode != 0:
             detail = (r.stderr or r.stdout or "").strip().splitlines()
-            tail = detail[-1] if detail else "无输出"
-            return "error", f"rdt 异常退出（exit {r.returncode}）：{tail}。运行 `rdt status` 查看详情"
+            tail = detail[-1] if detail else "no output"
+            return "error", f"rdt exited abnormally (exit {r.returncode}): {tail}. Run `rdt status` for details"
 
-        # 进程正常退出 → rdt 本身是活的（无论登录与否）
+        # Process exited normally -> rdt itself is alive (regardless of login state)
         try:
             data = json.loads(r.stdout or "")
         except json.JSONDecodeError:
             data = None
         if not isinstance(data, dict):
-            return "warn", "rdt-cli 可用但状态输出无法解析，运行 `rdt status` 查看登录状态"
+            return "warn", "rdt-cli is available but its status output could not be parsed; run `rdt status` to check login state"
 
         info = data.get("data")
         if not isinstance(info, dict):
@@ -141,25 +142,25 @@ class RedditChannel(Channel):
         username = info.get("username") or ""
 
         if authenticated:
-            suffix = f"（已登录：{username}）" if username else ""
+            suffix = f" (logged in: {username})" if username else ""
             return "ok", (
-                f"rdt-cli 可用{suffix}（搜索帖子、阅读全文、查看评论；"
-                "上游 2026-03 起停更，桌面用户建议迁移到 OpenCLI）"
+                f"rdt-cli available{suffix} (search posts, read full text, view comments; "
+                "upstream unmaintained since 2026-03, desktop users are encouraged to migrate to OpenCLI)"
             )
 
         return "warn", (
-            "rdt-cli 已安装但未登录。Reddit 自 2024 年起要求认证，"
-            "未登录时所有请求均返回 403。\n\n"
-            "方法一（自动）：运行 `rdt login`\n"
-            "  先在浏览器登录 reddit.com，再运行此命令自动提取 Cookie。\n\n"
-            "方法二（手动，适用于 Chrome/Edge 127+ 无法自动提取时）：\n"
-            "  1. Chrome 应用商店安装 Cookie-Editor 扩展：\n"
+            "rdt-cli is installed but not logged in. Reddit has required authentication since 2024; "
+            "all requests return 403 while logged out.\n\n"
+            "Method 1 (automatic): run `rdt login`\n"
+            "  Log into reddit.com in your browser first, then run this command to auto-extract cookies.\n\n"
+            "Method 2 (manual, for when Chrome/Edge 127+ can't auto-extract):\n"
+            "  1. Install the Cookie-Editor extension from the Chrome Web Store:\n"
             "     https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm\n"
-            "  2. 在浏览器打开 reddit.com（确保已登录）\n"
-            "  3. 点击 Cookie-Editor 图标，找到 `reddit_session`，复制其 Value\n"
-            f"  4. 将以下内容写入 {_CREDENTIAL_FILE}：\n"
-            '     {"cookies": {"reddit_session": "<粘贴 Value>"}, '
-            '"source": "manual", "username": "<你的用户名>", '
+            "  2. Open reddit.com in your browser (make sure you're logged in)\n"
+            "  3. Click the Cookie-Editor icon, find `reddit_session`, and copy its Value\n"
+            f"  4. Write the following into {_CREDENTIAL_FILE}:\n"
+            '     {"cookies": {"reddit_session": "<paste Value>"}, '
+            '"source": "manual", "username": "<your username>", '
             '"modhash": null, "saved_at": 0, "last_verified_at": null}\n\n'
-            "验证：`rdt status --json` 确认 authenticated: true"
+            "Verify: `rdt status --json` should show authenticated: true"
         )

--- a/agent_reach/channels/rss.py
+++ b/agent_reach/channels/rss.py
@@ -6,7 +6,7 @@ from .base import Channel
 
 class RSSChannel(Channel):
     name = "rss"
-    description = "RSS/Atom 订阅源"
+    description = "RSS/Atom feeds"
     backends = ["feedparser"]
     tier = 0
 
@@ -18,10 +18,10 @@ class RSSChannel(Channel):
             import feedparser  # noqa: F401
         except ImportError:
             self.active_backend = None
-            return "off", "feedparser 未安装。安装：pip install feedparser"
+            return "off", "feedparser not installed. Install: pip install feedparser"
         except Exception as e:
-            # 已安装但导入期崩溃（半残安装/版本冲突）→ 重装处方
+            # Installed but crashes on import (half-broken install / version conflict) -> reinstall hint
             self.active_backend = None
-            return "error", f"feedparser 导入失败：{e}\n修复：pip install --force-reinstall feedparser"
+            return "error", f"feedparser import failed: {e}\nFix: pip install --force-reinstall feedparser"
         self.active_backend = self.backends[0]
-        return "ok", "可读取 RSS/Atom 源"
+        return "ok", "Can read RSS/Atom feeds"

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -7,7 +7,7 @@ from agent_reach.probe import probe_command
 
 class TwitterChannel(Channel):
     name = "twitter"
-    description = "Twitter/X 推文"
+    description = "Twitter/X tweets"
     backends = ["twitter-cli", "OpenCLI", "bird CLI (legacy)"]
     tier = 1
 
@@ -19,9 +19,11 @@ class TwitterChannel(Channel):
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.
 
-        与其他多后端渠道同一套两段式：先收集全部候选状态，第一个 ok 获胜；
-        没有 ok 才轮到第一个 warn——否则「装了但未登录」的 twitter-cli
-        会把排在后面、完整可用的 OpenCLI 挡在门外。
+        Same two-phase approach as other multi-backend channels: collect all
+        candidate statuses first, the first "ok" wins; only fall through to
+        the first "warn" if there's no "ok" — otherwise an "installed but
+        not logged in" twitter-cli would block a fully-usable OpenCLI
+        further down the list.
         """
         self.active_backend = None
         findings = []
@@ -37,7 +39,7 @@ class TwitterChannel(Channel):
                 continue
 
             if result is None:
-                continue  # 未安装——不参与候选
+                continue  # not installed — not a candidate
             findings.append((backend, *result))
 
         for wanted in ("ok", "warn"):
@@ -46,22 +48,23 @@ class TwitterChannel(Channel):
                     self.active_backend = backend
                     return status, message
 
-        if findings:  # 只剩 broken/timeout 候选
+        if findings:  # only broken/timeout candidates remain
             return "error", "\n".join(m for _, _, m in findings)
 
         return "warn", (
-            "Twitter CLI 未安装。安装方式：\n"
+            "Twitter CLI not installed. Install with:\n"
             "  pipx install twitter-cli\n"
-            "或：\n"
+            "or:\n"
             "  uv tool install twitter-cli"
         )
 
     def _check_twitter_cli(self):
-        """探测 twitter-cli。返回 None 表示未安装，否则返回 (status, message)。
+        """Probe twitter-cli. Returns None if not installed, otherwise (status, message).
 
-        `twitter status` 才是健康信号：已登录时输出 "ok: true"，
-        未登录时以非零退出码输出 "not_authenticated"——工具本身是活的，
-        所以 probe 的 error 状态也要看 output 内容再分类。
+        `twitter status` is the real health signal: it prints "ok: true" when
+        logged in, and "not_authenticated" with a non-zero exit code when not
+        logged in — the tool itself is alive, so probe's "error" status still
+        needs to be reclassified by looking at the output content.
         """
         probe = probe_command(
             "twitter", ["status"], timeout=15, retries=1, package="twitter-cli"
@@ -69,26 +72,26 @@ class TwitterChannel(Channel):
         if probe.status == "missing":
             return None
         if probe.status == "broken":
-            return "error", "twitter-cli 命令存在但无法执行。\n" + probe.hint
+            return "error", "twitter-cli command exists but cannot execute.\n" + probe.hint
         if probe.status == "timeout":
-            return "error", "twitter-cli 健康检查超时（已重试 1 次）。\n" + probe.hint
+            return "error", "twitter-cli health check timed out (retried once).\n" + probe.hint
 
         output = probe.output
         if "ok: true" in output:
             return "ok", (
-                "twitter-cli 完整可用（搜索、读推文、时间线、长文/Article、"
-                "用户查询、Thread）"
+                "twitter-cli fully available (search, read tweets, timeline, long-form/Article, "
+                "user lookup, threads)"
             )
         if "not_authenticated" in output:
             return "warn", (
-                "twitter-cli 已安装但未认证。设置方式：\n"
+                "twitter-cli is installed but not authenticated. Set up with:\n"
                 "  export TWITTER_AUTH_TOKEN=\"xxx\"\n"
                 "  export TWITTER_CT0=\"yyy\"\n"
-                "或确保已在浏览器中登录 x.com"
+                "or make sure you're logged into x.com in your browser"
             )
         return "warn", (
-            "twitter-cli 已安装但认证检查失败。运行：\n"
-            "  twitter -v status 查看详细信息"
+            "twitter-cli is installed but the auth check failed. Run:\n"
+            "  twitter -v status for details"
         )
 
     def _check_opencli(self):
@@ -102,13 +105,13 @@ class TwitterChannel(Channel):
             return "error", st.hint
         if st.ready:
             return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
+                "OpenCLI available (reuses browser login session). Usage: "
                 "opencli twitter search/article/user-posts -f yaml"
             )
         return "warn", st.hint
 
     def _check_bird(self):
-        """探测 bird/birdx（legacy 回退）。返回 None 表示均未安装，否则返回 (status, message)。"""
+        """Probe bird/birdx (legacy fallback). Returns None if neither is installed, otherwise (status, message)."""
         last_failure = None
         for cmd in ("bird", "birdx"):
             probe = probe_command(
@@ -119,27 +122,27 @@ class TwitterChannel(Channel):
             if probe.status == "broken":
                 last_failure = (
                     "error",
-                    f"{cmd} 命令存在但无法执行（bird 是 npm 包，可用 "
-                    "npm install -g @steipete/bird 重装）。\n" + probe.hint,
+                    f"{cmd} command exists but cannot execute (bird is an npm package; reinstall with "
+                    "npm install -g @steipete/bird).\n" + probe.hint,
                 )
-                continue  # bird 坏了再试 birdx
+                continue  # bird is broken, still try birdx
             if probe.status == "timeout":
                 last_failure = (
                     "error",
-                    f"{cmd} 健康检查超时（已重试 1 次）。\n" + probe.hint,
+                    f"{cmd} health check timed out (retried once).\n" + probe.hint,
                 )
                 continue
 
             output = probe.output
             if probe.ok:
-                return "ok", "bird CLI 可用（读取、搜索推文，含长文/X Article）"
+                return "ok", "bird CLI available (read, search tweets, including long-form/X Article)"
             if "Missing credentials" in output or "missing" in output.lower():
                 return "warn", (
-                    "bird CLI 已安装但未配置认证。设置环境变量：\n"
+                    "bird CLI is installed but authentication is not configured. Set environment variables:\n"
                     "  export AUTH_TOKEN=\"xxx\"\n"
                     "  export CT0=\"yyy\""
                 )
             return "warn", (
-                "bird CLI 已安装但认证检查失败。"
+                "bird CLI is installed but the auth check failed."
             )
         return last_failure

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -19,7 +19,7 @@ def _get_json(url: str) -> Any:
 
 class V2EXChannel(Channel):
     name = "v2ex"
-    description = "V2EX 节点、主题与回复"
+    description = "V2EX nodes, topics, and replies"
     backends = ["V2EX API (public)"]
     tier = 0
 
@@ -42,10 +42,10 @@ class V2EXChannel(Channel):
                 "https://www.v2ex.com/api/topics/show.json?node_name=python&page=1"
             )
             self.active_backend = self.backends[0]
-            return "ok", "公开 API 可用（热门主题、节点浏览、主题详情、用户信息）"
+            return "ok", "Public API available (hot topics, node browsing, topic details, user info)"
         except Exception as e:
             self.active_backend = None
-            return "warn", f"V2EX API 连接失败（可能需要代理）：{e}"
+            return "warn", f"V2EX API connection failed (a proxy may be required): {e}"
 
     # ------------------------------------------------------------------ #
     # Data-fetching methods
@@ -206,9 +206,9 @@ class V2EXChannel(Channel):
         return [
             {
                 "error": (
-                    "V2EX 公开 API 不提供搜索端点。"
-                    f"建议改用：https://www.v2ex.com/?q={query} "
-                    "或通过 Exa channel 使用 site:v2ex.com 搜索。"
+                    "The V2EX public API does not provide a search endpoint. "
+                    f"Try instead: https://www.v2ex.com/?q={query} "
+                    "or search with site:v2ex.com via the Exa channel."
                 )
             }
         ]

--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -9,7 +9,7 @@ _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 
 class WebChannel(Channel):
     name = "web"
-    description = "任意网页"
+    description = "Any webpage"
     backends = ["Jina Reader"]
     tier = 0
 
@@ -17,12 +17,12 @@ class WebChannel(Channel):
         return True  # Fallback — handles any URL
 
     def check(self, config=None):
-        # 恒可用兜底渠道：无本地命令、不做网络探测（doctor 已有多个渠道触网），保持零开销
+        # Always-available fallback channel: no local command, no network probing (doctor already touches the network via other channels), keep it zero-overhead
         self.active_backend = self.backends[0]
-        return "ok", "通过 Jina Reader 读取任意网页（curl https://r.jina.ai/URL）"
+        return "ok", "Reads any webpage via Jina Reader (curl https://r.jina.ai/URL)"
 
     def read(self, url: str) -> str:
-        """通过 Jina Reader 读取网页，返回 Markdown 全文。"""
+        """Read a webpage via Jina Reader, returning the full Markdown text."""
         if not url.startswith(("http://", "https://")):
             url = "https://" + url
         jina_url = f"https://r.jina.ai/{url}"

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -148,7 +148,7 @@ def _clean_comment(comment):
 
 class XiaoHongShuChannel(Channel):
     name = "xiaohongshu"
-    description = "小红书笔记"
+    description = "XiaoHongShu (RED) notes"
     backends = ["OpenCLI", "xiaohongshu-mcp", "xhs-cli (xiaohongshu-cli)"]
     tier = 1
 
@@ -188,10 +188,10 @@ class XiaoHongShuChannel(Channel):
             return "error", "\n".join(m for _, _, m in findings)
 
         return "off", (
-            "未安装任何小红书后端。推荐：\n"
-            "  桌面：agent-reach install --channels opencli\n"
-            "       （复用 Chrome 登录态，刷过小红书即零配置可用）\n"
-            f"  服务器：xiaohongshu-mcp（自带无头浏览器+扫码登录）：{_MCP_INSTALL_URL}"
+            "No XiaoHongShu backend installed. Recommended:\n"
+            "  Desktop: agent-reach install --channels opencli\n"
+            "       (reuses your Chrome login session; works zero-config once you've browsed XiaoHongShu)\n"
+            f"  Server: xiaohongshu-mcp (bundles a headless browser + QR login): {_MCP_INSTALL_URL}"
         )
 
     def _check_opencli(self):
@@ -205,7 +205,7 @@ class XiaoHongShuChannel(Channel):
             return "error", st.hint
         if st.ready:
             return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
+                "OpenCLI available (reuses browser login session). Usage: "
                 "opencli xiaohongshu search/note/comments/feed -f yaml"
             )
         return "warn", st.hint
@@ -219,12 +219,12 @@ class XiaoHongShuChannel(Channel):
         )
         if mcporter.ok and "xiaohongshu" in mcporter.output:
             return "ok", (
-                "xiaohongshu-mcp 服务运行中"
-                "（mcporter call 'xiaohongshu.search_feeds(keyword: \"...\")'）。"
-                "若未登录，让 agent 调 get_login_qrcode 扫码"
+                "xiaohongshu-mcp service running "
+                "(mcporter call 'xiaohongshu.search_feeds(keyword: \"...\")'). "
+                "If not logged in, have the agent call get_login_qrcode to scan a QR code"
             )
         return "warn", (
-            "xiaohongshu-mcp 服务在跑但 mcporter 未接入。运行：\n"
+            "xiaohongshu-mcp service is running but mcporter is not connected to it. Run:\n"
             f"  mcporter config add xiaohongshu {_MCP_ENDPOINT}"
         )
 
@@ -236,23 +236,23 @@ class XiaoHongShuChannel(Channel):
         if probe.status == "missing":
             return None
         if probe.status == "broken":
-            return "error", "xhs 命令存在但无法执行\n" + probe.hint
+            return "error", "xhs command exists but cannot execute\n" + probe.hint
         if probe.status == "timeout":
-            return "warn", "xhs-cli 已安装但状态检测超时\n" + probe.hint
+            return "warn", "xhs-cli is installed but the status check timed out\n" + probe.hint
 
-        # 进程是活的（执行成功或运行后非零退出）——按输出内容分类
+        # The process is alive (ran successfully or exited non-zero) — classify by output content
         if probe.ok and "ok: true" in probe.output:
             return "ok", (
-                "xhs-cli 可用（搜索、阅读、评论、热门；上游 2026-03 起停更，"
-                "桌面用户建议迁移到 OpenCLI）"
+                "xhs-cli available (search, read, comment, trending; upstream unmaintained since 2026-03, "
+                "desktop users are encouraged to migrate to OpenCLI)"
             )
         if "not_authenticated" in probe.output or "expired" in probe.output:
             return "warn", (
-                "xhs-cli 已安装但未登录。运行：\n"
+                "xhs-cli is installed but not logged in. Run:\n"
                 "  xhs login\n"
-                "（自动从浏览器提取 Cookie，或扫码登录）"
+                "(auto-extracts cookies from your browser, or scan a QR code to log in)"
             )
         return "warn", (
-            "xhs-cli 已安装但状态异常。运行：\n"
-            "  xhs -v status 查看详细信息"
+            "xhs-cli is installed but its status is abnormal. Run:\n"
+            "  xhs -v status for details"
         )

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -9,7 +9,7 @@ from .base import Channel
 
 class XiaoyuzhouChannel(Channel):
     name = "xiaoyuzhou"
-    description = "小宇宙播客转文字"
+    description = "Xiaoyuzhou podcast transcription"
     backends = ["groq-whisper", "ffmpeg"]
     tier = 1
 
@@ -26,22 +26,22 @@ class XiaoyuzhouChannel(Channel):
         probe = probe_command("ffmpeg", ["-version"], timeout=10, package="ffmpeg")
         if probe.status == "missing":
             return "off", (
-                "需要 ffmpeg（音频转码和切片）。安装：\n"
+                "Requires ffmpeg (audio transcoding and slicing). Install:\n"
                 "  Ubuntu/Debian: apt install -y ffmpeg\n"
                 "  macOS: brew install ffmpeg"
             )
         if not probe.ok:
             return "error", (
-                "ffmpeg 无法执行，重装：brew install ffmpeg（macOS）/ apt install ffmpeg（Linux）"
+                "ffmpeg cannot execute, reinstall: brew install ffmpeg (macOS) / apt install ffmpeg (Linux)"
             )
 
         # Check script exists
         script = os.path.expanduser("~/.agent-reach/tools/xiaoyuzhou/transcribe.sh")
         if not os.path.isfile(script):
             return "off", (
-                "转录脚本未安装。运行：\n"
+                "Transcription script not installed. Run:\n"
                 "  agent-reach install --env=auto\n"
-                "  或手动复制 transcribe.sh 到 ~/.agent-reach/tools/xiaoyuzhou/"
+                "  or manually copy transcribe.sh to ~/.agent-reach/tools/xiaoyuzhou/"
             )
 
         # Check GROQ_API_KEY — prefer env var, fall back to Agent Reach config
@@ -54,10 +54,10 @@ class XiaoyuzhouChannel(Channel):
                 has_key = False
         if not has_key:
             return "warn", (
-                "需要配置 Groq API Key（免费）。步骤：\n"
-                "  1. 注册 https://console.groq.com\n"
-                "  2. 运行: agent-reach configure groq-key gsk_xxxxx"
+                "Requires a Groq API Key (free). Steps:\n"
+                "  1. Sign up at https://console.groq.com\n"
+                "  2. Run: agent-reach configure groq-key gsk_xxxxx"
             )
 
         self.active_backend = "groq-whisper"
-        return "ok", "完整可用（播客下载 + Whisper 转录）"
+        return "ok", "Fully available (podcast download + Whisper transcription)"

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -148,8 +148,8 @@ def _strip_html(text: str) -> str:
 
 class XueqiuChannel(Channel):
     name = "xueqiu"
-    description = "雪球股票行情与社区动态"
-    backends = ["Xueqiu API (需要登录 Cookie)"]
+    description = "Xueqiu stock quotes and community updates"
+    backends = ["Xueqiu API (requires login cookie)"]
     tier = 1
 
     # ------------------------------------------------------------------ #
@@ -173,12 +173,12 @@ class XueqiuChannel(Channel):
             items = (data.get("data") or {}).get("items") or []
             if items:
                 self.active_backend = self.backends[0]
-                return "ok", "公开 API 可用（行情、搜索、热帖、热股）"
-            return "warn", "API 响应异常（返回数据为空）"
+                return "ok", "Public API available (quotes, search, hot posts, hot stocks)"
+            return "warn", "API response is abnormal (empty data returned)"
         except Exception as e:
             return "warn", (
-                f"Xueqiu API 连接失败：{e}。"
-                "请先登录雪球后运行：agent-reach configure --from-browser chrome"
+                f"Xueqiu API connection failed: {e}. "
+                "Please log into Xueqiu first, then run: agent-reach configure --from-browser chrome"
             )
 
     # ------------------------------------------------------------------ #

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -22,7 +22,7 @@ def _has_js_runtime_config(config_path) -> bool:
 
 class YouTubeChannel(Channel):
     name = "youtube"
-    description = "YouTube 视频和字幕"
+    description = "YouTube videos and subtitles"
     backends = ["yt-dlp"]
     tier = 0
 
@@ -33,26 +33,26 @@ class YouTubeChannel(Channel):
         return "youtube.com" in d or "youtu.be" in d
 
     def check(self, config=None):
-        # 真跑 yt-dlp --version 探活，区分未装 / venv 断链 / 跑不动
+        # Actually run yt-dlp --version as a live probe, to distinguish not-installed / broken venv / won't run
         probe = probe_command("yt-dlp", ["--version"], timeout=10, package="yt-dlp")
         if probe.status == "missing":
             self.active_backend = None
-            return "off", "yt-dlp 未安装。安装：pip install yt-dlp"
+            return "off", "yt-dlp not installed. Install: pip install yt-dlp"
         if probe.status == "broken":
             self.active_backend = None
-            return "error", f"yt-dlp 已安装但无法执行\n{probe.hint}"
-        if not probe.ok:  # timeout / error：装了但跑不动
+            return "error", f"yt-dlp is installed but cannot execute\n{probe.hint}"
+        if not probe.ok:  # timeout / error: installed but won't run
             self.active_backend = None
             detail = probe.hint or probe.output or probe.status
-            return "error", f"yt-dlp 无法正常运行：{detail}"
-        # yt-dlp 本体是活的；后面的 JS runtime/转写检查只影响 ok/warn，不影响后端归属
+            return "error", f"yt-dlp isn't running correctly: {detail}"
+        # yt-dlp itself is alive; the JS runtime/transcription checks below only affect ok/warn, not backend attribution
         self.active_backend = "yt-dlp"
         # Check JS runtime
         has_js = shutil.which("deno") or shutil.which("node")
         if not has_js:
             return "warn", (
-                "yt-dlp 已安装但缺少 JS runtime（YouTube 必须）。\n"
-                "  安装 Node.js 或 deno，然后运行：agent-reach install"
+                "yt-dlp is installed but missing a JS runtime (required for YouTube).\n"
+                "  Install Node.js or deno, then run: agent-reach install"
             )
         # Check yt-dlp config for --js-runtimes
         # Deno works out of the box; Node.js requires explicit config
@@ -61,10 +61,10 @@ class YouTubeChannel(Channel):
             ytdlp_config = get_ytdlp_config_path()
             if not _has_js_runtime_config(ytdlp_config):
                 return "warn", (
-                    f"yt-dlp 已安装但未配置 JS runtime。运行：\n  {render_ytdlp_fix_command()}"
+                    f"yt-dlp is installed but the JS runtime is not configured. Run:\n  {render_ytdlp_fix_command()}"
                 )
         # Surface transcription readiness so `doctor` reports it.
-        msg = "可提取视频信息和字幕"
+        msg = "Can extract video info and subtitles"
         if config is not None:
             providers = []
             if config.is_configured("groq_whisper"):
@@ -73,9 +73,9 @@ class YouTubeChannel(Channel):
                 providers.append("openai")
             if providers:
                 if not shutil.which("ffmpeg"):
-                    msg += "（音频转写需安装 ffmpeg）"
+                    msg += " (audio transcription requires ffmpeg)"
                 else:
-                    msg += f"，可转写音频（{'→'.join(providers)}）"
+                    msg += f", can transcribe audio ({'→'.join(providers)})"
         return "ok", msg
 
     def transcribe(self, url: str, *, provider: str = "auto", config=None) -> str:

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -240,7 +240,7 @@ def _cmd_install(args):
         else:
             config.set("proxy", args.proxy)
             config.set("bilibili_proxy", args.proxy)  # legacy key
-            print(f"✅ 代理已保存（Agent 访问受限网络时使用）")
+            print(f"✅ Proxy saved (used by the Agent to access restricted networks)")
 
     # ── Install core system dependencies (lightweight, always) ──
     print()
@@ -262,7 +262,7 @@ def _cmd_install(args):
 
     if server_skipped_opencli_channels:
         print()
-        print("  -- OpenCLI 需要桌面环境 + Chrome，服务器环境跳过："
+        print("  -- OpenCLI requires a desktop environment + Chrome; skipped on server: "
               f"{', '.join(sorted(server_skipped_opencli_channels))}")
 
     # ── Install optional channels (only if --channels specified) ──
@@ -312,9 +312,9 @@ def _cmd_install(args):
     # Environment-specific advice
     if env == "server":
         print()
-        print("Tip: 部分平台对服务器 IP 有风控。")
-        print("   Reddit 必须登录态（rdt-cli + Cookie，见 doctor 提示），中国大陆网络还需代理。")
-        print("   保存代理供 Agent 使用：agent-reach configure proxy http://user:pass@ip:port")
+        print("Tip: some platforms rate-limit or block server IPs.")
+        print("   Reddit requires a logged-in session (rdt-cli + cookies, see doctor hints); mainland China networks also need a proxy.")
+        print("   Save a proxy for the Agent to use: agent-reach configure proxy http://user:pass@ip:port")
         print("   Cheap option: https://www.webshare.io ($1/month)")
 
     # Test channels
@@ -344,9 +344,9 @@ def _cmd_install(args):
 
         # Star reminder
         print()
-        print("如果 Agent Reach 帮到了你，给个 Star 让更多人发现它吧：")
+        print("If Agent Reach helped you, please star it so more people can find it:")
         print("   https://github.com/Panniantong/Agent-Reach")
-        print("   只需一秒，对独立开发者意义很大。谢谢！")
+        print("   It only takes a second and means a lot to an indie developer. Thank you!")
     else:
         print()
         print("Dry run complete. No changes were made.")
@@ -735,17 +735,17 @@ def _install_xhs_deps():
 
     print("Setting up XiaoHongShu...")
     if _detect_environment() == "server":
-        print("  服务器环境推荐 xiaohongshu-mcp（自带无头浏览器，扫码登录）：")
-        print("    1. 下载 binary：https://github.com/xpzouying/xiaohongshu-mcp/releases")
-        print("       （建议放到 ~/.agent-reach/tools/ 下）")
-        print("    2. 启动服务（首次运行会下载约 150MB 浏览器，请等待完成）")
-        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp")
-        print("    4. 验证：agent-reach doctor")
+        print("  On servers, xiaohongshu-mcp is recommended (bundles a headless browser, QR login):")
+        print("    1. Download the binary: https://github.com/xpzouying/xiaohongshu-mcp/releases")
+        print("       (recommended location: ~/.agent-reach/tools/)")
+        print("    2. Start the service (first run downloads ~150MB browser, please wait)")
+        print("    3. After scanning to log in, connect it: mcporter config add xiaohongshu http://localhost:18060/mcp")
+        print("    4. Verify: agent-reach doctor")
         return
 
     _install_opencli_deps()
     if shutil.which("xhs"):
-        print("  ✅ 检测到存量 xhs-cli，将作为备选后端继续可用")
+        print("  ✅ Detected an existing xhs-cli install; it will remain available as a fallback backend")
 
 
 def _install_opencli_deps():
@@ -775,7 +775,7 @@ def _install_opencli_deps():
 
     if not shutil.which("npm"):
         print("  [!]  OpenCLI requires Node.js ≥ 20. Install Node first:")
-        print("       https://nodejs.org  （或 brew install node）")
+        print("       https://nodejs.org  (or brew install node)")
         return
 
     try:
@@ -789,10 +789,10 @@ def _install_opencli_deps():
     st = opencli_status()
     if st.installed and not st.broken:
         print("  ✅ OpenCLI installed")
-        print("  最后一步（必须手动，Chrome 安全限制）：安装浏览器扩展")
-        print(f"    1. 打开 {OPENCLI_EXTENSION_URL}")
-        print("    2. 点「添加至 Chrome」")
-        print("    3. 运行 `opencli doctor` 验证连接")
+        print("  Last step (must be done manually, Chrome security restriction): install the browser extension")
+        print(f"    1. Open {OPENCLI_EXTENSION_URL}")
+        print("    2. Click \"Add to Chrome\"")
+        print("    3. Run `opencli doctor` to verify the connection")
     else:
         print(f"  [!]  OpenCLI install failed. Run: npm install -g {OPENCLI_PACKAGE}")
 
@@ -805,10 +805,10 @@ def _install_reddit_deps():
     """
     if _detect_environment() != "server":
         _install_opencli_deps()
-        print("  Reddit 走 OpenCLI（浏览器里登录过 reddit.com 即可用）")
+        print("  Reddit uses OpenCLI (works once you're logged into reddit.com in your browser)")
         import shutil
         if shutil.which("rdt"):
-            print("  ✅ 检测到存量 rdt-cli，将作为备选后端继续可用")
+            print("  ✅ Detected an existing rdt-cli install; it will remain available as a fallback backend")
         return
 
     _install_rdt_cli()
@@ -1066,8 +1066,8 @@ def _cmd_configure(args):
         # bilibili_proxy key is kept in sync for older configs.
         config.set("proxy", value)
         config.set("bilibili_proxy", value)
-        print("✅ 代理已保存（供 Agent 在访问 Reddit/Twitter 等需要代理的网络时设置 HTTP_PROXY/HTTPS_PROXY）")
-        print("  Note: B站走 bili-cli，国内网络无需代理。")
+        print("✅ Proxy saved (for the Agent to set HTTP_PROXY/HTTPS_PROXY when accessing networks like Reddit/Twitter that need a proxy)")
+        print("  Note: Bilibili uses bili-cli, no proxy needed on mainland China networks.")
 
     elif args.key == "twitter-cookies":
         # Accept two formats:
@@ -1506,13 +1506,13 @@ def _cmd_setup():
     import shutil
     import subprocess
 
-    print("【推荐】全网搜索 — Exa（通过 mcporter）")
-    print("  免费，无需 API Key")
+    print("[Recommended] Web-wide search — Exa (via mcporter)")
+    print("  Free, no API key needed")
 
     if not shutil.which("mcporter"):
-        print("  当前状态: -- mcporter 未安装")
-        print("  安装：npm install -g mcporter")
-        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  Current status: -- mcporter not installed")
+        print("  Install: npm install -g mcporter")
+        print("  Then: mcporter config add exa https://mcp.exa.ai/mcp")
         print()
     else:
         try:
@@ -1520,66 +1520,66 @@ def _cmd_setup():
                 ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=10
             )
             if "exa" in r.stdout.lower():
-                print("  当前状态: ✅ 已配置")
+                print("  Current status: ✅ Configured")
             else:
-                print("  当前状态: -- 未配置")
-                setup_now = input("  现在自动配置 Exa 吗？[Y/n]: ").strip().lower()
+                print("  Current status: -- Not configured")
+                setup_now = input("  Auto-configure Exa now? [Y/n]: ").strip().lower()
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
                         ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
                         capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                     )
                     if add_r.returncode == 0:
-                        print("  ✅ Exa 已配置")
+                        print("  ✅ Exa configured")
                     else:
-                        print("  [!] 自动配置失败，请手动执行：")
+                        print("  [!] Auto-configuration failed, please run manually:")
                         print("     mcporter config add exa https://mcp.exa.ai/mcp")
         except Exception:
-            print("  [!] 无法检查 Exa 配置，请手动执行：")
+            print("  [!] Could not check Exa configuration, please run manually:")
             print("     mcporter config add exa https://mcp.exa.ai/mcp")
         print()
 
     # Step 2: GitHub token
-    print("【可选】GitHub Token — 提高 API 限额")
-    print("  无 token: 60 次/小时 | 有 token: 5000 次/小时")
-    print("  获取: https://github.com/settings/tokens (无需任何权限)")
+    print("[Optional] GitHub Token — raise the API rate limit")
+    print("  No token: 60/hour | With token: 5000/hour")
+    print("  Get one: https://github.com/settings/tokens (no scopes needed)")
     current = config.get("github_token")
     if current:
-        print(f"  当前状态: ✅ 已配置")
+        print(f"  Current status: ✅ Configured")
     else:
-        key = input("  GITHUB_TOKEN (回车跳过): ").strip()
+        key = input("  GITHUB_TOKEN (press Enter to skip): ").strip()
         if key:
             config.set("github_token", key)
-            print("  ✅ GitHub API 已提升至 5000 次/小时！")
+            print("  ✅ GitHub API limit raised to 5000/hour!")
         else:
-            print("  跳过。公开 API 也能用")
+            print("  Skipped. The public API still works")
     print()
 
     # Step 3: Reddit — rdt-cli
-    print("【信息】Reddit — 必须登录态（无零配置路径）。桌面推荐 OpenCLI；或 rdt-cli：")
-    print(f"  安装：pipx install '{_RDT_GIT_SOURCE}'")
-    print("  然后运行：rdt login（需先在浏览器登录 reddit.com）")
+    print("[Info] Reddit — requires a logged-in session (no zero-config path). OpenCLI is recommended on desktop; or use rdt-cli:")
+    print(f"  Install: pipx install '{_RDT_GIT_SOURCE}'")
+    print("  Then run: rdt login (log into reddit.com in your browser first)")
     print()
 
     # Step 4: Groq (Whisper)
-    print("【可选】Groq API — 视频无字幕时的语音转文字")
-    print("  免费额度，注册: https://console.groq.com")
+    print("[Optional] Groq API — speech-to-text for videos without subtitles")
+    print("  Free tier, sign up: https://console.groq.com")
     current = config.get("groq_api_key")
     if current:
-        print(f"  当前状态: ✅ 已配置")
+        print(f"  Current status: ✅ Configured")
     else:
-        key = input("  GROQ_API_KEY (回车跳过): ").strip()
+        key = input("  GROQ_API_KEY (press Enter to skip): ").strip()
         if key:
             config.set("groq_api_key", key)
-            print("  ✅ 语音转文字已开启！")
+            print("  ✅ Speech-to-text enabled!")
         else:
-            print("  跳过")
+            print("  Skipped")
     print()
 
     # Summary
     print("=" * 40)
-    print(f"✅ 配置已保存到 {config.config_path}")
-    print("运行 agent-reach doctor 查看完整状态")
+    print(f"✅ Configuration saved to {config.config_path}")
+    print("Run agent-reach doctor to see the full status")
     print()
 
 
@@ -1610,15 +1610,15 @@ def _classify_update_error(exc):
 def _update_error_text(kind):
     """Map internal error kinds to user-facing text."""
     mapping = {
-        "timeout": "网络超时",
-        "dns": "DNS 解析失败",
-        "rate_limit": "GitHub API 速率限制",
-        "connection": "网络连接失败",
-        "server_error": "GitHub 服务暂时不可用",
-        "http": "HTTP 请求失败",
-        "unknown": "未知网络错误",
+        "timeout": "network timeout",
+        "dns": "DNS resolution failed",
+        "rate_limit": "GitHub API rate limit",
+        "connection": "network connection failed",
+        "server_error": "GitHub service temporarily unavailable",
+        "http": "HTTP request failed",
+        "unknown": "unknown network error",
     }
-    return mapping.get(kind, "请求失败")
+    return mapping.get(kind, "request failed")
 
 
 def _classify_github_response_error(resp):
@@ -1677,9 +1677,9 @@ def _github_get_with_retry(url, timeout=10, retries=3, sleeper=time.sleep):
 #: Full update = package + upstream tools + skill. The one-liner walks an
 #: agent through all three (docs/update.md); bare pip only updates the package.
 _UPDATE_INSTRUCTIONS = (
-    "更新方式（推荐，复制这句话给你的 AI Agent，会完整更新本体+上游工具+skill）：\n"
-    "  帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md\n"
-    "仅更新本体（不含上游工具和 skill）：\n"
+    "How to update (recommended — paste this to your AI Agent for a full update of the package + upstream tools + skill):\n"
+    "  Help me update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md\n"
+    "Package only (excludes upstream tools and skill):\n"
     "  pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip"
 )
 
@@ -1707,14 +1707,14 @@ def _cmd_check_update():
     """Check for newer versions on GitHub."""
     from agent_reach import __version__
 
-    print(f"当前版本: v{__version__}")
+    print(f"Current version: v{__version__}")
     release_url = "https://api.github.com/repos/Panniantong/Agent-Reach/releases/latest"
     commit_url = "https://api.github.com/repos/Panniantong/Agent-Reach/commits/main"
 
     # Fetch latest release with retry/backoff.
     resp, err, attempts = _github_get_with_retry(release_url, timeout=10, retries=3)
     if err:
-        print(f"[!] 无法检查更新（{_update_error_text(err)}，已重试 {attempts} 次）")
+        print(f"[!] Could not check for updates ({_update_error_text(err)}, retried {attempts} times)")
         return "error"
 
     if resp.status_code == 200:
@@ -1723,45 +1723,45 @@ def _cmd_check_update():
         body = data.get("body", "")
 
         if latest and _is_newer_version(latest, __version__):
-            print(f"最新版本: v{latest} ← 有更新！")
+            print(f"Latest version: v{latest} ← update available!")
             if body:
                 print()
-                print("更新内容：")
+                print("What's new:")
                 # Show first 20 lines of release notes
                 for line in body.strip().split("\n")[:20]:
                     print(f"  {line}")
             print()
             print(_UPDATE_INSTRUCTIONS)
             return "update_available"
-        print(f"✅ 已是最新版本")
+        print(f"✅ Already up to date")
         return "up_to_date"
 
     release_err = _classify_github_response_error(resp)
     if release_err == "rate_limit":
-        print("[!] 无法检查更新（GitHub API 速率限制，请稍后重试）")
+        print("[!] Could not check for updates (GitHub API rate limit, please retry later)")
         return "error"
 
     # No releases yet, fall back to latest main commit.
     resp2, err2, attempts2 = _github_get_with_retry(commit_url, timeout=10, retries=2)
     if err2:
-        print(f"[!] 无法检查更新（{_update_error_text(err2)}，已重试 {attempts + attempts2} 次）")
+        print(f"[!] Could not check for updates ({_update_error_text(err2)}, retried {attempts + attempts2} times)")
         return "error"
     if resp2.status_code == 200:
         commit = resp2.json()
         sha = commit.get("sha", "")[:7]
         msg = commit.get("commit", {}).get("message", "").split("\n")[0]
         date = commit.get("commit", {}).get("committer", {}).get("date", "")[:10]
-        print(f"最新提交: {sha} ({date}) {msg}")
+        print(f"Latest commit: {sha} ({date}) {msg}")
         print()
         print(_UPDATE_INSTRUCTIONS)
         return "unknown"
 
     commit_err = _classify_github_response_error(resp2)
     if commit_err == "rate_limit":
-        print("[!] 无法检查更新（GitHub API 速率限制，请稍后重试）")
+        print("[!] Could not check for updates (GitHub API rate limit, please retry later)")
         return "error"
 
-    print(f"[!] 无法检查更新（GitHub 返回 {resp2.status_code}）")
+    print(f"[!] Could not check for updates (GitHub returned {resp2.status_code})")
     return "error"
 
 
@@ -1785,9 +1785,9 @@ def _cmd_watch():
     # Find broken channels (were working, now broken)
     for key, r in results.items():
         if r["status"] in ("off", "error"):
-            issues.append(f"[X] {r['name']}：{r['message']}")
+            issues.append(f"[X] {r['name']}: {r['message']}")
         elif r["status"] == "warn":
-            issues.append(f"[!] {r['name']}：{r['message']}")
+            issues.append(f"[!] {r['name']}: {r['message']}")
 
     # Check for updates
     update_available = False
@@ -1808,12 +1808,12 @@ def _cmd_watch():
 
     # Output
     if not issues and not update_available:
-        print(f"Agent Reach: 全部正常 ({ok}/{total} 渠道可用，v{__version__} 已是最新)")
+        print(f"Agent Reach: all clear ({ok}/{total} channels available, v{__version__} up to date)")
         return
 
-    print(f"Agent Reach 监控报告")
+    print(f"Agent Reach Monitoring Report")
     print(f"=" * 40)
-    print(f"版本: v{__version__}  |  渠道: {ok}/{total}")
+    print(f"Version: v{__version__}  |  Channels: {ok}/{total}")
 
     if issues:
         print()
@@ -1822,12 +1822,12 @@ def _cmd_watch():
 
     if update_available:
         print()
-        print(f"新版本可用: v{new_version}")
+        print(f"New version available: v{new_version}")
         if release_body:
             for line in release_body.strip().split("\n")[:10]:
                 print(f"    {line}")
-        print("  更新（一句话发给 Agent 即可完整更新）：")
-        print("    帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md")
+        print("  Update (paste this to your Agent for a full update):")
+        print("    Help me update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md")
 
 
 if __name__ == "__main__":

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -288,10 +288,10 @@ def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
         if cookie_str and "xq_a_token" in cookie_str:
             config.set("xueqiu_cookie", cookie_str)
             n_cookies = len(cookie_str.split(";"))
-            results_list.append(("Xueqiu", True, f"{n_cookies} cookies (含 xq_a_token)"))
+            results_list.append(("Xueqiu", True, f"{n_cookies} cookies (includes xq_a_token)"))
         elif cookie_str:
             results_list.append(("Xueqiu", False,
-                                 f"找到 {len(cookie_str.split(';'))} 个 Cookie 但缺少 xq_a_token，"
-                                 f"请先在 {browser} 中登录 xueqiu.com"))
+                                 f"Found {len(cookie_str.split(';'))} cookie(s) but xq_a_token is missing, "
+                                 f"please log into xueqiu.com in {browser} first"))
 
     return results_list

--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -23,7 +23,7 @@ def check_all(config: Config) -> Dict[str, dict]:
         except Exception as e:  # noqa: BLE001 — doctor must survive any channel
             # Channels are registry singletons: a stale active_backend from a
             # previous check must not leak into an errored result.
-            status, message, active = "error", f"体检异常：{e}", None
+            status, message, active = "error", f"Health check error: {e}", None
         results[ch.name] = {
             "status": status,
             "name": ch.description,
@@ -40,7 +40,7 @@ def _name_msg(r: dict, escape) -> str:
     text = f"[bold]{escape(r['name'])}[/bold] — {escape(r['message'])}"
     active = r.get("active_backend")
     if active and len(r.get("backends", [])) > 1:
-        text += f" [dim]（当前后端：{escape(active)}）[/dim]"
+        text += f" [dim](active backend: {escape(active)})[/dim]"
     return text
 
 
@@ -52,16 +52,16 @@ def format_report(results: Dict[str, dict]) -> str:
         escape = lambda x: x
 
     lines = []
-    lines.append("[bold cyan]Agent Reach 状态[/bold cyan]")
+    lines.append("[bold cyan]Agent Reach Status[/bold cyan]")
     lines.append("[cyan]" + "=" * 40 + "[/cyan]")
-    lines.append("图例：[green]✅[/green] 可用  [yellow][!][/yellow] 已装但需配置/登录  [red][X][/red] 未安装")
+    lines.append("Legend: [green]✅[/green] available  [yellow][!][/yellow] installed but needs config/login  [red][X][/red] not installed")
 
     ok_count = sum(1 for r in results.values() if r["status"] == "ok")
     total = len(results)
 
     # Tier 0 — zero config
     lines.append("")
-    lines.append("[bold]✅ 装好即用：[/bold]")
+    lines.append("[bold]✅ Ready to use:[/bold]")
     for key, r in results.items():
         if r["tier"] == 0:
             name_msg = _name_msg(r, escape)
@@ -78,7 +78,7 @@ def format_report(results: Dict[str, dict]) -> str:
     tier1_inactive = {k: r for k, r in tier1.items() if r["status"] != "ok"}
     if tier1_active:
         lines.append("")
-        lines.append("[bold]可选渠道（已安装）：[/bold]")
+        lines.append("[bold]Optional channels (installed):[/bold]")
         for key, r in tier1_active.items():
             lines.append(f"  [green]✅[/green] {_name_msg(r, escape)}")
 
@@ -89,21 +89,21 @@ def format_report(results: Dict[str, dict]) -> str:
     if tier2_active:
         if not tier1_active:
             lines.append("")
-            lines.append("[bold]可选渠道（已安装）：[/bold]")
+            lines.append("[bold]Optional channels (installed):[/bold]")
         for key, r in tier2_active.items():
             lines.append(f"  [green]✅[/green] {_name_msg(r, escape)}")
 
     lines.append("")
     status_color = "green" if ok_count == total else ("yellow" if ok_count > 0 else "red")
-    lines.append(f"状态：[{status_color}]{ok_count}/{total}[/{status_color}] 个渠道可用")
+    lines.append(f"Status: [{status_color}]{ok_count}/{total}[/{status_color}] channels available")
 
     # Summarize inactive optional channels in one line instead of listing each
     all_inactive = list(tier1_inactive.values()) + list(tier2_inactive.values())
     if all_inactive:
         names = [r["name"] for r in all_inactive]
         lines.append(
-            f"还有 {len(names)} 个可选渠道可以解锁（{'、'.join(names)}），"
-            "告诉你的 Agent「帮我装 XXX」即可"
+            f"{len(names)} more optional channel(s) available to unlock ({', '.join(names)}) — "
+            "just tell your Agent \"help me set up XXX\""
         )
 
     # Security check: config file permissions (Unix only)
@@ -118,9 +118,9 @@ def format_report(results: Dict[str, dict]) -> str:
             if mode & (stat.S_IRGRP | stat.S_IROTH):
                 lines.append("")
                 lines.append(
-                    "[bold red][!]  安全提示：config.yaml 权限过宽（其他用户可读）[/bold red]"
+                    "[bold red][!]  Security notice: config.yaml permissions are too open (readable by other users)[/bold red]"
                 )
-                lines.append("   修复：chmod 600 ~/.agent-reach/config.yaml")
+                lines.append("   Fix: chmod 600 ~/.agent-reach/config.yaml")
         except OSError:
             pass
 

--- a/agent_reach/probe.py
+++ b/agent_reach/probe.py
@@ -38,9 +38,9 @@ class ProbeResult:
 def reinstall_hint(package: str) -> str:
     """Prescription for a broken (stale-venv) CLI install."""
     return (
-        f"命令存在但无法执行——通常是系统 Python 升级后 venv 解释器丢失。重装即可修复：\n"
+        f"Command exists but cannot execute — usually the venv interpreter went missing after a system Python upgrade. Reinstalling fixes it:\n"
         f"  uv tool install --force {package}\n"
-        f"或：pipx reinstall {package}"
+        f"or: pipx reinstall {package}"
     )
 
 
@@ -92,7 +92,7 @@ def _run_once(path: str, args: Sequence[str], timeout: int, package: str) -> Pro
     except OSError:
         return ProbeResult("broken", hint=reinstall_hint(package))
     except subprocess.TimeoutExpired:
-        return ProbeResult("timeout", hint=f"`{path}` 响应超时（>{timeout}s）")
+        return ProbeResult("timeout", hint=f"`{path}` timed out (>{timeout}s)")
 
     if r.returncode in _BROKEN_EXIT_CODES:
         return ProbeResult("broken", hint=reinstall_hint(package))

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -84,14 +84,14 @@ class TestOpenCLISiteChannels:
             "agent_reach.backends.opencli_status",
             lambda: OpenCLIStatus(
                 installed=True,
-                hint="OpenCLI 已安装，但 Chrome 扩展未安装。",
+                hint="OpenCLI is installed, but the Chrome extension is not.",
             ),
         )
         ch = InstagramChannel()
         status, msg = ch.check()
         assert status == "warn"
         assert ch.active_backend == "OpenCLI"
-        assert "Chrome 扩展" in msg
+        assert "Chrome extension" in msg
 
 
 class TestV2EXChannel:
@@ -124,7 +124,7 @@ class TestV2EXChannel:
         )
         status, msg = V2EXChannel().check()
         assert status == "ok"
-        assert "公开 API 可用" in msg
+        assert "Public API available" in msg
 
     def test_check_warn_when_api_unreachable(self, monkeypatch):
         import urllib.request
@@ -135,7 +135,7 @@ class TestV2EXChannel:
         monkeypatch.setattr(urllib.request, "urlopen", raise_error)
         status, msg = V2EXChannel().check()
         assert status == "warn"
-        assert "失败" in msg
+        assert "failed" in msg
 
     # ------------------------------------------------------------------ #
     # get_hot_topics
@@ -425,7 +425,7 @@ class TestXueqiuChannel:
         monkeypatch.setattr(xueqiu_mod._opener, "open", lambda req, timeout=None: FakeResponse())
         status, msg = XueqiuChannel().check()
         assert status == "ok"
-        assert "公开 API 可用" in msg
+        assert "Public API available" in msg
 
     def test_check_warn_when_api_unreachable(self, monkeypatch):
         import agent_reach.channels.xueqiu as xueqiu_mod
@@ -438,7 +438,7 @@ class TestXueqiuChannel:
         monkeypatch.setattr(xueqiu_mod._opener, "open", raise_error)
         status, msg = XueqiuChannel().check()
         assert status == "warn"
-        assert "失败" in msg
+        assert "failed" in msg
 
     # ------------------------------------------------------------------ #
     # get_stock_quote
@@ -754,13 +754,13 @@ class TestRedditChannel:
         from agent_reach.channels.reddit import RedditChannel
         status, msg = RedditChannel().check()
         assert status == "off"
-        # 诚实口径：明说没有零配置路径，推荐 OpenCLI + rdt git 源
-        assert "零配置" in msg
+        # Honest framing: state plainly there's no zero-config path, recommend OpenCLI + rdt git source
+        assert "zero-config" in msg
         assert "opencli" in msg
         assert "git+https://github.com/public-clis/rdt-cli.git" in msg
 
     def test_opencli_ready_wins(self, monkeypatch):
-        self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用（复用浏览器登录态）"))
+        self._isolate(monkeypatch, opencli=("ok", "OpenCLI available (reuses browser login session)"))
         monkeypatch.setattr(shutil, "which", lambda _: None)
         from agent_reach.channels.reddit import RedditChannel
         ch = RedditChannel()
@@ -825,11 +825,11 @@ class TestRedditChannel:
         ch = RedditChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "rdt 异常退出" in msg
+        assert "rdt exited abnormally" in msg
         assert ch.active_backend is None
 
     def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
+        """which() finds it but exec raises FileNotFoundError (broken venv) -> error + reinstall hint."""
         self._isolate(monkeypatch)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
 
@@ -841,13 +841,13 @@ class TestRedditChannel:
         ch = RedditChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "无法执行" in msg
-        assert "pipx install --force" in msg  # rdt 专用 git 源重装处方
+        assert "cannot execute" in msg
+        assert "pipx install --force" in msg  # rdt-specific git source reinstall hint
         assert "git+https://github.com/public-clis/rdt-cli.git" in msg
         assert ch.active_backend is None
 
     def test_reports_error_with_reinstall_hint_on_exit_127(self, monkeypatch):
-        """退出码 127（找到但跑不动）同样按断链处理。"""
+        """Exit code 127 (found but won't run) is also treated as a broken install."""
         self._isolate(monkeypatch)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
 
@@ -901,7 +901,7 @@ class TestXiaoHongShuChannel:
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
         assert status == "ok"
-        assert "xhs-cli 可用" in msg
+        assert "xhs-cli available" in msg
         assert ch.active_backend == "xhs-cli (xiaohongshu-cli)"
 
     def test_reports_warn_when_not_authenticated(self, monkeypatch):
@@ -944,14 +944,14 @@ class TestXiaoHongShuChannel:
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "无法执行" in msg
+        assert "cannot execute" in msg
         assert "uv tool install --force xiaohongshu-cli" in msg
         assert "pipx reinstall xiaohongshu-cli" in msg
         assert ch.active_backend is None
 
     def test_opencli_ready_wins_over_cli(self, monkeypatch):
-        """OpenCLI 完整可用时按序获胜，即使 xhs-cli 也完整可用。"""
-        self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用（复用浏览器登录态）"))
+        """OpenCLI wins by priority order when fully available, even if xhs-cli is also fully available."""
+        self._isolate(monkeypatch, opencli=("ok", "OpenCLI available (reuses browser login session)"))
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
         def fake_run(cmd, **kwargs):
@@ -965,8 +965,8 @@ class TestXiaoHongShuChannel:
         assert ch.active_backend == "OpenCLI"
 
     def test_opencli_warn_loses_to_usable_cli(self, monkeypatch):
-        """OpenCLI 装了但扩展未连（warn）时，完整可用的 xhs-cli 获胜。"""
-        self._isolate(monkeypatch, opencli=("warn", "扩展未连接"))
+        """When OpenCLI is installed but its extension isn't connected (warn), a fully-usable xhs-cli wins."""
+        self._isolate(monkeypatch, opencli=("warn", "extension not connected"))
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
         def fake_run(cmd, **kwargs):
@@ -1019,8 +1019,8 @@ class TestXiaoHongShuChannel:
         assert ch.active_backend == "xiaohongshu-mcp"
 
     def test_backend_override_prefers_cli(self, monkeypatch):
-        """config xiaohongshu_backend=xhs-cli 时，即使 OpenCLI ready 也用 xhs-cli。"""
-        self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用"))
+        """When config xiaohongshu_backend=xhs-cli, use xhs-cli even if OpenCLI is ready."""
+        self._isolate(monkeypatch, opencli=("ok", "OpenCLI available"))
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
         def fake_run(cmd, **kwargs):
@@ -1064,11 +1064,11 @@ class TestBilibiliChannel:
         ch = BilibiliChannel()
         status, msg = ch.check()
         assert status == "ok"
-        assert "bili-cli 可用" in msg
+        assert "bili-cli available" in msg
         assert ch.active_backend == "bili-cli"
 
     def test_bili_broken_falls_back_to_api_with_hint_kept(self, monkeypatch):
-        """bili 断链 → API 兜底获胜，但重装处方必须保留在消息里。"""
+        """bili is broken -> the API fallback wins, but the reinstall hint must still surface in the message."""
         self._isolate(monkeypatch, api_ok=True)
         monkeypatch.setattr(
             shutil, "which",
@@ -1082,9 +1082,9 @@ class TestBilibiliChannel:
         from agent_reach.channels.bilibili import BilibiliChannel
         ch = BilibiliChannel()
         status, msg = ch.check()
-        assert status == "ok"  # 搜索 API 兜底
-        assert ch.active_backend == "B站搜索 API"
-        assert "备选后端异常" in msg
+        assert status == "ok"  # search API fallback
+        assert ch.active_backend == "Bilibili search API"
+        assert "fallback backend issue" in msg
         assert "pipx reinstall bilibili-cli" in msg
 
     def test_bili_broken_and_no_fallback_reports_error(self, monkeypatch):
@@ -1106,7 +1106,7 @@ class TestBilibiliChannel:
         assert ch.active_backend is None
 
     def test_opencli_serves_when_bili_missing(self, monkeypatch):
-        self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用（字幕）"), api_ok=True)
+        self._isolate(monkeypatch, opencli=("ok", "OpenCLI available (subtitles)"), api_ok=True)
         monkeypatch.setattr(shutil, "which", lambda _: None)
         from agent_reach.channels.bilibili import BilibiliChannel
         ch = BilibiliChannel()
@@ -1121,7 +1121,7 @@ class TestBilibiliChannel:
         ch = BilibiliChannel()
         status, msg = ch.check()
         assert status == "ok"
-        assert ch.active_backend == "B站搜索 API"
+        assert ch.active_backend == "Bilibili search API"
         assert "bilibili-cli" in msg
 
     def test_off_when_everything_unreachable(self, monkeypatch):
@@ -1136,7 +1136,7 @@ class TestBilibiliChannel:
 
 class TestYouTubeChannel:
     def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """yt-dlp which 命中但 exec 抛 FileNotFoundError → error + 重装处方。"""
+        """yt-dlp: which() finds it but exec raises FileNotFoundError -> error + reinstall hint."""
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/yt-dlp")
 
         def fake_run(cmd, **kwargs):
@@ -1147,14 +1147,14 @@ class TestYouTubeChannel:
         ch = YouTubeChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "无法执行" in msg
+        assert "cannot execute" in msg
         assert "uv tool install --force yt-dlp" in msg
         assert ch.active_backend is None
 
 
 class TestGitHubChannel:
     def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """gh which 命中但 exec 失败 → error + brew 重装处方（gh 不是 pip 包）。"""
+        """gh: which() finds it but exec fails -> error + brew reinstall hint (gh is not a pip package)."""
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
 
         def fake_run(cmd, **kwargs):
@@ -1165,7 +1165,7 @@ class TestGitHubChannel:
         ch = GitHubChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "无法执行" in msg
+        assert "cannot execute" in msg
         assert "brew reinstall gh" in msg
         assert ch.active_backend is None
 
@@ -1183,7 +1183,7 @@ class TestGitHubChannel:
         assert ch.active_backend == "gh CLI"
 
     def test_active_backend_set_when_unauthenticated(self, monkeypatch):
-        """gh auth status 非零退出是正常业务态（未登录）：warn 但后端可用。"""
+        """gh auth status exiting non-zero is a normal business state (not logged in): warn but backend available."""
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
 
         def fake_run(cmd, **kwargs):
@@ -1284,7 +1284,7 @@ class TestXiaoyuzhouChannel:
         ch = XiaoyuzhouChannel()
         status, msg = ch.check()
         assert status == "error"
-        assert "无法执行" in msg
+        assert "cannot execute" in msg
         assert "brew install ffmpeg" in msg
         assert ch.active_backend is None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -179,7 +179,7 @@ class TestCLI:
         )
 
         out = capsys.readouterr().out
-        assert "服务器环境跳过：facebook, instagram, opencli" in out
+        assert "skipped on server: facebook, instagram, opencli" in out
         assert "[dry-run] Would install optional channels: bilibili" in out
         assert "facebook, instagram, opencli, bilibili" not in out
 
@@ -263,8 +263,8 @@ class TestCheckUpdateRetry:
 
         captured = capsys.readouterr()
         assert result == "error"
-        assert "网络超时" in captured.out
-        assert "已重试 3 次" in captured.out
+        assert "network timeout" in captured.out
+        assert "retried 3 times" in captured.out
 
 
 class TestVersionCompare:
@@ -297,10 +297,10 @@ class TestWatchVersionCompare:
         monkeypatch.setattr(cli, "_github_get_with_retry", lambda *a, **k: (R(), None, 1))
         monkeypatch.setattr(
             "agent_reach.doctor.check_all",
-            lambda config: {"web": {"status": "ok", "name": "任意网页", "message": "ok",
+            lambda config: {"web": {"status": "ok", "name": "Any webpage", "message": "ok",
                             "tier": 0, "backends": ["Jina Reader"], "active_backend": "Jina Reader"}},
         )
         cli._cmd_watch()
         out = capsys.readouterr().out
-        assert "新版本可用" not in out
-        assert "全部正常" in out
+        assert "New version available" not in out
+        assert "all clear" in out

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -100,10 +100,10 @@ class TestDoctor:
         import re
         plain = re.sub(r"\[[^\]]*\]", "", report)
         assert "Agent Reach" in plain
-        assert "装好即用：" in plain
-        assert "1/3 个渠道可用" in plain
+        assert "Ready to use:" in plain
+        assert "1/3 channels available" in plain
         # Inactive optional channels should be summarized in one line
-        assert "可选渠道可以解锁" in plain
+        assert "optional channel(s) available to unlock" in plain
 
 
 def test_stale_active_backend_does_not_leak_into_errored_result(monkeypatch):

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -29,7 +29,7 @@ def test_not_installed():
     st, _ = _status_with(ProbeResult("missing"))
     assert not st.installed
     assert not st.ready
-    assert "未安装" in opencli_summary(st)
+    assert "not installed" in opencli_summary(st)
 
 
 def test_broken_node_env_gives_npm_hint():
@@ -74,7 +74,7 @@ def test_sleeping_extension_counts_as_ready():
     assert not st.extension_connected
     assert st.extension_installed
     assert st.ready
-    assert "唤醒" in opencli_summary(st)
+    assert "wakes" in opencli_summary(st)
     assert st.hint == ""
 
 
@@ -86,7 +86,7 @@ def test_daemon_not_running_parsed_correctly():
     assert st.installed
     assert not st.daemon_running
     assert not st.extension_connected
-    assert "自动启动" in opencli_summary(st)
+    assert "starts automatically" in opencli_summary(st)
 
 
 def test_probe_uses_daemon_status_not_doctor():

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -25,7 +25,7 @@ def test_check_twitter_cli_found_and_auth_ok():
         status, message = channel.check()
     assert status == "ok"
     assert "twitter-cli" in message
-    assert "完整可用" in message
+    assert "fully available" in message
     assert channel.active_backend == "twitter-cli"
 
 
@@ -41,8 +41,8 @@ def test_check_twitter_cli_found_auth_missing():
     ):
         status, message = channel.check()
     assert status == "warn"
-    assert "未认证" in message
-    # 未认证是业务态：工具进程活着，后端仍可用
+    assert "not authenticated" in message
+    # Not authenticated is a normal business state: the tool process is alive, backend still available
     assert channel.active_backend == "twitter-cli"
 
 
@@ -78,7 +78,7 @@ def test_check_bird_fallback_auth_missing():
     ):
         status, message = channel.check()
     assert status == "warn"
-    assert "未配置认证" in message
+    assert "authentication is not configured" in message
 
 
 # --- neither installed ---
@@ -117,7 +117,7 @@ def test_twitter_cli_preferred_over_bird():
 # --- broken install (stale venv shim) ---
 
 def test_check_twitter_cli_broken_reports_error_with_reinstall_hint():
-    """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
+    """which() finds it but exec raises FileNotFoundError (broken venv) -> error + reinstall hint."""
     channel = TwitterChannel()
     with patch(
         "shutil.which",
@@ -125,14 +125,14 @@ def test_check_twitter_cli_broken_reports_error_with_reinstall_hint():
     ), patch("subprocess.run", side_effect=FileNotFoundError("/usr/local/bin/twitter")):
         status, message = channel.check()
     assert status == "error"
-    assert "无法执行" in message
+    assert "cannot execute" in message
     assert "uv tool install --force twitter-cli" in message
     assert "pipx reinstall twitter-cli" in message
     assert channel.active_backend is None
 
 
 def test_check_twitter_cli_broken_falls_back_to_bird():
-    """twitter-cli 断链但 bird 健康 → 回退到 bird，后端正确归属。"""
+    """twitter-cli is broken but bird is healthy -> falls back to bird, backend correctly attributed."""
     channel = TwitterChannel()
 
     def which_side_effect(name):
@@ -155,14 +155,14 @@ def test_check_twitter_cli_broken_falls_back_to_bird():
 
 
 def test_unauthenticated_twitter_cli_does_not_block_working_opencli():
-    """warn 候选不得屏蔽排在后面的 ok 候选(Codex review 发现)。"""
+    """A "warn" candidate must not block an "ok" candidate later in the list (found via Codex review)."""
     channel = TwitterChannel()
     with patch.object(
         TwitterChannel, "_check_twitter_cli",
-        return_value=("warn", "twitter-cli 已安装但未认证"),
+        return_value=("warn", "twitter-cli is installed but not authenticated"),
     ), patch.object(
         TwitterChannel, "_check_opencli",
-        return_value=("ok", "OpenCLI 可用（复用浏览器登录态）"),
+        return_value=("ok", "OpenCLI available (reuses browser login session)"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
         status, msg = channel.check()
     assert status == "ok"
@@ -173,12 +173,12 @@ def test_all_warn_falls_back_to_first_warn():
     channel = TwitterChannel()
     with patch.object(
         TwitterChannel, "_check_twitter_cli",
-        return_value=("warn", "twitter-cli 未认证"),
+        return_value=("warn", "twitter-cli not authenticated"),
     ), patch.object(
         TwitterChannel, "_check_opencli",
-        return_value=("warn", "扩展未连接"),
+        return_value=("warn", "extension not connected"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
         status, msg = channel.check()
     assert status == "warn"
     assert channel.active_backend == "twitter-cli"
-    assert "未认证" in msg
+    assert "not authenticated" in msg

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -118,7 +118,7 @@ def test_check_ok_with_deno():
          patch("shutil.which", side_effect=_which("deno")):
         status, message = ch.check()
     assert status == "ok"
-    assert message == "可提取视频信息和字幕"
+    assert message == "Can extract video info and subtitles"
     assert ch.active_backend == "yt-dlp"
 
 
@@ -133,7 +133,7 @@ def test_check_ok_reports_transcription_when_provider_and_ffmpeg_present():
         status, message = ch.check(config=cfg)
     assert status == "ok"
     assert "groq" in message
-    assert "可转写音频" in message
+    assert "can transcribe audio" in message
 
 
 def test_check_ok_flags_missing_ffmpeg_for_transcription():


### PR DESCRIPTION
## Summary
- Translates all user-facing Chinese CLI output to English, in place, across `cli.py`, `doctor.py`, `probe.py`, `backends/opencli.py`, `cookie_extract.py`, and all `channels/*.py` — doctor status lines, install/setup wizard prompts, fix-it command suggestions, error/exception messages, and channel description labels.
- Updates test assertions in 6 test files that matched the old Chinese substrings so they check the equivalent English text.
- Out of scope (left as-is): README.md/SKILL.md/docs (this project already maintains separate English docs like `README_en.md`/`SKILL_en.md`), pure dev docstrings in `v2ex.py`/`xueqiu.py` that are never surfaced to users or the MCP server, and one literal substring match (`"已登录" in result.stdout` in `cli.py`) against text returned by the upstream OpenCLI tool itself, not text this codebase prints.

## Test plan
- [x] `pytest tests/ -v` — 196 passed
- [x] Ran `agent-reach doctor` manually and confirmed clean English output
- [x] Confirmed no remaining Chinese in scoped files except the documented dev-docstring/upstream-passthrough exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)