### PR TITLE
docs(readme): add Agent Skills Hub friend link

### DIFF
--- a/.openteams/specs/2026-07-10-agent-skills-hub-friend-link-design.html
+++ b/.openteams/specs/2026-07-10-agent-skills-hub-friend-link-design.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Skills Hub 友链设计</title>
+  <style>
+    :root { color-scheme: light; --ink: #18212f; --muted: #5e6b7c; --line: #dce3ec; --accent: #2563eb; }
+    body { margin: 0; background: #f5f7fb; color: var(--ink); font: 16px/1.65 system-ui, -apple-system, sans-serif; }
+    main { max-width: 760px; margin: 56px auto; padding: 36px; background: #fff; border: 1px solid var(--line); border-radius: 18px; box-shadow: 0 18px 50px rgba(24, 33, 47, .08); }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: -.02em; }
+    h2 { margin-top: 30px; font-size: 18px; }
+    p { margin: 8px 0; }
+    .meta { color: var(--muted); }
+    .copy { padding: 16px 18px; border-left: 4px solid var(--accent); background: #f7f9ff; border-radius: 8px; }
+    code { color: #1d4ed8; background: #eef3ff; padding: 2px 5px; border-radius: 5px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Agent Skills Hub 友链设计</h1>
+    <p class="meta">2026-07-10 · Agent Reach README 双语同步</p>
+
+    <h2>目标与范围</h2>
+    <p>在中文 <code>README.md</code> 的“友情链接”和英文 <code>docs/README_en.md</code> 的“Friends”中，各新增一条 Agent Skills Hub 链接。放在腾讯云 OpenClaw 之后、AtomGit 镜像之前；不改动其他内容。</p>
+
+    <h2>中文文案</h2>
+    <p class="copy"><strong>Agent Skills Hub</strong> — 找 Claude 技能和 MCP 服务器，不用猜哪个安全：133,000+ 个条目全部安全分级、质量评分，每 8 小时刷新。</p>
+
+    <h2>English copy</h2>
+    <p class="copy"><strong>Agent Skills Hub</strong> — Find Claude skills &amp; MCP servers without guessing what's safe. Every one of 133,000+ entries is security-graded, quality-scored, and refreshed every 8 hours.</p>
+
+    <h2>验收</h2>
+    <p>确认两个 README 的链接均为 <code>https://agentskillshub.top/</code>，中文与英文信息一致，Markdown 格式检查通过，完整测试通过，并只提交本次相关文件。</p>
+  </main>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Builder 也欢迎备注：`Builder + 你在做什么`
 
 [腾讯云 OpenClaw](https://www.tencentcloud.com/act/pro/intl-openclaw?referral_code=G76Y819A&lang=zh&pg=) — 在腾讯云Lighthouse秒级部署OpenClaw全能助手，可通过对话丝滑接入Agent Reach，给你的OpenClaw一键装上互联网能力。
 
+[Agent Skills Hub](https://agentskillshub.top/) — 找 Claude 技能和 MCP 服务器，不用猜哪个安全：133,000+ 个条目全部安全分级、质量评分，每 8 小时刷新。
+
 [AtomGit 镜像](https://atomgit.com/qq_51337814/Agent-Reach) — Agent Reach 的 AtomGit 同步镜像，便于国内访问与克隆。
 
 ## Star History

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -295,6 +295,8 @@ For collaboration or questions, add me on WeChat — I'll invite you to the comm
 
 [OpenClaw on Tencent Cloud](https://www.tencentcloud.com/act/pro/intl-openclaw?referral_code=G76Y819A&lang=en&pg=) — One-click OpenClaw on Tencent Cloud: chat to connect Agent Reach & unlock internet power.
 
+[Agent Skills Hub](https://agentskillshub.top/) — Find Claude skills & MCP servers without guessing what's safe. Every one of 133,000+ entries is security-graded, quality-scored, and refreshed every 8 hours.
+
 [AtomGit mirror](https://atomgit.com/qq_51337814/Agent-Reach) — Synchronized AtomGit mirror for Agent Reach.
 
 ## Star History


### PR DESCRIPTION
## Summary

- add Agent Skills Hub to the Chinese `友情链接` section
- add the matching English entry to `Friends`
- keep the placement and copy synchronized across both READMEs

## Why

Agent Skills Hub provides a security-graded, quality-scored directory of Claude skills and MCP servers, which is relevant to Agent Reach users.

## Validation

- `uv run --isolated --python /Users/panpan/.local/bin/python3.12 --extra dev pytest tests/ -v` — 196 passed
- `git diff --check` — passed
- `https://agentskillshub.top/` — HTTP 200