### PR TITLE
fix: bump dead yt-dlp pin and gate doctor's --js-runtimes prescription on version support

### DIFF
--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """YouTube — check if yt-dlp is available with JS runtime."""
 
+import re
 import shutil
 
 from agent_reach.probe import probe_command
@@ -8,6 +9,8 @@ from agent_reach.utils.paths import get_ytdlp_config_path, render_ytdlp_fix_comm
 from agent_reach.utils.text import read_utf8_text
 
 from .base import Channel
+
+_JS_RUNTIMES_SUPPORTED_FROM = (2026, 7, 4)
 
 
 def _has_js_runtime_config(config_path) -> bool:
@@ -18,6 +21,12 @@ def _has_js_runtime_config(config_path) -> bool:
         return "--js-runtimes" in read_utf8_text(config_path)
     except OSError:
         return False
+
+
+def _parse_ytdlp_version(version: str):
+    """Return a comparable yt-dlp version tuple, or ``None`` if unknown."""
+    match = re.fullmatch(r"\s*(\d+)\.(\d+)\.(\d+)\s*", version)
+    return tuple(map(int, match.groups())) if match else None
 
 
 class YouTubeChannel(Channel):
@@ -60,6 +69,12 @@ class YouTubeChannel(Channel):
         if not has_deno:
             ytdlp_config = get_ytdlp_config_path()
             if not _has_js_runtime_config(ytdlp_config):
+                version = _parse_ytdlp_version(probe.output)
+                if version is not None and version < _JS_RUNTIMES_SUPPORTED_FROM:
+                    return "warn", (
+                        "yt-dlp 版本过旧，无法配置 JS runtime。请升级：\n"
+                        "  pip install -U yt-dlp"
+                    )
                 return "warn", (
                     f"yt-dlp 已安装但未配置 JS runtime。运行：\n  {render_ytdlp_fix_command()}"
                 )
@@ -88,4 +103,3 @@ class YouTubeChannel(Channel):
         from agent_reach.transcribe import transcribe as _transcribe
 
         return _transcribe(url, provider=provider, config=config)
-

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ python-dotenv==1.2.1
 loguru==0.7.3
 PyYAML==6.0.3
 rich==14.3.2
-yt-dlp==2025.5.22
+yt-dlp==2026.7.4
 
 pytest==8.0.0
 ruff==0.15.1

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -11,11 +11,12 @@ channel coverage after rss (#360), github (#361), web (#363),
 reddit (#364), xueqiu (#365) and v2ex (#366).
 """
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
-from agent_reach.probe import ProbeResult
 from agent_reach.channels import youtube as yt
 from agent_reach.channels.youtube import YouTubeChannel, _has_js_runtime_config
+from agent_reach.probe import ProbeResult
 
 
 def _which(*present):
@@ -104,12 +105,44 @@ def test_check_warn_when_no_js_runtime_but_backend_active():
 
 def test_check_warn_when_node_only_and_config_missing_flag():
     ch = YouTubeChannel()
-    with patch.object(yt, "probe_command", return_value=ProbeResult("ok")), \
+    probe = ProbeResult("ok", output="2026.07.04")
+    with patch.object(yt, "probe_command", return_value=probe), \
          patch("shutil.which", side_effect=_which("node")), \
          patch.object(yt, "_has_js_runtime_config", return_value=False):
         status, message = ch.check()
     assert status == "warn"
+    assert "--js-runtimes" in message
     assert ch.active_backend == "yt-dlp"
+
+
+def test_check_warns_to_upgrade_stale_ytdlp_before_prescribing_node_runtime():
+    ch = YouTubeChannel()
+    with patch.object(yt, "probe_command", return_value=ProbeResult("ok", output="2025.05.22")), \
+         patch("shutil.which", side_effect=_which("node")), \
+         patch.object(yt, "_has_js_runtime_config", return_value=False):
+        status, message = ch.check()
+    assert status == "warn"
+    assert "pip install -U yt-dlp" in message
+    assert "--js-runtimes" not in message
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_keeps_node_runtime_prescription_for_unparseable_ytdlp_version():
+    for output in ("", "dev"):
+        ch = YouTubeChannel()
+        with patch.object(yt, "probe_command", return_value=ProbeResult("ok", output=output)), \
+             patch("shutil.which", side_effect=_which("node")), \
+             patch.object(yt, "_has_js_runtime_config", return_value=False):
+            status, message = ch.check()
+        assert status == "warn"
+        assert "--js-runtimes" in message
+
+
+def test_constraints_pin_ytdlp_to_2026_or_later():
+    constraints = Path(__file__).parents[1] / "constraints.txt"
+    pin = next(line for line in constraints.read_text(encoding="utf-8").splitlines()
+               if line.startswith("yt-dlp=="))
+    assert int(pin.removeprefix("yt-dlp==").split(".", 1)[0]) >= 2026
 
 
 def test_check_ok_with_deno():


### PR DESCRIPTION
## Summary

`doctor` on a Node-only machine prescribes appending `--js-runtimes node` to the yt-dlp config, but `constraints.txt` pins `yt-dlp==2025.5.22`, which doesn't support that flag, so every subsequent yt-dlp call dies with `error: no such option: --js-runtimes`. This bumps the pin to a current release and gates the prescription on the installed yt-dlp version so the tested pin and doctor's advice can no longer contradict each other.

## Background

The reporter (ayoubagrebi062-hue, #503) verified two coupled problems: the ~14-month-old pin can no longer parse 2026 YouTube (`YoutubeIEContentProviderLogger.debug() got an unexpected keyword argument 'once'`), and even after upgrading yt-dlp by hand, re-running the documented `pip install -c constraints.txt ...` downgrades it back to the broken pin. Meanwhile `YouTubeChannel.check()` prescribes `--js-runtimes`, a flag `2025.5.22` rejects.

This makes two coordinated changes, mapping to the reporter's own suggestions:

- `constraints.txt`: pin `yt-dlp==2026.7.4` (the reporter-verified working version), which parses 2026 YouTube and supports `--js-runtimes`.
- `YouTubeChannel.check()`: the probe already runs `yt-dlp --version`, so parse that in-process and only prescribe `--js-runtimes` when the installed version is at/above the supported floor. Below the floor it returns a `warn` telling the user to `pip install -U yt-dlp` instead of printing a flag the binary will reject; empty or unparseable version output falls back to today's prescription so nothing regresses. `paths.py` (which renders the fix command) is untouched.

Added tests to `tests/test_youtube_channel.py` covering the supported, stale, and unparseable-version paths, the unchanged deno path, and a consistency guard asserting `constraints.txt` pins a 2026-or-later release. `pytest tests/test_youtube_channel.py` passes (16 tests).

Closes #503
