### PR TITLE
fix(doctor): match mcporter server names exactly

### DIFF
--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -4,6 +4,7 @@
 from agent_reach.probe import probe_command
 
 from .base import Channel
+from .mcporter import configured_server_names
 
 #: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
 _MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
@@ -20,7 +21,7 @@ class ExaSearchChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
+        probe = probe_command("mcporter", ["config", "list", "--json"], timeout=10, package="mcporter")
         if probe.status == "missing":
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
@@ -31,7 +32,7 @@ class ExaSearchChannel(Channel):
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
             return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "exa" in probe.output.lower():
+        if "exa" in configured_server_names(probe.output):
             self.active_backend = self.backends[0]
             return "ok", "全网语义搜索可用（免费，无需 API Key）"
         return "off", (

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -4,6 +4,7 @@
 from agent_reach.probe import probe_command
 
 from .base import Channel
+from .mcporter import configured_server_names
 
 #: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
 _MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
@@ -21,7 +22,7 @@ class LinkedInChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
+        probe = probe_command("mcporter", ["config", "list", "--json"], timeout=10, package="mcporter")
         if probe.status == "missing":
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
@@ -33,7 +34,7 @@ class LinkedInChannel(Channel):
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
             return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "linkedin" in probe.output.lower():
+        if "linkedin" in configured_server_names(probe.output):
             self.active_backend = "linkedin-scraper-mcp"
             return "ok", "完整可用（Profile、公司、职位搜索）"
         return "off", (

--- a/agent_reach/channels/mcporter.py
+++ b/agent_reach/channels/mcporter.py
@@ -1,0 +1,24 @@
+"""Helpers for interpreting mcporter's machine-readable config output."""
+
+from __future__ import annotations
+
+import json
+
+
+def configured_server_names(output: str) -> set[str]:
+    """Return configured server names without matching paths or other metadata."""
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError:
+        return set()
+
+    servers = payload.get("servers", []) if isinstance(payload, dict) else []
+    if not isinstance(servers, list):
+        return set()
+
+    return {
+        name.casefold()
+        for server in servers
+        if isinstance(server, dict)
+        if isinstance(name := server.get("name"), str)
+    }

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1218,7 +1218,7 @@ class TestLinkedInChannel:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "linkedin  http://localhost:3000/mcp", "")
+            return subprocess.CompletedProcess(cmd, 0, json.dumps({"servers": [{"name": "linkedin"}]}), "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
@@ -1227,11 +1227,28 @@ class TestLinkedInChannel:
         assert status == "ok"
         assert ch.active_backend == "linkedin-scraper-mcp"
 
+    def test_config_path_containing_linkedin_is_not_a_backend(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            payload = {
+                "servers": [{
+                    "name": "unrelated",
+                    "source": {"path": "/tmp/linkedin-project/config/mcporter.json"},
+                }],
+            }
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.linkedin import LinkedInChannel
+        status, _ = LinkedInChannel().check()
+        assert status == "off"
+
     def test_off_without_backend_when_linkedin_not_configured(self, monkeypatch):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa  https://mcp.exa.ai/mcp", "")
+            return subprocess.CompletedProcess(cmd, 0, json.dumps({"servers": [{"name": "exa"}]}), "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
@@ -1261,7 +1278,7 @@ class TestExaSearchChannel:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa  https://mcp.exa.ai/mcp", "")
+            return subprocess.CompletedProcess(cmd, 0, json.dumps({"servers": [{"name": "exa"}]}), "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.exa_search import ExaSearchChannel
@@ -1269,6 +1286,23 @@ class TestExaSearchChannel:
         status, msg = ch.check()
         assert status == "ok"
         assert ch.active_backend == "Exa via mcporter"
+
+    def test_config_path_containing_exa_is_not_a_backend(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            payload = {
+                "servers": [{
+                    "name": "unrelated",
+                    "source": {"path": "/tmp/example-project/config/mcporter.json"},
+                }],
+            }
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.exa_search import ExaSearchChannel
+        status, _ = ExaSearchChannel().check()
+        assert status == "off"
 
 
 class TestXiaoyuzhouChannel:


### PR DESCRIPTION
## Summary

- ask `mcporter config list` for JSON and match exact configured server names
- share the parser between the LinkedIn and Exa doctor checks
- add regressions for config paths containing `linkedin` or `exa` without either server being configured

## Root cause

The doctor channels substring-matched the full human-readable `mcporter config list` output. Its project config path contains the current working directory, so a directory such as `example-project` or `linkedin-project` could make an unconfigured backend appear healthy.

## Validation

- `python -m pytest tests -q` (`187 passed, 11 skipped`)
- `python -m ruff check agent_reach/channels/mcporter.py agent_reach/channels/linkedin.py agent_reach/channels/exa_search.py tests/test_channels.py`
- `python -m mypy --follow-imports=skip agent_reach/channels/mcporter.py`
- `git diff --check`

Fixes #508
