### PR TITLE
feat(channels): add zhihu channel via opencli

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📖 **Reddit** | —（没有零配置路径：匿名接口已被封） | 搜索 + 读帖子和评论 | 桌面装 OpenCLI 用浏览器登录态；或 rdt-cli + Cookie |
 | 📘 **Facebook** | — | 搜索、主页、Feed、群组列表 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
+| 💭 **知乎** | — | 搜索、热榜、问题详情、用户主页/回答/文章 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📕 **小红书** | — | 搜索、阅读、评论 | 桌面装 OpenCLI（刷过小红书即可用）；服务器用 xiaohongshu-mcp 扫码 |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
@@ -92,7 +93,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 
 > **不知道怎么配？不用查文档。** 直接告诉 Agent「帮我配 XXX」，它知道需要什么、会一步一步引导你。
 >
-> 🍪 需要 Cookie/登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram 等），优先让用户在自己的浏览器里登录。OpenCLI 复用 Chrome 登录态；传统 CLI 才需要 Cookie-Editor 导出 Cookie。
+> 🍪 需要 Cookie/登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram、知乎 等），优先让用户在自己的浏览器里登录。OpenCLI 复用 Chrome 登录态；传统 CLI 才需要 Cookie-Editor 导出 Cookie。
 >
 > 🔒 Cookie 只存在你本地，不上传不外传。代码完全开源，随时可审查。
 > 💻 本地电脑不需要代理。代理只有部署在服务器上才需要（~$1/月）。
@@ -138,7 +139,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 3. **配置搜索引擎** — 通过 MCP 接入 Exa（免费，无需 API Key）
 4. **检测环境** — 判断是本地电脑还是服务器，给出对应的配置建议
 5. **注册 SKILL.md** — 在 Agent 的 skills 目录安装使用指南，以后 Agent 遇到"全网调研"、"搜推特"、"看视频"这类需求，会自动知道该调哪个上游工具
-6. **问你要不要更多** — 默认只激活 6 个零配置渠道；小红书、Twitter、Reddit、Facebook、Instagram 这些需要登录态的，Agent 会列菜单问你要哪些，点名才装
+6. **问你要不要更多** — 默认只激活 6 个零配置渠道；小红书、Twitter、Reddit、Facebook、Instagram、知乎 这些需要登录态的，Agent 会列菜单问你要哪些，点名才装
 
 安装完之后，`agent-reach doctor` 一条命令告诉你每个渠道的状态、当前走哪条路。
 </details>
@@ -156,7 +157,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 - "全网搜一下 LLM 框架对比" → Exa 语义搜索
 - "订阅这个 RSS" → `feedparser` 解析
 
-**不需要记命令。** Agent 读了 SKILL.md 之后自己知道该调什么。需要登录的平台（小红书、Twitter、Reddit、Facebook、Instagram），告诉 Agent「帮我配 XXX」即可解锁。
+**不需要记命令。** Agent 读了 SKILL.md 之后自己知道该调什么。需要登录的平台（小红书、Twitter、Reddit、Facebook、Instagram、知乎），告诉 Agent「帮我配 XXX」即可解锁。
 
 ---
 
@@ -188,6 +189,7 @@ channels/
 ├── reddit.py       → OpenCLI ▸ rdt-cli（无零配置路径，必须登录态）
 ├── facebook.py     → OpenCLI（桌面浏览器登录态）
 ├── instagram.py    → OpenCLI（桌面浏览器登录态）
+├── zhihu.py        → OpenCLI（桌面浏览器登录态）
 ├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── linkedin.py     → linkedin-mcp ▸ Jina Reader
 ├── rss.py          → feedparser
