### PR TITLE
fix(installer): use platform-specific yt-dlp config path

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -9,13 +9,14 @@ Usage:
     agent-reach setup
 """
 
-import sys
 import argparse
 import json
 import os
+import sys
 import time
 
 from agent_reach import __version__
+from agent_reach.utils.paths import get_ytdlp_config_path
 
 # Pinned to the 0.4.2 state — PyPI still only has 0.4.1 (upstream issue #10).
 _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66"
@@ -634,8 +635,8 @@ def _install_system_deps():
 
     # ── yt-dlp JS runtime config (YouTube requires external JS runtime) ──
     if shutil.which("node"):
-        ytdlp_config_dir = os.path.expanduser("~/.config/yt-dlp")
-        ytdlp_config = os.path.join(ytdlp_config_dir, "config")
+        ytdlp_config = str(get_ytdlp_config_path())
+        ytdlp_config_dir = os.path.dirname(ytdlp_config)
         needs_config = True
         if os.path.exists(ytdlp_config):
             with open(ytdlp_config, "r") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,6 +113,28 @@ class TestCLI:
         assert commands == [["pipx", "install", cli._RDT_GIT_SOURCE]]
         assert "✅ rdt-cli installed" in out
 
+    def test_install_system_deps_uses_platform_ytdlp_config_path(
+        self, monkeypatch, tmp_path
+    ):
+        config_path = tmp_path / "Library" / "Application Support" / "yt-dlp" / "config"
+
+        monkeypatch.setattr("agent_reach.utils.paths.sys.platform", "darwin")
+        monkeypatch.setattr("agent_reach.utils.paths.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda name: f"/usr/bin/{name}" if name in {"gh", "node", "npm"} else None,
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "", ""),
+        )
+
+        cli._install_system_deps()
+
+        assert config_path.read_text(encoding="utf-8") == "--js-runtimes node\n"
+
     def test_install_reddit_deps_routes_by_environment(self, monkeypatch):
         """桌面 → OpenCLI;服务器 → rdt-cli(钉 git 源)。"""
         calls = []


### PR DESCRIPTION
## What changed

- Reuse `get_ytdlp_config_path()` when the installer configures the Node.js runtime for yt-dlp.
- Add a regression test that simulates macOS and verifies the installer writes `--js-runtimes node` under `~/Library/Application Support/yt-dlp/config`.

## Why

In v1.5.0, `_install_system_deps()` hardcodes the Linux path `~/.config/yt-dlp/config`, while the YouTube doctor check uses the platform-aware path helper. On macOS this makes installation report success, but the following `agent-reach doctor` cannot find the setting and warns that the JS runtime is not configured.

Using the existing shared helper keeps installation and health checks aligned on every supported platform.

## User impact

After `agent-reach install --env=auto` on macOS, YouTube readiness is detected correctly without requiring users to duplicate the yt-dlp setting manually.

## Validation

- `python3 -m pytest tests/ -q` — 197 passed
- `python3 -m ruff check --select F401 agent_reach/cli.py tests/test_cli.py` — passed
