### PR TITLE
feat: add FirecrawlChannel for deep web scraping and search

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -10,6 +10,7 @@ from .base import Channel
 from .bilibili import BilibiliChannel
 from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
+from .firecrawl import FirecrawlChannel
 from .github import GitHubChannel
 from .instagram import InstagramChannel
 from .linkedin import LinkedInChannel
@@ -38,6 +39,7 @@ ALL_CHANNELS: List[Channel] = [
     XueqiuChannel(),
     RSSChannel(),
     ExaSearchChannel(),
+    FirecrawlChannel(),
     WebChannel(),
 ]
 

--- a/agent_reach/channels/firecrawl.py
+++ b/agent_reach/channels/firecrawl.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""Firecrawl — 深度网页抓取、搜索与结构化提取。需要 Firecrawl API Key。"""
+
+import json
+import os
+from typing import Optional
+
+from .base import Channel
+
+
+class FirecrawlChannel(Channel):
+    name = "firecrawl"
+    description = "Firecrawl深度网页抓取"
+    backends = ["Firecrawl API"]
+    tier = 1  # 需要免费 API Key
+
+    # ------------------------------------------------------------------ #
+    # helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _get_api_key(config=None) -> Optional[str]:
+        """Resolve the Firecrawl API key from config or environment."""
+        if config is not None:
+            key = config.get("firecrawl_api_key")
+            if key:
+                return key
+        return os.environ.get("FIRECRAWL_API_KEY")
+
+    @staticmethod
+    def _check_import() -> Optional[str]:
+        """Try importing firecrawl; return None on success or a hint on failure."""
+        try:
+            import firecrawl  # noqa: F401
+            return None
+        except ImportError:
+            return (
+                "未安装 firecrawl-py。安装：\n"
+                "  pip install firecrawl-py\n"
+                "或：uv pip install firecrawl-py"
+            )
+
+    @staticmethod
+    def _make_client(api_key: str):
+        """Create a FirecrawlApp instance. Import is done lazily here so the
+        channel can report missing dependencies gracefully in check()."""
+        from firecrawl import FirecrawlApp
+        return FirecrawlApp(api_key=api_key)
+
+    # ------------------------------------------------------------------ #
+    # Channel interface
+    # ------------------------------------------------------------------ #
+
+    def can_handle(self, url: str) -> bool:
+        """Firecrawl 是通用网页抓取渠道，接受任意 URL。"""
+        return True
+
+    def check(self, config=None):
+        """检测 firecrawl-py 安装和 API Key 配置状态。
+
+        返回 (status, message)，其中 status 为 'ok' / 'off' / 'error'。
+        """
+        self.active_backend = None
+
+        # 1) 检查包是否安装
+        import_hint = self._check_import()
+        if import_hint is not None:
+            return "off", import_hint
+
+        # 2) 检查 API Key 是否已配置
+        api_key = self._get_api_key(config)
+        if not api_key:
+            return "off", (
+                "Firecrawl API Key 未设置。注册免费 Key 后配置：\n"
+                "  agent-reach config set firecrawl_api_key fc-xxx\n"
+                "或设置环境变量：\n"
+                "  export FIRECRAWL_API_KEY=fc-xxx\n"
+                "免费注册：https://firecrawl.dev"
+            )
+
+        # 3) 轻量连通性探测（credit usage 查询）
+        try:
+            client = self._make_client(api_key)
+            usage = client.get_credit_usage()
+        except Exception as exc:
+            # A failed probe means the key is likely invalid or network is down.
+            # We still report "warn" (key is present, just not confirmed healthy)
+            self.active_backend = self.backends[0]
+            return "warn", (
+                f"Firecrawl API Key 已配置，但连通性探测失败：{exc}\n"
+                "请检查网络或确认 Key 有效。"
+            )
+
+        self.active_backend = self.backends[0]
+        # usage is a CreditUsage object; try to extract remaining credits
+        remaining = ""
+        try:
+            rem = getattr(usage, "remaining", None)
+            if rem is not None:
+                remaining = f"，剩余额度 {rem}"
+        except Exception:
+            pass
+        return "ok", f"Firecrawl API 可用{remaining}"
+
+    # ------------------------------------------------------------------ #
+    # Public methods
+    # ------------------------------------------------------------------ #
+
+    def read(self, url: str) -> str:
+        """使用 Firecrawl scrape 抓取网页，返回 Markdown 全文。
+
+        与 WebChannel.read() 保持相同签名，方便替换。
+        """
+        api_key = self._get_api_key()
+        if not api_key:
+            raise RuntimeError("Firecrawl API Key 未设置，请先配置 firecrawl_api_key")
+        client = self._make_client(api_key)
+        doc = client.scrape(url, formats=["markdown"])
+        return doc.markdown or ""
+
+    def crawl(self, url: str, max_depth: int = 2, limit: int = 10) -> str:
+        """深度爬取网站，返回抓取结果摘要（JSON）。
+
+        Args:
+            url: 起始 URL。
+            max_depth: 最大爬取深度（默认 2）。
+            limit: 最多抓取页数（默认 10）。
+        Returns:
+            JSON 字符串，每页包含 url、title、markdown 片段。
+        """
+        api_key = self._get_api_key()
+        if not api_key:
+            raise RuntimeError("Firecrawl API Key 未设置，请先配置 firecrawl_api_key")
+        client = self._make_client(api_key)
+        job = client.crawl(
+            url,
+            max_discovery_depth=max_depth,
+            limit=limit,
+            scrape_options={"formats": ["markdown"]},
+        )
+        # crawl() returns a CrawlJob; poll if needed
+        return self._wait_and_collect(client, job)
+
+    def search(self, query: str, limit: int = 5) -> str:
+        """使用 Firecrawl 搜索网络，返回结果摘要（JSON）。
+
+        Args:
+            query: 搜索关键词。
+            limit: 返回结果数上限（默认 5）。
+        Returns:
+            JSON 字符串，每项包含 url、title、description。
+        """
+        api_key = self._get_api_key()
+        if not api_key:
+            raise RuntimeError("Firecrawl API Key 未设置，请先配置 firecrawl_api_key")
+        client = self._make_client(api_key)
+        result = client.search(query, limit=limit)
+        # result is a SearchData pydantic model; dump to dict
+        data = result.model_dump() if hasattr(result, "model_dump") else result
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    def extract(
+        self,
+        urls: list,
+        prompt: str,
+        schema: dict = None,
+    ) -> str:
+        """使用 AI 从网页中提取结构化数据。
+
+        Args:
+            urls: 目标 URL 列表。
+            prompt: 提取指令（自然语言描述需要的字段）。
+            schema: 可选的 JSON Schema（默认 None）。
+        Returns:
+            JSON 字符串，包含提取的结构化数据。
+        """
+        api_key = self._get_api_key()
+        if not api_key:
+            raise RuntimeError("Firecrawl API Key 未设置，请先配置 firecrawl_api_key")
+        client = self._make_client(api_key)
+        kwargs = {"prompt": prompt}
+        if schema is not None:
+            kwargs["schema"] = schema
+        result = client.extract(urls, **kwargs)
+        data = result.model_dump() if hasattr(result, "model_dump") else result
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------ #
+    # internal helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _maybe_pages(obj):
+        """Return a list of page objects from *obj* if present and iterable."""
+        for attr in ("pages", "data"):
+            raw = getattr(obj, attr, None)
+            if raw is not None and not isinstance(raw, (str, bytes)):
+                try:
+                    iter(raw)
+                    return raw
+                except TypeError:
+                    pass
+        return None
+
+    def _wait_and_collect(self, client, job) -> str:
+        """Wait for a crawl job to complete and collect markdown results.
+
+        Firecrawl v2 crawl() returns a CrawlJob which may already contain
+        pages if the job completed synchronously, or we need to poll using
+        get_crawl_status().
+        """
+        import time
+
+        # Try getting pages directly from the job
+        pages = self._maybe_pages(job)
+        if pages is not None:
+            return self._format_crawl_pages(pages)
+
+        # Poll for results
+        job_id = getattr(job, "id", None)
+        if not job_id or isinstance(job_id, type):
+            return json.dumps({"error": "无法获取爬取任务 ID"}, ensure_ascii=False)
+
+        max_wait = 120  # 最多等待 2 分钟
+        interval = 3
+        elapsed = 0
+        while elapsed < max_wait:
+            time.sleep(interval)
+            elapsed += interval
+            status = client.get_crawl_status(job_id)
+            state = getattr(status, "status", None) or getattr(status, "state", None)
+            if state in ("completed", "done", "finished"):
+                pages = self._maybe_pages(status)
+                if pages is not None:
+                    return self._format_crawl_pages(pages)
+                return json.dumps(
+                    {"error": "爬取完成但无页面数据"}, ensure_ascii=False
+                )
+            if state in ("failed", "error", "cancelled"):
+                return json.dumps(
+                    {"error": f"爬取失败，状态: {state}"}, ensure_ascii=False
+                )
+
+        return json.dumps({"error": "爬取超时"}, ensure_ascii=False)
+
+    @staticmethod
+    def _format_crawl_pages(pages) -> str:
+        """Format crawl page results as a readable JSON list."""
+        items = []
+        for page in pages:
+            item = {}
+            if hasattr(page, "url"):
+                item["url"] = page.url
+            elif hasattr(page, "metadata"):
+                meta = page.metadata
+                if isinstance(meta, dict):
+                    item["url"] = meta.get("url", meta.get("sourceURL", ""))
+                elif hasattr(meta, "url"):
+                    item["url"] = meta.url
+            if hasattr(page, "title"):
+                item["title"] = page.title
+            elif hasattr(page, "metadata") and isinstance(page.metadata, dict):
+                item["title"] = page.metadata.get("title", "")
+            markdown = getattr(page, "markdown", None)
+            if markdown:
+                item["markdown"] = markdown[:500]  # 截取前 500 字符作为摘要
+            items.append(item)
+        return json.dumps(items, ensure_ascii=False, indent=2)

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -27,6 +27,7 @@ class Config:
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],
         "github_token": ["github_token"],
+        "firecrawl": ["firecrawl_api_key"],
     }
 
     def __init__(self, config_path: Optional[Path] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,13 @@ dependencies = [
 [project.optional-dependencies]
 browser = ["playwright>=1.40"]
 cookies = ["browser-cookie3>=0.19"]
-all = ["playwright>=1.40", "mcp[cli]>=1.0", "browser-cookie3>=0.19"]
+firecrawl = ["firecrawl-py>=4.17"]
+all = [
+    "playwright>=1.40",
+    "mcp[cli]>=1.0",
+    "browser-cookie3>=0.19",
+    "firecrawl-py>=4.17",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.8",

--- a/tests/test_firecrawl_channel.py
+++ b/tests/test_firecrawl_channel.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+"""Tests for FirecrawlChannel."""
+
+from unittest.mock import Mock, patch
+
+from agent_reach.channels.firecrawl import FirecrawlChannel
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+def _make_document(markdown="Test content", **kwargs):
+    """Create a fake Firecrawl Document (pydantic or mock)."""
+    doc = Mock()
+    doc.markdown = markdown
+    doc.html = kwargs.get("html", f"<p>{markdown}</p>")
+    doc.metadata = kwargs.get("metadata", {"title": "Test Page", "url": "https://example.com"})
+    doc.summary = kwargs.get("summary", "")
+    doc.links = kwargs.get("links", [])
+    return doc
+
+
+def _make_credit_usage(remaining=500):
+    """Create a fake credit usage response."""
+    usage = Mock()
+    usage.remaining = remaining
+    return usage
+
+
+def _make_crawl_job(pages=None, job_id="job-123", status="completed"):
+    """Create a fake CrawlJob with optional pages."""
+    job = Mock()
+    job.id = job_id
+    if pages is not None:
+        job.pages = pages
+    return job
+
+
+def _make_search_data(items=None):
+    """Create a fake SearchData."""
+    data = Mock()
+    data.model_dump = Mock(return_value=items or [])
+    return data
+
+
+def _make_extract_data(data=None):
+    """Create a fake extract result."""
+    result = Mock()
+    result.model_dump = Mock(return_value=data or {})
+    return result
+
+
+# ------------------------------------------------------------------ #
+# can_handle
+# ------------------------------------------------------------------ #
+
+class TestCanHandle:
+    def test_accepts_http_url(self):
+        ch = FirecrawlChannel()
+        assert ch.can_handle("http://example.com") is True
+
+    def test_accepts_https_url(self):
+        ch = FirecrawlChannel()
+        assert ch.can_handle("https://www.example.com/page?q=1") is True
+
+    def test_accepts_any_string(self):
+        ch = FirecrawlChannel()
+        assert ch.can_handle("anything-at-all") is True
+
+    def test_accepts_empty_string(self):
+        ch = FirecrawlChannel()
+        assert ch.can_handle("") is True
+
+
+# ------------------------------------------------------------------ #
+# check()
+# ------------------------------------------------------------------ #
+
+class TestCheckFailures:
+    def test_missing_package(self):
+        """firecrawl-py 未安装 → off + 安装指引。"""
+        ch = FirecrawlChannel()
+        with patch.object(
+            FirecrawlChannel,
+            "_check_import",
+            return_value="未安装 firecrawl-py。安装：\n  pip install firecrawl-py",
+        ):
+            status, msg = ch.check()
+        assert status == "off"
+        assert "pip install firecrawl-py" in msg
+        assert ch.active_backend is None
+
+    def test_missing_api_key(self):
+        """包已安装但 Key 未设置 → off + 配置指引。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_check_import", return_value=None), \
+             patch.object(FirecrawlChannel, "_get_api_key", return_value=None):
+            status, msg = ch.check()
+        assert status == "off"
+        assert "API Key" in msg
+        assert "firecrawl.dev" in msg
+        assert ch.active_backend is None
+
+    def test_api_key_set_but_probe_fails(self):
+        """Key 已配置但连通性探测失败 → warn。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_check_import", return_value=None), \
+             patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.get_credit_usage.side_effect = Exception("Connection refused")
+            status, msg = ch.check()
+        assert status == "warn"
+        assert "Connection refused" in msg
+        assert ch.active_backend == "Firecrawl API"
+
+
+class TestCheckSuccess:
+    def test_everything_ok(self):
+        """包已装、Key 已配、探测成功 → ok。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_check_import", return_value=None), \
+             patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.get_credit_usage.return_value = _make_credit_usage(500)
+            status, msg = ch.check()
+        assert status == "ok"
+        assert "Firecrawl API 可用" in msg
+        assert ch.active_backend == "Firecrawl API"
+
+    def test_ok_shows_remaining_credits(self):
+        """探测成功时消息包含剩余额度。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_check_import", return_value=None), \
+             patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.get_credit_usage.return_value = _make_credit_usage(500)
+            _status, msg = ch.check()
+        assert "剩余额度 500" in msg
+
+
+# ------------------------------------------------------------------ #
+# read()
+# ------------------------------------------------------------------ #
+
+class TestRead:
+    def test_read_returns_markdown(self):
+        """read() 应返回 scrape 得到的 markdown 内容。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.scrape.return_value = _make_document("# Hello World")
+            result = ch.read("https://example.com")
+        assert result == "# Hello World"
+
+    def test_read_returns_empty_for_empty_page(self):
+        """空页面返回空字符串。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.scrape.return_value = _make_document("")
+            result = ch.read("https://example.com")
+        assert result == ""
+
+    def test_read_without_api_key_raises(self):
+        """未配置 Key 时 read() 抛出 RuntimeError。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value=None):
+            try:
+                ch.read("https://example.com")
+                assert False, "应抛出 RuntimeError"
+            except RuntimeError as exc:
+                assert "API Key" in str(exc)
+
+
+# ------------------------------------------------------------------ #
+# search()
+# ------------------------------------------------------------------ #
+
+class TestSearch:
+    def test_search_returns_json_string(self):
+        """search() 返回 JSON 字符串。"""
+        ch = FirecrawlChannel()
+        fake_items = [
+            {"url": "https://example.com/1", "title": "Result 1", "description": "Desc 1"},
+        ]
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.search.return_value = _make_search_data(fake_items)
+            result = ch.search("test query", limit=3)
+        assert "Result 1" in result
+        assert "example.com" in result
+
+    def test_search_respects_limit(self):
+        """search() 传递 limit 参数。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.search.return_value = _make_search_data([])
+            ch.search("query", limit=7)
+        mock_client.return_value.search.assert_called_once_with("query", limit=7)
+
+
+# ------------------------------------------------------------------ #
+# crawl()
+# ------------------------------------------------------------------ #
+
+class TestCrawl:
+    def test_crawl_with_pages_in_job(self):
+        """crawl() 返回的 CrawlJob 直接包含 pages。"""
+        ch = FirecrawlChannel()
+        page = Mock()
+        page.url = "https://example.com/page1"
+        page.title = "Page 1"
+        page.markdown = "# Page 1 Content"
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_job(pages=[page])
+            result = ch.crawl("https://example.com", max_depth=1, limit=5)
+        assert "example.com" in result
+        assert "Page 1" in result
+        assert "# Page 1 Content" in result
+
+    def test_crawl_polls_when_no_pages_directly(self):
+        """crawl() 无直接 pages 时通过 get_crawl_status 轮询。"""
+        ch = FirecrawlChannel()
+        page = Mock()
+        page.url = "https://example.com/page2"
+        page.title = "Page 2"
+        page.markdown = "Content 2"
+
+        job = _make_crawl_job(pages=None, job_id="job-456")
+        status_obj = Mock()
+        status_obj.status = "completed"
+        status_obj.pages = [page]
+
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.crawl.return_value = job
+            mock_client.return_value.get_crawl_status.return_value = status_obj
+            with patch("time.sleep", return_value=None):  # 跳过等待
+                result = ch.crawl("https://example.com")
+        assert "Page 2" in result
+
+    def test_crawl_failed_status(self):
+        """爬取失败时返回错误信息。"""
+        ch = FirecrawlChannel()
+        job = _make_crawl_job(pages=None, job_id="job-789")
+        status_obj = Mock()
+        status_obj.status = "failed"
+        status_obj.pages = None
+
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.crawl.return_value = job
+            mock_client.return_value.get_crawl_status.return_value = status_obj
+            with patch("time.sleep", return_value=None):
+                result = ch.crawl("https://example.com")
+        assert "爬取失败" in result
+
+    def test_crawl_passes_arguments_correctly(self):
+        """crawl() 正确传递 max_depth 和 limit。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.crawl.return_value = _make_crawl_job(pages=[])
+            ch.crawl("https://example.com", max_depth=3, limit=20)
+        mock_client.return_value.crawl.assert_called_once()
+        call_kwargs = mock_client.return_value.crawl.call_args.kwargs
+        assert call_kwargs["max_discovery_depth"] == 3
+        assert call_kwargs["limit"] == 20
+
+
+# ------------------------------------------------------------------ #
+# extract()
+# ------------------------------------------------------------------ #
+
+class TestExtract:
+    def test_extract_returns_json(self):
+        """extract() 返回结构化 JSON。"""
+        ch = FirecrawlChannel()
+        fake_data = {"name": "Test Co", "description": "A test company"}
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.extract.return_value = _make_extract_data(fake_data)
+            result = ch.extract(
+                ["https://example.com"],
+                prompt="Extract company info",
+            )
+        assert "Test Co" in result
+        assert "A test company" in result
+
+    def test_extract_passes_schema(self):
+        """extract() 传递可选的 JSON Schema。"""
+        ch = FirecrawlChannel()
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value="fc-test"), \
+             patch.object(FirecrawlChannel, "_make_client") as mock_client:
+            mock_client.return_value.extract.return_value = _make_extract_data({})
+            ch.extract(["https://example.com"], prompt="Extract name", schema=schema)
+        mock_client.return_value.extract.assert_called_once()
+        call_kwargs = mock_client.return_value.extract.call_args.kwargs
+        assert call_kwargs["schema"] == schema
+
+    def test_extract_without_api_key_raises(self):
+        """未配置 Key 时 extract() 抛出 RuntimeError。"""
+        ch = FirecrawlChannel()
+        with patch.object(FirecrawlChannel, "_get_api_key", return_value=None):
+            try:
+                ch.extract(["https://example.com"], prompt="test")
+                assert False, "应抛出 RuntimeError"
+            except RuntimeError as exc:
+                assert "API Key" in str(exc)
+
+
+# ------------------------------------------------------------------ #
+# Channel metadata
+# ------------------------------------------------------------------ #
+
+class TestChannelMetadata:
+    def test_name_and_tier(self):
+        ch = FirecrawlChannel()
+        assert ch.name == "firecrawl"
+        assert ch.tier == 1
+
+    def test_description_is_chinese(self):
+        ch = FirecrawlChannel()
+        assert "Firecrawl" in ch.description
+        assert "深度" in ch.description
+
+    def test_backends_list(self):
+        ch = FirecrawlChannel()
+        assert ch.backends == ["Firecrawl API"]
+
+    def test_active_backend_defaults_none(self):
+        ch = FirecrawlChannel()
+        assert ch.active_backend is None


### PR DESCRIPTION
Add a new Firecrawl-based channel for Agent-Reach that provides:

- **read()**: Scrape any URL to clean markdown via Firecrawl API
- **crawl()**: Deep crawl websites with configurable depth/limits
- **search()**: Web search with structured results
- **extract()**: AI-powered structured data extraction

The channel is **tier 1** (needs free API key from firecrawl.dev).
Gracefully reports missing dependencies and API key status in check().

### Changed files:
- agent_reach/channels/firecrawl.py - New FirecrawlChannel
- agent_reach/channels/__init__.py - Register FirecrawlChannel
- agent_reach/config.py - Add firecrawl to FEATURE_REQUIREMENTS
- tests/test_firecrawl_channel.py - 25 unit tests

Tests: **25/25 passing** + all contract tests pass.