### PR TITLE
Fix get_hot_posts ignoring the limit parameter

### DIFF
--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -259,7 +259,7 @@ class XueqiuChannel(Channel):
         """
         data = _get_json(
             "https://xueqiu.com/v4/statuses/public_timeline_by_category.json"
-            "?since_id=-1&max_id=-1&count=20&category=-1"
+            f"?since_id=-1&max_id=-1&count={limit}&category=-1"
         )
         items = data.get("list") or []
         results = []


### PR DESCRIPTION
## Problem

`XueqiuChannel.get_hot_posts(limit)` (`agent_reach/channels/xueqiu.py`) documents its argument as `limit: 最多返回条数（上限 50）` ("max number of posts to return, up to 50"), but the request hard-codes the page size to `count=20`:

```python
data = _get_json(
    "https://xueqiu.com/v4/statuses/public_timeline_by_category.json"
    "?since_id=-1&max_id=-1&count=20&category=-1"
)
items = data.get("list") or []
results = []
for item in items[:limit]:
    ...
```

The server therefore never returns more than 20 posts, and the later `items[:limit]` slice can only shrink those 20 — it can never reach the documented maximum. So `get_hot_posts(limit=50)` silently returns just 20.

## Evidence (siblings prove intent)

The two sibling methods in the same file thread `limit` into the page-size parameter:

- `search_stock`: `f"?code={...}&size={limit}"`
- `get_hot_stocks`: `f"?size={limit}&type={stock_type}"`

Both then slice `items[:limit]`. `get_hot_posts` is the only one that omits `limit` from the request.

## Reproduction

Against a stub that honors the URL's page-size (the same contract the `size={limit}` siblings rely on):

| call | before | after |
|---|---|---|
| `get_hot_posts(limit=50)` | 20 ❌ | 50 ✅ |

## Fix

```python
f"?since_id=-1&max_id=-1&count={limit}&category=-1"
```

Matches the `size={limit}` pattern of both siblings so the requested count is honored.