@@ -206,6 +208,7 @@ channels/
 | Reddit | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [rdt-cli](https://github.com/public-clis/rdt-cli) | 匿名接口已被封、官方 API 审批制——只剩登录态路线 |
 | Facebook | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | — | Graph API/Groups API 权限收紧；浏览器登录态是当前最实用路径 |
 | Instagram | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | 官方 Graph API（Business/Creator + 审批） | instaloader 类路径不稳定；OpenCLI 复用真实浏览器会话 |
+| 知乎 | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | — | 无公开匿名 API；OpenCLI 复用真实浏览器登录态，覆盖搜索/热榜/问答/用户 |
 | YouTube 字幕 + 搜索 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | — | 154K Star，YouTube 仍是最佳（注意：不再用于 B站） |
 | B站 | [bili-cli](https://github.com/public-clis/bilibili-cli) | OpenCLI ▸ 搜索 API | yt-dlp 被 B站风控 412 封死（2026-06 实测），bili-cli 无登录可搜可读 |
 | 搜全网 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI 语义搜索，MCP 接入免 Key |
@@ -234,7 +237,7 @@ Agent Reach 在设计上重视安全：
 
 > ⚠️ **封号风险提醒：** 使用 Cookie 登录的平台（Twitter、小红书等），通过脚本/API 调用**存在被平台检测并封号的风险**。请务必使用**专用小号**，不要用你的主账号。
 
-需要 Cookie 或登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram 等）建议使用**专用小号**，不要用主账号。原因有二：
+需要 Cookie 或登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram、知乎 等）建议使用**专用小号**，不要用主账号。原因有二：
 1. **封号风险** — 平台可能检测到非正常浏览器的 API 调用行为，导致账号被限制或封禁
 2. **安全风险** — Cookie 等同于完整登录权限，用小号可以在凭据泄露时限制影响范围
 

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -22,6 +22,7 @@ from .xiaohongshu import XiaoHongShuChannel
 from .xiaoyuzhou import XiaoyuzhouChannel
 from .xueqiu import XueqiuChannel
 from .youtube import YouTubeChannel
+from .zhihu import ZhihuChannel
 
 ALL_CHANNELS: List[Channel] = [
     GitHubChannel(),
@@ -36,6 +37,7 @@ ALL_CHANNELS: List[Channel] = [
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),
+    ZhihuChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/zhihu.py
+++ b/agent_reach/channels/zhihu.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Zhihu — OpenCLI backend using the user's logged-in Chrome session."""
+
+from ._opencli_site import OpenCLISiteChannel
+
+
+class ZhihuChannel(OpenCLISiteChannel):
+    name = "zhihu"
+    description = "知乎问答、文章和热榜"
+    site = "zhihu"
+    domains = ("zhihu.com",)
+    usage = "opencli zhihu search/question/hot/user/answer-detail -f yaml"
+    login_hint = "zhihu.com"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -75,7 +75,7 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,zhihu,bilibili,linkedin,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -201,12 +201,13 @@ def _cmd_install(args):
         "reddit":      _install_reddit_deps,
         "facebook":    _install_opencli_deps,
         "instagram":   _install_opencli_deps,
+        "zhihu":       _install_opencli_deps,
         "bilibili":    _install_bili_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
         # linkedin: manual setup, no auto-install
     }
-    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
+    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram", "zhihu"}
     COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili"}
 
     requested_channels = set()
@@ -339,7 +340,7 @@ def _cmd_install(args):
             # First install — hint about optional channels
             print()
             print("More channels available! Use --channels to install:")
-            print("   agent-reach install --channels=twitter,xiaohongshu,reddit,facebook,instagram,...")
+            print("   agent-reach install --channels=twitter,xiaohongshu,reddit,facebook,instagram,zhihu,...")
             print("   agent-reach install --channels=all  (install everything)")
 
         # Star reminder

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
+  Instagram, 知乎/zhihu, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
   雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,7 +18,7 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/知乎) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -30,6 +30,7 @@ triggers:
     - Reddit: reddit
     - Facebook: facebook/fb/facebook groups
     - Instagram: instagram/ig
+    - 知乎: zhihu/知乎/知乎回答/知乎文章/知乎热榜
   - career: 招聘/职位/求职/linkedin/领英/找工作
   - dev: github/代码/仓库/gh/issue/pr/分支/commit
   - web: 网页/链接/文章/rss/读一下/打开这个
@@ -42,11 +43,11 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
-1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram）先跑
+1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram/知乎）先跑
    `agent-reach doctor --json`，按各平台 `active_backend` 字段选命令组。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
@@ -62,7 +63,7 @@ metadata:
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
-| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
+| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/知乎 | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
@@ -108,6 +109,11 @@ opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # 搜用户
 opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
+
+# 知乎（桌面 OpenCLI，复用浏览器登录态；所有命令都需要登录）
+opencli zhihu search "query" -f yaml
+opencli zhihu hot -f yaml
+opencli zhihu question QUESTION_ID -f yaml
 ```
 
 ## 环境检查
@@ -126,7 +132,7 @@ agent-reach doctor --json
 根据用户需求，阅读对应的详细文档：
 
 - [搜索工具](references/search.md) — Exa AI 搜索
-- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
+- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram, 知乎（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -6,10 +6,10 @@ description: >
   web for X", "see what people say about X", "look this up".
 
   Also MUST USE when user mentions any platform or shares any URL/link:
-  Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
+  Twitter/X, Reddit, Facebook, Instagram, Zhihu, YouTube, GitHub, Bilibili, XiaoHongShu,
   Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -23,13 +23,13 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
 
 1. **Health-check before acting**: for multi-backend/login-backed platforms (XiaoHongShu /
-   Reddit / Bilibili / Twitter / Facebook / Instagram), run `agent-reach doctor --json` first and
+   Reddit / Bilibili / Twitter / Facebook / Instagram / Zhihu), run `agent-reach doctor --json` first and
    pick the command group matching each platform's `active_backend`.
 2. **Announce what you use**: say "using agent-reach, platform X via backend Y"
    before starting.
@@ -50,7 +50,7 @@ these platforms — do not invent your own approach.**
 | User intent | Category | Details |
 |---------|------|---------|
 | Web / code search | search | [references/search.md](references/search.md) |
-| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
+| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram / Zhihu | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
@@ -96,6 +96,11 @@ opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # user search
 opencli instagram user USERNAME -f yaml        # recent posts from one user
+
+# Zhihu (desktop OpenCLI, browser session; all commands require login)
+opencli zhihu search "query" -f yaml
+opencli zhihu hot -f yaml
+opencli zhihu question QUESTION_ID -f yaml
 ```
 
 ## Environment check
@@ -117,7 +122,7 @@ common cases; references hold per-backend command groups, caveats, retry
 chains — note: reference docs are written in Chinese, commands are universal):
 
 - [Search](references/search.md) — Exa AI search
-- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)
+- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram, Zhihu (multi-backend/login-backed groups)
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -1,6 +1,6 @@
 # 社交媒体 & 社区
 
-小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram。
+小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram、知乎。
 
 ## 小红书 / XiaoHongShu（多后端）
 
@@ -273,3 +273,33 @@ opencli instagram saved --limit 20 -f yaml
 ```
 
 > 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 instagram.com。`instagram search` 是用户搜索；读帖子需要先确定 username，再用 `instagram user USERNAME`。若出现 429 / login required，先让用户在 Chrome 里重新登录并降低频率。
+
+## 知乎 / Zhihu（OpenCLI，必须登录态）
+
+知乎走 OpenCLI，复用用户 Chrome 里的 zhihu.com 登录态。先跑 `agent-reach doctor --json` 看 zhihu 的 `active_backend`，正常应为 `OpenCLI`。知乎没有匿名公开 API，所有读取命令都需要登录态。
+
+```bash
+# 搜索（问题/回答/文章）
+opencli zhihu search "query" -f yaml
+
+# 热榜
+opencli zhihu hot -f yaml
+
+# 问题详情 + 回答列表
+opencli zhihu question QUESTION_ID -f yaml
+
+# 单个回答完整内容
+opencli zhihu answer-detail ANSWER_ID -f yaml
+
+# 用户主页资料（粉丝/关注/回答/文章/获赞数）
+opencli zhihu user USERNAME -f yaml
+
+# 用户的回答列表 / 文章列表
+opencli zhihu user-answers USERNAME -f yaml
+opencli zhihu user-articles USERNAME -f yaml
+
+# 导出知乎文章为 Markdown
+opencli zhihu download ARTICLE_URL -f yaml
+```
+
+> 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 zhihu.com（`opencli zhihu login` 可打开登录页等待认证完成）。写操作（`answer`/`comment`/`like`/`follow`）在 OpenCLI 上游存在，但 Agent Reach 只负责读取/搜索，不要调用写操作命令。若提示登录错误，先让用户在 Chrome 里重新登录 zhihu.com。

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -76,6 +76,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 | 📕 **XiaoHongShu** | Read · Search · Comments | OpenCLI / MCP | Desktop: [OpenCLI](https://github.com/jackwener/opencli) (reuses browser session); Server: [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) (QR login); legacy xhs-cli still works |
 | 📘 **Facebook** | Search · Profiles · Feed · Groups list | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 📷 **Instagram** | User search · Profiles · Recent posts · Explore | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
+| 💭 **Zhihu (知乎)** | Search · Hot list · Question detail · User profile/answers/articles | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 💼 **LinkedIn** | Jina Reader (public pages) | Full profiles, companies, job search | Tell your Agent "help me set up LinkedIn" |
 | 💻 **V2EX** | Hot topics · Node topics · Topic detail + replies · User profile | Zero config | Public JSON API, no auth required. Great for tech community content |
 | 📈 **Xueqiu (雪球)** | Stock quotes · Search · Hot posts · Hot stocks | Browser cookie | Tell your Agent "help me set up Xueqiu" |
@@ -208,9 +209,9 @@ $ agent-reach doctor
 🔧 Configurable:
   ⬜ Reddit posts and comments — needs login: rdt-cli after `rdt login`, or OpenCLI browser session
   ⬜ XiaoHongShu notes — desktop: OpenCLI (browser session); server: xiaohongshu-mcp (QR)
-  ⬜ Facebook / Instagram — desktop: OpenCLI browser session
+  ⬜ Facebook / Instagram / Zhihu — desktop: OpenCLI browser session
 
-Status: 6/9 channels available
+Status: 6/10 channels available
 ```
 
 ---
