### PR TITLE
fix: use saved Twitter credentials for health checks

### DIFF
--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -28,7 +28,7 @@ class TwitterChannel(Channel):
 
         for backend in self.ordered_backends(config):
             if backend == "twitter-cli":
-                result = self._check_twitter_cli()
+                result = self._check_twitter_cli(config)
             elif backend == "OpenCLI":
                 result = self._check_opencli()
             elif backend == "bird CLI (legacy)":
@@ -56,15 +56,30 @@ class TwitterChannel(Channel):
             "  uv tool install twitter-cli"
         )
 
-    def _check_twitter_cli(self):
+    def _check_twitter_cli(self, config=None):
         """探测 twitter-cli。返回 None 表示未安装，否则返回 (status, message)。
 
         `twitter status` 才是健康信号：已登录时输出 "ok: true"，
         未登录时以非零退出码输出 "not_authenticated"——工具本身是活的，
         所以 probe 的 error 状态也要看 output 内容再分类。
         """
+        env = None
+        if config:
+            auth_token = config.get("twitter_auth_token")
+            ct0 = config.get("twitter_ct0")
+            if auth_token and ct0:
+                env = {
+                    "TWITTER_AUTH_TOKEN": auth_token,
+                    "TWITTER_CT0": ct0,
+                }
+
         probe = probe_command(
-            "twitter", ["status"], timeout=15, retries=1, package="twitter-cli"
+            "twitter",
+            ["status"],
+            timeout=15,
+            retries=1,
+            package="twitter-cli",
+            env=env,
         )
         if probe.status == "missing":
             return None

--- a/agent_reach/probe.py
+++ b/agent_reach/probe.py
@@ -16,7 +16,7 @@ not just file existence.
 import shutil
 import subprocess
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Mapping, Optional, Sequence
 
 from agent_reach.utils.process import utf8_subprocess_env
 
@@ -50,6 +50,7 @@ def probe_command(
     timeout: int = 10,
     retries: int = 0,
     package: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
 ) -> ProbeResult:
     """Actually execute `cmd *args` and classify the result.
 
@@ -66,7 +67,7 @@ def probe_command(
 
     last: Optional[ProbeResult] = None
     for _ in range(retries + 1):
-        last = _run_once(path, args, timeout, package or cmd)
+        last = _run_once(path, args, timeout, package or cmd, env)
         if last.ok:
             return last
         # missing/broken won't heal between retries — only transient
@@ -76,15 +77,24 @@ def probe_command(
     return last
 
 
-def _run_once(path: str, args: Sequence[str], timeout: int, package: str) -> ProbeResult:
+def _run_once(
+    path: str,
+    args: Sequence[str],
+    timeout: int,
+    package: str,
+    env: Optional[Mapping[str, str]] = None,
+) -> ProbeResult:
     try:
+        subprocess_env = utf8_subprocess_env()
+        if env:
+            subprocess_env.update(env)
         r = subprocess.run(
             [path, *args],
             capture_output=True,
             encoding="utf-8",
             errors="replace",
             timeout=timeout,
-            env=utf8_subprocess_env(),
+            env=subprocess_env,
         )
     except FileNotFoundError:
         # which() found it but exec failed: the shebang interpreter is gone

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -49,6 +49,18 @@ def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
+def test_command_env_is_available_only_to_the_probed_process(tmp_path, monkeypatch):
+    script = _make_executable(
+        tmp_path / "env-tool", "#!/bin/sh\necho \"$PROBE_VALUE\"\n"
+    )
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+
+    r = probe_command("env-tool", env={"PROBE_VALUE": "from-probe-env"})
+    assert r.ok
+    assert r.output == "from-probe-env"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_nonzero_exit_classified_as_error(tmp_path, monkeypatch):
     script = _make_executable(
         tmp_path / "failing-tool", "#!/bin/sh\necho 'boom' >&2\nexit 3\n"

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -50,7 +50,7 @@ def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_command_env_is_available_only_to_the_probed_process(tmp_path, monkeypatch):
-    script = _make_executable(
+    _make_executable(
         tmp_path / "env-tool", "#!/bin/sh\necho \"$PROBE_VALUE\"\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -29,6 +29,25 @@ def test_check_twitter_cli_found_and_auth_ok():
     assert channel.active_backend == "twitter-cli"
 
 
+def test_check_twitter_cli_uses_credentials_saved_by_agent_reach():
+    """The health probe must use credentials persisted by configure twitter-cookies."""
+    channel = TwitterChannel()
+    config = Mock()
+    config.get.side_effect = lambda key: {
+        "twitter_auth_token": "saved-auth-token",
+        "twitter_ct0": "saved-ct0",
+    }.get(key)
+
+    with patch("shutil.which", return_value="/usr/local/bin/twitter"), patch(
+        "subprocess.run", return_value=_cp(stdout="ok: true\n", returncode=0)
+    ) as run:
+        status, _ = channel._check_twitter_cli(config)
+
+    assert status == "ok"
+    assert run.call_args.kwargs["env"]["TWITTER_AUTH_TOKEN"] == "saved-auth-token"
+    assert run.call_args.kwargs["env"]["TWITTER_CT0"] == "saved-ct0"
+
+
 def test_check_twitter_cli_found_auth_missing():
     """twitter-cli found + not_authenticated → warn about auth."""
     channel = TwitterChannel()


### PR DESCRIPTION
Fixes #506

## Summary
- allow `probe_command` callers to provide environment variables for the child process only
- load Twitter credentials saved by `agent-reach configure twitter-cookies` when probing `twitter status`
- add regression coverage for probe-local environment variables and configured Twitter credentials

## Validation
- `pytest` — 198 passed

The credentials are passed only to the `twitter status` child process; they are not printed or exported into the parent environment.