### PR TITLE
docs(youtube): add OpenCLI transcript fallback

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -83,6 +83,9 @@ gh search repos "query" --sort stars --limit 10
 # YouTube 字幕（注意：B站不要用 yt-dlp，见 video.md）
 yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
 
+# YouTube 浏览器会话字幕兜底（yt-dlp 遇到 bot-check / JS challenge 时）
+opencli youtube transcript "URL" -f json
+
 # V2EX 热门
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -71,6 +71,9 @@ gh search repos "query" --sort stars --limit 10
 # YouTube subtitles (NOTE: never use yt-dlp for Bilibili — see video.md)
 yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
 
+# Browser-session fallback when yt-dlp hits a bot-check or JS challenge
+opencli youtube transcript "URL" -f json
+
 # V2EX hot topics
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
 

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -39,6 +39,21 @@ yt-dlp --dump-json "ytsearch5:query"
 > **字幕注意**: 手动上传的字幕提取可靠；自动生成字幕可能存在行间重复，需后处理。
 > **评论注意**: `--write-comments` 基于网页抓取（非 YouTube Data API），部分评论可能丢失。
 
+### 浏览器会话兜底：OpenCLI transcript
+
+当 `yt-dlp` 遇到 bot-check、JS challenge 或本机匿名请求受限时，如果用户
+已经在桌面浏览器中登录 YouTube，并且 OpenCLI Browser Bridge 已连接，可以
+使用浏览器会话读取视频字幕：
+
+```bash
+opencli doctor
+opencli youtube transcript "https://www.youtube.com/watch?v=VIDEO_ID" -f json
+```
+
+该命令返回带时间戳的字幕片段，适合直接交给 Agent 做后续整理。它只复用
+用户已经授权的浏览器会话，不绕过 CAPTCHA、付费墙、私密权限或地区限制。
+如果 OpenCLI 也没有可用字幕，再使用下面的 Whisper 音频转写兜底。
+
 ### 无字幕兜底：Whisper 音频转写
 
 ```bash
@@ -124,7 +139,7 @@ agent-reach doctor
 
 | 场景 | 推荐工具 |
 |-----|---------|
-| YouTube 字幕 | yt-dlp |
+| YouTube 字幕 | yt-dlp；bot-check / JS challenge 时用 `opencli youtube transcript` |
 | B站视频详情/搜索 | bili-cli |
 | B站字幕 | opencli bilibili subtitle |
 | 播客转录 | 小宇宙 transcribe.sh |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,3 +59,22 @@ twitter check
 > 如果返回 "Missing credentials"，需要设置 AUTH_TOKEN 和 CT0 环境变量。
 >
 > **Fallback：** 如果你已经安装了 bird CLI（`npm install -g @steipete/bird`），它也能正常工作。Agent Reach 会自动检测已安装的工具。
+
+---
+
+## YouTube: yt-dlp 遇到 bot-check 或 JS challenge
+
+**症状：** `yt-dlp` 报 `Sign in to confirm you're not a bot`、JS challenge
+失败，或者匿名请求拿不到字幕。
+
+**解决方案：** 在本地桌面浏览器中登录 YouTube，安装并连接 OpenCLI
+Browser Bridge，然后运行：
+
+```bash
+opencli doctor
+opencli youtube transcript "https://www.youtube.com/watch?v=VIDEO_ID" -f json
+```
+
+OpenCLI 读取的是用户已经授权的浏览器会话，返回带时间戳的字幕片段。它不
+绕过 CAPTCHA、付费墙、私密权限或地区限制。若浏览器会话也没有字幕，使用
+`agent-reach transcribe` 配合 Groq/OpenAI Whisper 作为音频转写兜底。

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -110,8 +110,11 @@ def test_youtube_warns_when_node_only_and_no_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr("shutil.which", fake_which)
     monkeypatch.setattr("subprocess.run", _fake_run_ok)  # yt-dlp probe really executes now
-    # Point to a non-existent config file
-    monkeypatch.setattr("os.path.expanduser", lambda p: str(tmp_path / ".config/yt-dlp/config"))
+    # Point the current platform-aware helper to a deterministic empty config.
+    monkeypatch.setattr(
+        "agent_reach.channels.youtube.get_ytdlp_config_path",
+        lambda: tmp_path / ".config/yt-dlp/config",
+    )
 
     ch = YouTubeChannel()
     status, message = ch.check()

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -22,6 +22,8 @@ class TestSkillCommand(unittest.TestCase):
 
         self.assertTrue(default_skill.strip())
         self.assertTrue(english_skill.strip())
+        self.assertIn("opencli youtube transcript", default_skill)
+        self.assertIn("opencli youtube transcript", english_skill)
 
     def test_install_skill_creates_skill_md(self):
         """_install_skill should create SKILL.md in the first available skill dir."""


### PR DESCRIPTION
## Summary

Document an OpenCLI Browser Bridge fallback for YouTube transcript extraction when
the default `yt-dlp` route hits a bot-check, JavaScript challenge, or an
anonymous subtitle failure.

This keeps `yt-dlp` as the default route and adds a documented browser-session
fallback:

```bash
opencli doctor
opencli youtube transcript "https://www.youtube.com/watch?v=VIDEO_ID" -f json
```

The returned JSON contains timestamped transcript segments that an agent can
pass to downstream analysis.

## Changes

- Add the fallback command to both localized skill entry points.
- Add the full route, limitations, and troubleshooting guidance to the video
  reference and troubleshooting guide.
- Add a skill-resource regression assertion so both locales keep the route.
- Make the existing Windows YouTube config-path test deterministic by mocking
  the current platform-aware helper instead of the deprecated `expanduser()`
  path.

## Real-world validation

On a Windows desktop with OpenCLI v1.8.6 and a connected Browser Bridge:

- `opencli doctor` reported the daemon and extension connected.
- `opencli youtube transcript "https://www.youtube.com/watch?v=eWFKPPgHMCw" -f json`
  succeeded and returned a timestamped transcript for the full video.
- The downstream source-gated workflow then admitted the transcript as primary
  video material; its browser-first decision is documented in the companion
  project: https://github.com/sitabanubanu/codex-knowledge-workflow-skills/blob/codex/acquisition-bundle-v2/docs/adr/0003-browser-bridge-primary-acquisition.md

## Tests

- `pytest tests/ -q` -> **185 passed, 11 skipped**
- `pytest tests/test_skill_command.py -q` -> **5 passed**
- `ruff check tests/test_channel_contracts.py tests/test_skill_command.py` -> passed
- `python -m py_compile agent_reach/cli.py` -> passed
- `git diff --check` -> passed

## Boundary

This only uses a browser session the user has already authorized. It does not
bypass CAPTCHA, paywalls, private access, account permissions, or regional
restrictions. If the browser session has no usable transcript, the existing
Whisper fallback remains the next route.

This complements the current bot-check and cookie-handling work in #459 and
#460; it does not replace `yt-dlp` or add a new report-generation layer.