@@ -237,6 +238,7 @@ channels/
 ├── reddit.py       → OpenCLI ▸ rdt-cli (no zero-config path, login required)
 ├── facebook.py     → OpenCLI (desktop browser session)
 ├── instagram.py    → OpenCLI (desktop browser session)
+├── zhihu.py        → OpenCLI (desktop browser session)
 ├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── linkedin.py     → linkedin-mcp ▸ Jina Reader
 ├── rss.py          → feedparser
@@ -255,6 +257,7 @@ Each channel file **actually probes** its candidate backends in order (not just 
 | Reddit | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | [rdt-cli](https://github.com/public-clis/rdt-cli) | Anonymous endpoints blocked, official API gated — logged-in sessions are the only route left |
 | Facebook | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | — | Graph/Groups API access is heavily restricted; browser sessions are the practical route |
 | Instagram | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | Official Graph API (Business/Creator + review) | Instaloader-style paths are unstable; OpenCLI reuses the real browser session |
+| Zhihu | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | — | No public anonymous API; OpenCLI reuses the real browser session, covering search/hot list/Q&A/user |
 | YouTube subtitles + search | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | — | 154K stars, still the best for YouTube (no longer used for Bilibili) |
 | Bilibili | [bili-cli](https://github.com/public-clis/bilibili-cli) | OpenCLI ▸ search API | yt-dlp is 412-blocked by Bilibili (verified June 2026); bili-cli searches and reads without login |
 | Search the web | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI semantic search, MCP integration, no API key |

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,7 +96,7 @@ After installing the basics, **ask the user** which additional channels they nee
 >
 > 还有这些可选渠道，你需要哪些？
 >
-> - 🌟 **OpenCLI**（桌面推荐）— 一次安装，小红书/Reddit/Facebook/Instagram/B站字幕/Twitter 备选全解锁（复用浏览器登录态，零配置；只需在 Chrome 商店点一次"添加扩展"）
+> - 🌟 **OpenCLI**（桌面推荐）— 一次安装，小红书/Reddit/Facebook/Instagram/知乎/B站字幕/Twitter 备选全解锁（复用浏览器登录态，零配置；只需在 Chrome 商店点一次"添加扩展"）
 > - 🐦 **Twitter/X** — 搜推文、看时间线（需要登录 Cookie）
 > - 📈 **雪球** — 股票行情、热门帖子（需要登录 Cookie）
 > - 🎙️ **小宇宙播客** — 音频转文字（需要免费 Groq Key）
@@ -104,6 +104,7 @@ After installing the basics, **ask the user** which additional channels they nee
 > - 📖 **Reddit** — 搜索和阅读帖子（必须登录态：桌面 OpenCLI 或 rdt-cli + Cookie）
 > - 📘 **Facebook** — 搜索、主页、Feed、群组列表（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📷 **Instagram** — 用户搜索、Profile、用户最近帖子、Explore（桌面走 OpenCLI，复用 Chrome 登录态）
+> - 💭 **知乎** — 搜索、热榜、问题详情、用户主页/回答/文章（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📺 **B站完整版** — 热门、排行、搜索、视频详情（bili-cli，无需登录）
 > - 💼 **LinkedIn** — Profile、职位搜索
 >
@@ -114,10 +115,11 @@ Based on the user's choice, run:
 ```bash
 agent-reach install --env=auto --channels=opencli,xiaohongshu   # Example: desktop user chose XHS (OpenCLI-backed)
 agent-reach install --env=auto --channels=facebook,instagram    # Example: desktop user chose Meta social channels
+agent-reach install --env=auto --channels=zhihu                 # Example: desktop user chose Zhihu
 agent-reach install --env=auto --channels=all              # User wants everything
 ```
 
-Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `bilibili`, `linkedin`, `all`
+Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `zhihu`, `bilibili`, `linkedin`, `all`
 
 ### Step 3: Fix what's broken
 
@@ -131,7 +133,7 @@ Only ask the user when you genuinely need their input (credentials, permissions,
 
 Some channels need credentials only the user can provide. Based on the doctor output, ask for what's missing:
 
-> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
+> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram, Zhihu), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
 > 1. **Account ban** — platforms may detect non-browser API calls and restrict or ban the account
 > 2. **Credential exposure** — cookies grant full account access; using a secondary account limits the blast radius if credentials are ever compromised
 
@@ -143,7 +145,7 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 > 3. 点击插件 → Export → Header String
 > 4. 把导出的字符串发给 Agent
 >
-> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
+> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram、知乎）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
 
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
@@ -224,6 +226,27 @@ agent-reach install --channels facebook,instagram
 >    ```
 >
 > Facebook Groups 当前只承诺读取用户登录后可见的群组列表/最近动态，不承诺任意群帖子和评论 API。Instagram 的 search 是用户搜索，不是全站帖子关键词搜索；若提示 429/登录错误，先让用户在 Chrome 里重新登录并降低频率。
+
+**知乎（桌面 OpenCLI）:**
+> 知乎走 OpenCLI：复用用户自己的 Chrome 登录态，覆盖搜索、热榜、问题详情、用户主页/回答/文章。所有读取命令都需要登录态（无匿名接口）。服务器/无桌面环境不推荐支持。
+
+```bash
+agent-reach install --channels zhihu
+```
+
+> 装完后：
+> 1. 确认 Chrome 已安装 OpenCLI 扩展并通过 `opencli doctor`
+> 2. 在 Chrome 里登录 zhihu.com（或 `opencli zhihu login`）
+> 3. Agent 直接调用：
+>    ```bash
+>    opencli zhihu search "query" -f yaml
+>    opencli zhihu hot -f yaml
+>    opencli zhihu question <question_id> -f yaml
+>    opencli zhihu user <username> -f yaml
+>    opencli zhihu answer-detail <answer_id> -f yaml
+>    ```
+>
+> 若提示登录错误，先让用户在 Chrome 里重新登录 zhihu.com。
 
 **雪球 / Xueqiu (股票行情 + 热门帖子):**
 > "雪球需要登录后的 Cookie。请先在 Chrome 里登录 xueqiu.com，然后运行："
@@ -351,6 +374,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | Reddit | `opencli`（备选 `rdt`） | `opencli reddit search "query" -f yaml` / `rdt read POST_ID` |
 | Facebook | `opencli` | `opencli facebook search "query" -f yaml` |
 | Instagram | `opencli` | `opencli instagram user nasa -f yaml` |
+| 知乎 | `opencli` | `opencli zhihu search "query" -f yaml` |
 | GitHub | `gh` | `gh search repos "query"` |
 | Web | `curl` + Jina | `curl -s "https://r.jina.ai/URL"` |
 | Exa Search | `mcporter` | `mcporter call 'exa.web_search_exa(...)'` |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Agent Reach
 
-> Give your AI agent eyes to see the internet. Agent Reach installs, routes, and health-checks upstream tools for 15 platforms — Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Xiaoyuzhou Podcast, RSS, web search, and any web page. One install, zero API fees.
+> Give your AI agent eyes to see the internet. Agent Reach installs, routes, and health-checks upstream tools for 16 platforms — Twitter/X, Reddit, Facebook, Instagram, Zhihu, YouTube, GitHub, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Xiaoyuzhou Podcast, RSS, web search, and any web page. One install, zero API fees.
 
 ## Quick Start
 
@@ -14,11 +14,11 @@
 
 ## Key Features
 
-- Read any URL: tweets, Reddit posts, Facebook pages/feed/groups, Instagram profiles/posts, YouTube videos (transcripts), GitHub repos, articles, XiaoHongShu notes, Bilibili videos, RSS feeds
-- Search/discover across platforms: Twitter/X, Reddit, Facebook, Instagram user search, GitHub, YouTube, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Web (via Exa)
+- Read any URL: tweets, Reddit posts, Facebook pages/feed/groups, Instagram profiles/posts, Zhihu questions/answers/articles, YouTube videos (transcripts), GitHub repos, articles, XiaoHongShu notes, Bilibili videos, RSS feeds
+- Search/discover across platforms: Twitter/X, Reddit, Facebook, Instagram user search, Zhihu, GitHub, YouTube, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Web (via Exa)
 - Self-diagnosis: `agent-reach doctor` checks what works and what needs setup
 - Auto-installs dependencies: `agent-reach install --env=auto`
-- Browser-session / cookie auth for platforms that require login (Twitter, Reddit, Facebook, Instagram, XiaoHongShu, Xueqiu)
+- Browser-session / cookie auth for platforms that require login (Twitter, Reddit, Facebook, Instagram, Zhihu, XiaoHongShu, Xueqiu)
 - Proxy support for platforms that block server IPs (Reddit, Twitter)
 - Zero API fees: all backends are free and open-source (OpenCLI, twitter-cli, rdt-cli, bili-cli, yt-dlp, Jina Reader, mcporter/Exa, etc.)
 

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -176,6 +176,7 @@ def test_channel_can_handle_contract():
         "linkedin": "https://www.linkedin.com/in/test",
         "rss": "https://example.com/feed.xml",
         "xueqiu": "https://xueqiu.com/S/SH600519",
+        "zhihu": "https://www.zhihu.com/question/12345",
         "exa_search": "https://example.com",
         "web": "https://example.com",
     }

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -13,6 +13,7 @@ from agent_reach.channels.instagram import InstagramChannel
 from agent_reach.channels.v2ex import V2EXChannel
 from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
 from agent_reach.channels.xueqiu import XueqiuChannel
+from agent_reach.channels.zhihu import ZhihuChannel
 
 
 class TestChannelRegistry:
@@ -33,6 +34,7 @@ class TestChannelRegistry:
         assert "facebook" in names
         assert "instagram" in names
         assert "v2ex" in names
+        assert "zhihu" in names
 
 
 class TestOpenCLISiteChannels:
@@ -50,6 +52,14 @@ class TestOpenCLISiteChannels:
         assert ch.can_handle("https://instagram.com/p/abc123/")
         assert ch.can_handle("https://instagr.am/p/abc123/")
         assert not ch.can_handle("https://facebook.com/openai")
+
+    def test_zhihu_can_handle_common_urls(self):
+        ch = ZhihuChannel()
+        assert ch.can_handle("https://www.zhihu.com/question/12345")
+        assert ch.can_handle("https://zhuanlan.zhihu.com/p/98765")
+        assert ch.can_handle("https://www.zhihu.com/people/someone")
+        assert not ch.can_handle("https://zhihu.example.com/x")
+        assert not ch.can_handle("https://www.v2ex.com/t/1")
 
     def test_opencli_ready_reports_ok(self, monkeypatch):
         monkeypatch.setattr(
@@ -78,6 +88,22 @@ class TestOpenCLISiteChannels:
         assert ch.active_backend is None
         assert "agent-reach install --channels opencli" in msg
         assert "instagram.com" in msg
+
+    def test_zhihu_opencli_ready_reports_ok(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent_reach.backends.opencli_status",
+            lambda: OpenCLIStatus(
+                installed=True,
+                extension_connected=True,
+                version="1.8.3",
+            ),
+        )
+        ch = ZhihuChannel()
+        status, msg = ch.check()
+        assert status == "ok"
+        assert ch.active_backend == "OpenCLI"
+        assert "opencli zhihu" in msg
+        assert "zhihu.com" in msg
 
     def test_opencli_installed_without_extension_reports_warn(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,7 +158,7 @@ class TestCLI:
                 proxy="",
                 safe=False,
                 dry_run=False,
-                channels="facebook,instagram,opencli",
+                channels="facebook,instagram,zhihu,opencli",
             )
         )
 
@@ -174,14 +174,14 @@ class TestCLI:
                 proxy="",
                 safe=False,
                 dry_run=True,
-                channels="facebook,instagram,opencli,bilibili",
+                channels="facebook,instagram,zhihu,opencli,bilibili",
             )
         )
 
         out = capsys.readouterr().out
-        assert "服务器环境跳过：facebook, instagram, opencli" in out
+        assert "服务器环境跳过：facebook, instagram, opencli, zhihu" in out
         assert "[dry-run] Would install optional channels: bilibili" in out
-        assert "facebook, instagram, opencli, bilibili" not in out
+        assert "facebook, instagram, opencli, zhihu, bilibili" not in out
 
 
 class TestCheckUpdateRetry:


### PR DESCRIPTION
## Summary

Adds Zhihu (知乎) as an OpenCLI-backed desktop channel — same pattern as
Facebook/Instagram (#447).

- Add `ZhihuChannel` on the existing `OpenCLISiteChannel` helper (declaration-only, ~14 lines)
- Register in doctor/channel registry (before the generic rss/exa/web fallbacks)
- Route `--channels=zhihu` to the shared OpenCLI installer (dedupes with other OpenCLI channels)
- Skip Zhihu in server installs (needs desktop Chrome)
- Update README, English README, install docs, agent skills, social reference, and `llms.txt`; platform count 15 → 16

## Validation

- `python -m pytest tests/ -q` -> 198 passed (+7 new: can_handle URLs, registry membership, check ok-path, install routing/server-skip)
- `ruff check` on new/touched files -> passed
- Wheel build (`python -m build`) + duplicate-entry/data-file check mirroring CI's wheel-gate -> `zhihu.py` ships, 53 entries, no duplicates
- `agent-reach doctor --json` -> `zhihu` `ok`, active backend `OpenCLI`
- `opencli zhihu hot -f yaml` -> returned live 热榜 entries
- `opencli zhihu search "Agent Reach" -f yaml` -> returned real search results, including a `zhuanlan.zhihu.com` article URL — confirmed `can_handle()` matches it too
- `opencli zhihu question <id> -f yaml` -> question + answers (verified via search results)

## Notes

- All OpenCLI zhihu read commands are `[cookie]` — they need a logged-in
  zhihu.com session in Chrome (`opencli zhihu login` to establish one).
  Unlike Facebook/Instagram there is no anonymous read path documented.
- Read surface: search / hot / question / answer-detail / user /
  user-answers / user-articles / pins / download (Markdown export) /
  collections. Write ops (answer/comment/like/follow) exist upstream but are
  out of scope — Agent Reach is read/search only.
- `zhuanlan.zhihu.com` (专栏) is covered by suffix matching on `zhihu.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)