### PR TITLE
docs(skill): route WeChat article URLs away from Jina

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
   Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
-  雪球/股票行情, RSS feeds, or any web URL.
+  雪球/股票行情, RSS feeds, 微信公众号/weixin/mp.weixin.qq.com, or any web URL.
 
   15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
@@ -32,7 +32,7 @@ triggers:
     - Instagram: instagram/ig
   - career: 招聘/职位/求职/linkedin/领英/找工作
   - dev: github/代码/仓库/gh/issue/pr/分支/commit
-  - web: 网页/链接/文章/rss/读一下/打开这个
+  - web: 网页/链接/文章/rss/读一下/打开这个/微信公众号/微信文章/mp.weixin.qq.com
   - video: youtube/视频/播客/字幕/小宇宙/转录/yt
   - finance: 雪球/股票/stock/xueqiu/行情/基金
 metadata:
@@ -65,7 +65,7 @@ metadata:
 | 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
-| 网页/文章/RSS | web | [references/web.md](references/web.md) |
+| 网页/文章/RSS（含微信公众号直链，非零配置） | web | [references/web.md](references/web.md) |
 | YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
 
 ## 零配置快速命令
@@ -129,7 +129,7 @@ agent-reach doctor --json
 - [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
-- [网页阅读](references/web.md) — Jina Reader, RSS
+- [网页阅读](references/web.md) — Jina Reader, RSS, 微信公众号（Tier-2，勿用 Jina）
 - [视频播客](references/video.md) — YouTube, B站, 小宇宙
 
 ## 配置渠道

--- a/agent_reach/skill/references/web.md
+++ b/agent_reach/skill/references/web.md
@@ -1,6 +1,53 @@
 # 网页阅读
 
-通用网页、RSS。
+通用网页、RSS。**微信公众号文章链接除外** — 见下方专用路由（非零配置）。
+
+## 微信公众号 (`mp.weixin.qq.com`) — 勿用 Jina
+
+微信对数据中心 IP 返回「环境异常」验证页。Jina Reader、WebFetch、Tavily extract 等**响应很快但内容无效**（拿到的是验证页，不是正文）。
+
+**适用**：用户已提供单篇文章链接（`https://mp.weixin.qq.com/s/...`）。  
+**不适用**：在公众号内「搜索关键词」— Exa 等搜索引擎对微信全文索引极差，应请用户提供直链。
+
+### 推荐：独立工具（需安装浏览器自动化）
+
+维护者提供的专用工具（Camoufox 反检测 + MCP/CLI）：
+
+```bash
+git clone https://github.com/Panniantong/wechat-article-for-ai.git
+cd wechat-article-for-ai
+pip install -r requirements.txt
+python main.py "https://mp.weixin.qq.com/s/ARTICLE_ID"
+```
+
+- 遇 CAPTCHA：加 `--no-headless` 手动过验证后重试
+- Agent 集成：仓库内含 MCP server 与 SKILL.md
+
+### 备选：Agent 自带浏览器 MCP
+
+若环境已有 Playwright / browser MCP（如 Cursor `user-Playwright`）：
+
+1. `browser_navigate` 打开文章 URL
+2. `browser_snapshot` 读取正文（通常比 Jina 可靠）
+
+### 禁止
+
+对 `mp.weixin.qq.com` 使用：
+
+```bash
+# BAD — returns verification page, not article body
+curl -s "https://r.jina.ai/https://mp.weixin.qq.com/s/ARTICLE_ID"
+```
+
+### 已知坑
+
+| 问题 | 处理 |
+|------|------|
+| Windows Python 输出中文报 `UnicodeEncodeError` | 设 `PYTHONUTF8=1` 或 `python -X utf8`，或输出到文件 |
+| 页面显示环境异常 / CAPTCHA | 换浏览器自动化方案；`wechat-article-for-ai --no-headless` |
+| 误以为 Jina 超时=网络慢 | 实际是反爬；不要用 Jina 重试 |
+
+> Agent Reach v1.4+ 不再把微信公众号列为零配置 channel（#347）。有直链时用本节的 Tier-2 方案，避免虚假「已读取」。
 
 ## 通用网页 (Jina Reader)
 
@@ -45,6 +92,7 @@ for e in feedparser.parse('FEED_URL').entries[:5]:
 
 | 场景 | 推荐工具 |
 |-----|---------|
+| **微信公众号文章直链** | [wechat-article-for-ai](https://github.com/Panniantong/wechat-article-for-ai) 或 browser MCP（**勿用 Jina**） |
 | 通用网页 | Jina Reader (`curl r.jina.ai`) |
 | 需要图片/格式控制 | web-reader MCP |
 | RSS 订阅 | feedparser |


### PR DESCRIPTION
## Summary

- Add a **WeChat article** section to `references/web.md` for `mp.weixin.qq.com/s/...` links (Tier-2, **not** zero-config).
- Explain why Jina/WebFetch/Tavily fail fast with a verification page instead of article body.
- Point agents to [wechat-article-for-ai](https://github.com/Panniantong/wechat-article-for-ai) (maintainer tool) and browser MCP as fallbacks.
- Document Windows `UnicodeEncodeError` / CAPTCHA gotchas from real-world testing.
- Extend `SKILL.md` triggers so agents route 微信公众号/weixin URLs to `web.md` instead of default Jina.

## Context

After #347 removed the WeChat channel (correctly — it was advertised as zero-config but unreliable), agents still hit #339-style failures when users share a direct article link: they try Jina, get a fast “success” with useless content, or misdiagnose it as a network timeout.

This PR does **not** re-add a WeChat channel to `doctor.py`. It only documents honest routing consistent with the v1.4+ philosophy.

## Test plan

- [x] Docs-only change; no code/tests affected
- [x] Verified locally: `mp.weixin.qq.com` + Jina returns 环境异常 page; Playwright / `wechat-article-for-ai` returns full text
- [ ] Maintainer review: wording + whether to link `wechat-article-for-ai` as the canonical recommendation


Made with [Cursor](https://cursor.com)