### PR TITLE
fix(doctor): detect OpenCLI extension on Edge and unpacked installs

### DIFF
--- a/agent_reach/backends/opencli.py
+++ b/agent_reach/backends/opencli.py
@@ -13,7 +13,8 @@ Probing notes (verified live):
     service worker sleeps and any real opencli command wakes it up
     (verified: status flips disconnected→connected after one call).
     Since daemon status can't tell "sleeping" from "never installed",
-    we check Chrome's Extensions directory on disk to disambiguate.
+    we check Chrome/Edge/Chromium Extensions directories and OpenCLI's
+    unpacked layout on disk to disambiguate.
 """
 
 import glob
@@ -28,30 +29,38 @@ OPENCLI_EXTENSION_URL = (
     f"https://chromewebstore.google.com/detail/opencli/{OPENCLI_EXTENSION_ID}"
 )
 
-#: Chrome-family profile roots that contain <Profile>/Extensions/<id>/
+#: Chromium-family profile roots that contain <Profile>/Extensions/<id>/
 _CHROME_PROFILE_ROOTS = (
     "~/Library/Application Support/Google/Chrome",  # macOS Chrome
     "~/Library/Application Support/Chromium",       # macOS Chromium
+    "~/Library/Application Support/Microsoft Edge",  # macOS Edge
     "~/.config/google-chrome",                      # Linux Chrome
     "~/.config/chromium",                           # Linux Chromium
+    "~/.config/microsoft-edge",                     # Linux Edge
 )
+
+_OPENCLI_UNPACKED_EXTENSION = "~/.opencli/extension"
 
 
 def _extension_installed_on_disk() -> bool:
-    """True if the OpenCLI extension exists in any Chrome profile.
+    """True if the OpenCLI extension exists on disk.
 
-    Store-installed extensions always live under
-    <profile>/Extensions/<extension id>/ — this disambiguates a sleeping
-    service worker from a never-installed extension. Dev installs via
-    "Load unpacked" are not covered (those users can read `opencli doctor`).
+    Covers Chrome Web Store installs under any known Chrome/Edge/Chromium
+    profile, plus OpenCLI's common unpacked layout at ~/.opencli/extension/
+    (Load unpacked in Chrome or Edge). Distinguishes a sleeping service
+    worker from a never-installed extension without calling `opencli doctor`.
     """
     roots = [os.path.expanduser(p) for p in _CHROME_PROFILE_ROOTS]
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:  # Windows
         roots.append(os.path.join(local_app_data, "Google", "Chrome", "User Data"))
+        roots.append(os.path.join(local_app_data, "Microsoft", "Edge", "User Data"))
     for root in roots:
         if glob.glob(os.path.join(root, "*", "Extensions", OPENCLI_EXTENSION_ID)):
             return True
+    unpacked = os.path.expanduser(_OPENCLI_UNPACKED_EXTENSION)
+    if os.path.isfile(os.path.join(unpacked, "manifest.json")):
+        return True
     return False
 
 
@@ -114,9 +123,10 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
         st.extension_installed = _extension_installed_on_disk()
         if not st.extension_installed:
             st.hint = (
-                "OpenCLI 已安装，但 Chrome 扩展未安装。\n"
-                f"  1. 安装扩展（需手动点一次）：{OPENCLI_EXTENSION_URL}\n"
-                "  2. 保持 Chrome 打开，运行 `opencli doctor` 验证"
+                "OpenCLI 已安装，但浏览器扩展未安装。\n"
+                f"  1. 安装扩展（Chrome 商店或 Edge/Chrome Load unpacked）："
+                f"{OPENCLI_EXTENSION_URL}\n"
+                "  2. 保持浏览器打开，运行 `opencli doctor` 验证"
             )
     return st
 

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for the OpenCLI cross-channel backend probing."""
 
+import os
+from pathlib import Path
 from unittest.mock import patch
 
 from agent_reach.backends import opencli_status, opencli_summary
+from agent_reach.backends.opencli import OPENCLI_EXTENSION_ID, _extension_installed_on_disk
 from agent_reach.probe import ProbeResult
 
 
@@ -98,3 +101,44 @@ def test_probe_uses_daemon_status_not_doctor():
     )
     assert ["daemon", "status"] in calls
     assert ["doctor"] not in calls
+
+
+def test_extension_installed_detects_edge_profile(tmp_path, monkeypatch):
+    edge_root = tmp_path / "Microsoft Edge"
+    ext_dir = edge_root / "Default" / "Extensions" / OPENCLI_EXTENSION_ID / "1.0.0"
+    ext_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "agent_reach.backends.opencli._CHROME_PROFILE_ROOTS",
+        (str(edge_root),),
+    )
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    (tmp_path / "empty-home").mkdir()
+
+    assert _extension_installed_on_disk() is True
+
+
+def test_extension_installed_detects_opencli_unpacked_dir(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    manifest = home / ".opencli" / "extension" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"name": "OpenCLI"}', encoding="utf-8")
+
+    monkeypatch.setattr("agent_reach.backends.opencli._CHROME_PROFILE_ROOTS", ())
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(home / p.replace("~/", "")))
+
+    assert _extension_installed_on_disk() is True
+
+
+def test_extension_installed_false_without_chrome_edge_or_unpacked(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("agent_reach.backends.opencli._CHROME_PROFILE_ROOTS", ())
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(home / p.replace("~/", "")))
+
+    assert _extension_installed_on_disk() is False

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for the OpenCLI cross-channel backend probing."""
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -128,7 +127,6 @@ def test_extension_installed_detects_opencli_unpacked_dir(tmp_path, monkeypatch)
     monkeypatch.setattr("agent_reach.backends.opencli._CHROME_PROFILE_ROOTS", ())
     monkeypatch.delenv("LOCALAPPDATA", raising=False)
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(os.path, "expanduser", lambda p: str(home / p.replace("~/", "")))
 
     assert _extension_installed_on_disk() is True
 
@@ -139,6 +137,5 @@ def test_extension_installed_false_without_chrome_edge_or_unpacked(tmp_path, mon
     monkeypatch.setattr("agent_reach.backends.opencli._CHROME_PROFILE_ROOTS", ())
     monkeypatch.delenv("LOCALAPPDATA", raising=False)
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(os.path, "expanduser", lambda p: str(home / p.replace("~/", "")))
 
     assert _extension_installed_on_disk() is False


### PR DESCRIPTION
## Summary
- Widen OpenCLI on-disk extension detection to Microsoft Edge profile roots (macOS/Linux/Windows).
- Treat `~/.opencli/extension/manifest.json` as an unpacked install so sleeping extensions no longer false-negative in `doctor`.
- Soften the missing-extension hint so it is not Chrome-only.

Fixes #513.

## Test plan
- [x] `pytest tests/test_opencli_backend.py -v`
- [x] `pytest tests/ -q`
- [ ] Manual (optional): Edge + Load unpacked from `~/.opencli/extension`, leave extension disconnected/sleeping, confirm `agent-reach doctor --json` reports reddit/facebook/instagram/xiaohongshu ready when disk path exists


Made with [Cursor](https://cursor.com)