### PR TITLE
feat(channels): add Discord and Telegram support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.6.0] - 2026-07-22
+
+### ✨ Features / 新增
+
+#### 🎮 Discord + ✈️ Telegram —— 两个新渠道
+
+- **Discord**（`discord-cli` / PyPI `kabi-discord-cli`，命令 `discord`）：用账号 user token 走 Discord HTTP API，同步/搜索/导出你能访问的服务器与频道消息，本地优先存 SQLite。⚠️ user token 自动化违反 Discord ToS，建议使用专用小号。
+- **Telegram**（`tg-cli` / PyPI `kabi-tg-cli`，命令 `tg`）：MTProto 用户账号（非 Bot API），同步/搜索/导出/监听对话与频道，可读你加入的私有群。首次 `tg chats` 手机号登录。
+- 两者均为 tier-1 单后端渠道，`check()` 以 `status` 退出码作认证信号（0 = 已登录），设计参照小红书 / Twitter 渠道，保持一致。
+- 已接入 `agent-reach doctor`、`agent-reach install --channels discord,telegram`、SKILL.md 路由表与 references/social.md 命令组；新增 `guides/setup-discord.md` / `guides/setup-telegram.md` 配置指南。
+- 支持平台数 15 → 17。
+
+---
+
 ## [1.3.1] - 2026-03-27
 
 ### 🐛 Bug Fixes / 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - 两者均为 tier-1 单后端渠道，`check()` 以 `status` 退出码作认证信号（0 = 已登录），设计参照小红书 / Twitter 渠道，保持一致。
 - 已接入 `agent-reach doctor`、`agent-reach install --channels discord,telegram`、SKILL.md 路由表与 references/social.md 命令组；新增 `guides/setup-discord.md` / `guides/setup-telegram.md` 配置指南。
 - 支持平台数 15 → 17。
+- 健壮性：`probe_command` 健康探测改用 `stdin=DEVNULL`，避免像 `tg status` 这类未配置时会交互式提示（要求输入手机号）的命令在 `doctor` 里阻塞到超时。由新 Telegram 渠道触发，惠及所有渠道。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📘 **Facebook** | — | 搜索、主页、Feed、群组列表 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📕 **小红书** | — | 搜索、阅读、评论 | 桌面装 OpenCLI（刷过小红书即可用）；服务器用 xiaohongshu-mcp 扫码 |
+| 🎮 **Discord** | — | 服务器/频道消息同步、搜索、导出 | 告诉 Agent「帮我配 Discord」（user token，建议专用小号） |
+| ✈️ **Telegram** | — | 对话/频道消息同步、搜索、导出、监听 | 告诉 Agent「帮我配 Telegram」（手机号登录一次） |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
 | 📈 **雪球** | 股票行情、搜索股票、热门帖子、热门股票排行 | — | 告诉 Agent「帮我配雪球」 |
@@ -212,6 +214,8 @@ channels/
 | GitHub | [gh CLI](https://cli.github.com) | — | 官方工具，认证后完整 API 能力 |
 | 读 RSS | [feedparser](https://github.com/kurtmckee/feedparser) | — | Python 生态标准选择 |
 | 小红书 | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)（服务器）▸ xhs-cli | xhs-cli 作者已转投 OpenCLI（24K Star）；浏览器登录态零摩擦 |
+| Discord | [discord-cli](https://github.com/jackwener/discord-cli) | — | user token 走 HTTP API，本地优先同步进 SQLite；注意 ToS/封号风险 |
+| Telegram | [tg-cli](https://github.com/jackwener/tg-cli) | — | MTProto 用户账号（非 Bot API），可读私有群/频道，本地优先同步 |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | Jina Reader | MCP 服务，浏览器自动化 |
 
 > 📌 这些都是「当前选型」，基于真机实测定期复核。某条路失效了我们换下一条——`agent-reach doctor` 永远告诉你现在走的是哪条。

--- a/agent_reach/__init__.py
+++ b/agent_reach/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Agent Reach — Give your AI Agent eyes to see the entire internet."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __author__ = "Neo Reid"
 
 from agent_reach.core import AgentReach

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 # Import all channels
 from .base import Channel
 from .bilibili import BilibiliChannel
+from .discord import DiscordChannel
 from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
@@ -15,6 +16,7 @@ from .instagram import InstagramChannel
 from .linkedin import LinkedInChannel
 from .reddit import RedditChannel
 from .rss import RSSChannel
+from .telegram import TelegramChannel
 from .twitter import TwitterChannel
 from .v2ex import V2EXChannel
 from .web import WebChannel
@@ -32,6 +34,8 @@ ALL_CHANNELS: List[Channel] = [
     InstagramChannel(),
     BilibiliChannel(),
     XiaoHongShuChannel(),
+    DiscordChannel(),
+    TelegramChannel(),
     LinkedInChannel(),
     XiaoyuzhouChannel(),
     V2EXChannel(),

--- a/agent_reach/channels/discord.py
+++ b/agent_reach/channels/discord.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Discord — discord-cli（用户 token，本地优先同步/搜索/导出）。
+
+单后端：discord-cli（PyPI 包 kabi-discord-cli，命令 `discord`）。它用本地
+Discord/浏览器会话里的 **user token** 走 Discord HTTP API，把消息同步进本地
+SQLite 供人和 Agent 查询。健康信号取 `discord status`：已登录时退出码 0，
+未认证/token 失效时非零退出并输出 not_authenticated——所以退出码就是认证态，
+无需解析富文本。
+
+风险提示：user token 自动化违反 Discord ToS，可能触发风控封号，务必只在
+自己的、可承受风险的账号上使用（见 guides/setup-discord.md）。
+"""
+
+from agent_reach.probe import probe_command
+
+from .base import Channel
+
+
+class DiscordChannel(Channel):
+    name = "discord"
+    description = "Discord 服务器与频道消息"
+    backends = ["discord-cli"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "discord.com" in d or "discord.gg" in d or "discordapp.com" in d
+
+    def check(self, config=None):
+        """探测唯一后端 discord-cli；ok 直接当选，warn 兜底给出处方。"""
+        self.active_backend = None
+        findings = []
+
+        for backend in self.ordered_backends(config):
+            if backend == "discord-cli":
+                result = self._check_discord_cli()
+            else:
+                continue
+            if result is None:
+                continue  # 未安装——不参与候选
+            findings.append((backend, *result))
+
+        for wanted in ("ok", "warn"):
+            for backend, status, message in findings:
+                if status == wanted:
+                    self.active_backend = backend
+                    return status, message
+
+        if findings:  # 只剩 broken/timeout 候选
+            return "error", "\n".join(m for _, _, m in findings)
+
+        return "off", (
+            "未安装 discord-cli。安装方式：\n"
+            "  uv tool install kabi-discord-cli\n"
+            "或：pipx install kabi-discord-cli\n"
+            "装好后运行 `discord auth --save` 登录（详见 setup-discord.md）"
+        )
+
+    def _check_discord_cli(self):
+        """探测 discord-cli。返回 None 表示未安装，否则返回 (status, message)。
+
+        `discord status` 才是健康信号：已登录退出码 0；未认证时非零退出并输出
+        not_authenticated——工具进程是活的，业务态归为 warn。
+        """
+        probe = probe_command(
+            "discord", ["status"], timeout=15, retries=1, package="kabi-discord-cli"
+        )
+        if probe.status == "missing":
+            return None
+        if probe.status == "broken":
+            return "error", "discord 命令存在但无法执行。\n" + probe.hint
+        if probe.status == "timeout":
+            return "error", "discord-cli 健康检查超时（已重试 1 次）。\n" + probe.hint
+
+        if probe.ok:  # 退出码 0 == 已认证
+            return "ok", (
+                "discord-cli 完整可用（列服务器/频道、读历史、搜索、导出、AI 分析）"
+            )
+
+        # 进程活着但非零退出——业务态，多为未认证
+        output = probe.output
+        if "not_authenticated" in output or "invalid_token" in output:
+            return "warn", (
+                "discord-cli 已安装但未认证。运行：\n"
+                "  discord auth --save\n"
+                "（自动从本地 Discord/浏览器会话提取 user token）"
+            )
+        return "warn", (
+            "discord-cli 已安装但状态检查失败。运行：\n"
+            "  discord status 查看详细信息"
+        )

--- a/agent_reach/channels/telegram.py
+++ b/agent_reach/channels/telegram.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""Telegram — tg-cli（MTProto 用户账号，本地优先同步/搜索/导出）。
+
+单后端：tg-cli（PyPI 包 kabi-tg-cli，命令 `tg`）。它用你自己的 Telegram 账号
+走 MTProto（不是 Bot API），把对话同步进本地 SQLite 供人和 Agent 查询。
+健康信号取 `tg status`：已登录时退出码 0，未登录时非零退出——退出码即认证态。
+
+自带 Telegram Desktop API 凭据，首次运行 `tg chats` 输入手机号+验证码即可登录，
+无需自建应用（也可用 TG_API_ID / TG_API_HASH 覆盖，见 guides/setup-telegram.md）。
+"""
+
+from agent_reach.probe import probe_command
+
+from .base import Channel
+
+
+class TelegramChannel(Channel):
+    name = "telegram"
+    description = "Telegram 对话与频道消息"
+    backends = ["tg-cli"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        from urllib.parse import urlparse
+        d = urlparse(url).netloc.lower()
+        return "t.me" in d or "telegram.me" in d or "telegram.dog" in d
+
+    def check(self, config=None):
+        """探测唯一后端 tg-cli；ok 直接当选，warn 兜底给出处方。"""
+        self.active_backend = None
+        findings = []
+
+        for backend in self.ordered_backends(config):
+            if backend == "tg-cli":
+                result = self._check_tg_cli()
+            else:
+                continue
+            if result is None:
+                continue  # 未安装——不参与候选
+            findings.append((backend, *result))
+
+        for wanted in ("ok", "warn"):
+            for backend, status, message in findings:
+                if status == wanted:
+                    self.active_backend = backend
+                    return status, message
+
+        if findings:  # 只剩 broken/timeout 候选
+            return "error", "\n".join(m for _, _, m in findings)
+
+        return "off", (
+            "未安装 tg-cli。安装方式：\n"
+            "  uv tool install kabi-tg-cli\n"
+            "或：pipx install kabi-tg-cli\n"
+            "装好后运行 `tg chats` 完成手机号登录（详见 setup-telegram.md）"
+        )
+
+    def _check_tg_cli(self):
+        """探测 tg-cli。返回 None 表示未安装，否则返回 (status, message)。
+
+        `tg status` 才是健康信号：已登录退出码 0；未登录时非零退出——工具进程
+        是活的，业务态归为 warn。
+        """
+        probe = probe_command(
+            "tg", ["status"], timeout=15, retries=1, package="kabi-tg-cli"
+        )
+        if probe.status == "missing":
+            return None
+        if probe.status == "broken":
+            return "error", "tg 命令存在但无法执行。\n" + probe.hint
+        if probe.status == "timeout":
+            return "error", "tg-cli 健康检查超时（已重试 1 次）。\n" + probe.hint
+
+        if probe.ok:  # 退出码 0 == 已登录
+            return "ok", (
+                "tg-cli 完整可用（同步对话、读历史、搜索、导出、实时监听）"
+            )
+
+        # 进程活着但非零退出——业务态，多为未登录
+        return "warn", (
+            "tg-cli 已安装但未登录。运行：\n"
+            "  tg chats\n"
+            "（首次运行输入手机号+验证码完成登录）"
+        )

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -75,7 +75,8 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,bilibili,discord,"
+                                "telegram,linkedin,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -202,6 +203,8 @@ def _cmd_install(args):
         "facebook":    _install_opencli_deps,
         "instagram":   _install_opencli_deps,
         "bilibili":    _install_bili_deps,
+        "discord":     _install_discord_deps,
+        "telegram":    _install_telegram_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
         # linkedin: manual setup, no auto-install
@@ -860,6 +863,56 @@ def _install_bili_deps():
             except Exception:
                 pass
     print("  [!]  bili-cli install failed. Run: pipx install bilibili-cli")
+
+
+def _install_discord_deps():
+    """Install discord-cli for Discord sync/search/export."""
+    import shutil
+    import subprocess
+
+    print("Setting up Discord (discord-cli)...")
+    if shutil.which("discord"):
+        print("  ✅ discord-cli already installed")
+        print("     登录：discord auth --save（自动提取本地会话 user token）")
+        return
+    for tool, cmd in [("pipx", ["pipx", "install", "kabi-discord-cli"]),
+                      ("uv", ["uv", "tool", "install", "kabi-discord-cli"])]:
+        if shutil.which(tool):
+            try:
+                subprocess.run(cmd, capture_output=True, encoding="utf-8",
+                               errors="replace", timeout=120)
+                if shutil.which("discord"):
+                    print("  ✅ discord-cli installed")
+                    print("     登录：discord auth --save（自动提取本地会话 user token）")
+                    return
+            except Exception:
+                pass
+    print("  [!]  discord-cli install failed. Run: pipx install kabi-discord-cli")
+
+
+def _install_telegram_deps():
+    """Install tg-cli for Telegram sync/search/export."""
+    import shutil
+    import subprocess
+
+    print("Setting up Telegram (tg-cli)...")
+    if shutil.which("tg"):
+        print("  ✅ tg-cli already installed")
+        print("     登录：tg chats（首次输入手机号+验证码）")
+        return
+    for tool, cmd in [("pipx", ["pipx", "install", "kabi-tg-cli"]),
+                      ("uv", ["uv", "tool", "install", "kabi-tg-cli"])]:
+        if shutil.which(tool):
+            try:
+                subprocess.run(cmd, capture_output=True, encoding="utf-8",
+                               errors="replace", timeout=120)
+                if shutil.which("tg"):
+                    print("  ✅ tg-cli installed")
+                    print("     登录：tg chats（首次输入手机号+验证码）")
+                    return
+            except Exception:
+                pass
+    print("  [!]  tg-cli install failed. Run: pipx install kabi-tg-cli")
 
 
 def _install_system_deps_safe():

--- a/agent_reach/guides/setup-discord.md
+++ b/agent_reach/guides/setup-discord.md
@@ -1,0 +1,62 @@
+# Discord 配置指南
+
+## 功能说明
+读取、搜索、同步和导出你能访问的 Discord 服务器/频道消息。通过 [discord-cli](https://github.com/jackwener/discord-cli)（PyPI 包 `kabi-discord-cli`，本地优先同步进 SQLite）实现。
+
+> ⚠️ **封号风险提醒**：discord-cli 用的是你账号的 **user token** 走 Discord HTTP API，属于 user-token 自动化，**违反 Discord ToS，可能被检测并限制/封禁账号**。请务必使用**专用小号**，不要用主账号，并自行评估风险。
+
+## 前置条件
+- Python 3.10+（pipx / uv 安装）
+- 本地已登录 Discord（桌面客户端或浏览器，用于提取 user token）
+
+## Agent 可自动完成的步骤
+
+### 1. 安装 discord-cli
+```bash
+uv tool install kabi-discord-cli
+# 或：pipx install kabi-discord-cli
+```
+
+### 2. 登录（提取 user token）
+```bash
+discord auth --save
+```
+
+> 自动从本地 Discord/浏览器会话提取 user token 并保存到 `.env`。
+
+### 3. 验证
+```bash
+agent-reach doctor
+```
+
+应该看到 Discord 显示为 ✅。也可单独查状态：`discord status`（退出码 0 = 已认证）。
+
+## 使用示例
+
+```bash
+# 列服务器 / 频道
+discord dc guilds --yaml
+discord dc channels <GUILD> --yaml
+
+# 搜索某频道的消息
+discord search "关键词" -c general --yaml
+
+# 同步可访问的文本频道（首次引导）
+discord dc sync-all
+
+# 导出（大数据集写文件）
+discord export -c general -o /tmp/general.yaml
+```
+
+> 结构化输出用 `--yaml`（非 TTY 默认即 YAML），`-n` 控制条数，输出契约见上游 SCHEMA.md。
+
+## 常见问题
+
+**Q: token 失效了？**
+A: 重新运行 `discord auth --save`（`discord status` 会以非零退出码提示 `not_authenticated`）。
+
+**Q: 命令存在但无法执行？**
+A: 多为系统 Python 升级后 venv 断链，重装即可：`uv tool install --force kabi-discord-cli`。
+
+**Q: 只能读到部分频道？**
+A: 只能访问你账号有权限看到的服务器/频道；user token 无法越权。

--- a/agent_reach/guides/setup-telegram.md
+++ b/agent_reach/guides/setup-telegram.md
@@ -1,0 +1,71 @@
+# Telegram 配置指南
+
+## 功能说明
+同步、搜索、导出和监听你 Telegram 账号里的对话与频道消息。通过 [tg-cli](https://github.com/jackwener/tg-cli)（PyPI 包 `kabi-tg-cli`，本地优先同步进 SQLite）实现。走 **MTProto 用户账号**（不是 Bot API），能读到你自己加入的私有群/频道。
+
+## 前置条件
+- Python 3.10+（pipx / uv 安装）
+- 一个 Telegram 账号 + 能收验证码的手机号
+
+## Agent 可自动完成的步骤
+
+### 1. 安装 tg-cli
+```bash
+uv tool install kabi-tg-cli
+# 或：pipx install kabi-tg-cli
+```
+
+## 需要用户手动做的步骤
+
+### 2. 登录（首次需交互）
+
+**输入手机号 + 短信/App 验证码，Agent 无法代填**，请用户自己跑一次：
+
+```bash
+tg chats
+```
+
+> 自带 Telegram Desktop API 凭据，无需自建应用。首次会提示输入手机号（含国家码，如 `+8613800138000`）和验证码，登录态保存在本地 session，后续命令免登录。
+
+### 3. 验证
+```bash
+agent-reach doctor
+```
+
+应该看到 Telegram 显示为 ✅。也可单独查状态：`tg status`（退出码 0 = 已登录）。
+
+## 使用示例
+
+```bash
+# 列对话 / 查当前用户
+tg chats --type group
+tg whoami --yaml
+
+# 拉历史、增量同步
+tg history CHAT -n 1000
+tg sync CHAT
+
+# 搜索（存量缓存）
+tg search "Rust" -c "牛油果" --yaml
+tg search "Rust|Golang" --regex
+
+# 近实时缓存（后台监听）
+tg listen --persist
+```
+
+> 结构化输出用 `--yaml`（非 TTY 默认即 YAML）。查询走本地 SQLite 缓存，先 `tg sync` / `tg refresh` 保持新鲜。
+
+## 常见问题
+
+**Q: 想用自己的 App 凭据？**
+A: 设置环境变量后再登录：
+```bash
+export TG_API_ID=123456
+export TG_API_HASH=your_telegram_app_hash
+```
+
+**Q: 命令存在但无法执行？**
+A: 多为系统 Python 升级后 venv 断链，重装即可：`uv tool install --force kabi-tg-cli`。
+
+**Q: doctor 一直显示未登录？**
+A: `tg status` 非零退出即未登录，跑一次 `tg chats` 完成手机号登录。

--- a/agent_reach/probe.py
+++ b/agent_reach/probe.py
@@ -81,6 +81,12 @@ def _run_once(path: str, args: Sequence[str], timeout: int, package: str) -> Pro
         r = subprocess.run(
             [path, *args],
             capture_output=True,
+            # Health probes must never read the terminal: a CLI that falls
+            # through to an interactive prompt when unconfigured (e.g. `tg
+            # status` asking for a phone number when no session exists) would
+            # otherwise block on the user's TTY until `timeout`. DEVNULL turns
+            # any such prompt into an immediate EOF so the command exits fast.
+            stdin=subprocess.DEVNULL,
             encoding="utf-8",
             errors="replace",
             timeout=timeout,

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
-  雪球/股票行情, RSS feeds, or any web URL.
+  Instagram, Discord, Telegram/tg, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube,
+  GitHub code search, 小宇宙播客, 雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  17 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,7 +18,7 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/Discord/Telegram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -30,6 +30,8 @@ triggers:
     - Reddit: reddit
     - Facebook: facebook/fb/facebook groups
     - Instagram: instagram/ig
+    - Discord: discord/dc/服务器/频道
+    - Telegram: telegram/tg/电报/tme
   - career: 招聘/职位/求职/linkedin/领英/找工作
   - dev: github/代码/仓库/gh/issue/pr/分支/commit
   - web: 网页/链接/文章/rss/读一下/打开这个
@@ -42,7 +44,7 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+17 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
@@ -62,7 +64,7 @@ metadata:
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
-| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
+| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/Discord/Telegram | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
@@ -108,6 +110,14 @@ opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # 搜用户
 opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
+
+# Discord（discord-cli，user token；先 discord auth --save 登录）
+discord dc guilds --yaml                        # 列服务器
+discord search "query" -c general --yaml        # 搜某频道消息
+
+# Telegram（tg-cli，MTProto 用户账号；先 tg chats 登录）
+tg chats --yaml                                 # 列对话
+tg search "query" -c "chat_name" --yaml         # 搜存量缓存
 ```
 
 ## 环境检查
@@ -126,7 +136,7 @@ agent-reach doctor --json
 根据用户需求，阅读对应的详细文档：
 
 - [搜索工具](references/search.md) — Exa AI 搜索
-- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
+- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram, Discord, Telegram（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -6,10 +6,11 @@ description: >
   web for X", "see what people say about X", "look this up".
 
   Also MUST USE when user mentions any platform or shares any URL/link:
-  Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
-  Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
+  Twitter/X, Reddit, Facebook, Instagram, Discord, Telegram, YouTube, GitHub,
+  Bilibili, XiaoHongShu, Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX,
+  Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  17 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -23,7 +24,7 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+17 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
@@ -50,7 +51,7 @@ these platforms — do not invent your own approach.**
 | User intent | Category | Details |
 |---------|------|---------|
 | Web / code search | search | [references/search.md](references/search.md) |
-| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
+| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram / Discord / Telegram | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
@@ -96,6 +97,14 @@ opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # user search
 opencli instagram user USERNAME -f yaml        # recent posts from one user
+
+# Discord (discord-cli, user token; run `discord auth --save` first)
+discord dc guilds --yaml                        # list servers
+discord search "query" -c general --yaml        # search one channel
+
+# Telegram (tg-cli, MTProto user account; run `tg chats` to log in first)
+tg chats --yaml                                 # list dialogs
+tg search "query" -c "chat_name" --yaml         # search local cache
 ```
 
 ## Environment check
@@ -117,7 +126,7 @@ common cases; references hold per-backend command groups, caveats, retry
 chains — note: reference docs are written in Chinese, commands are universal):
 
 - [Search](references/search.md) — Exa AI search
-- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)
+- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram, Discord, Telegram (multi-backend/login-backed groups)
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -1,6 +1,6 @@
 # 社交媒体 & 社区
 
-小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram。
+小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram、Discord、Telegram。
 
 ## 小红书 / XiaoHongShu（多后端）
 
@@ -273,3 +273,67 @@ opencli instagram saved --limit 20 -f yaml
 ```
 
 > 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 instagram.com。`instagram search` 是用户搜索；读帖子需要先确定 username，再用 `instagram user USERNAME`。若出现 429 / login required，先让用户在 Chrome 里重新登录并降低频率。
+
+## Discord (discord-cli，必须登录态)
+
+Discord 走 [discord-cli](https://github.com/jackwener/discord-cli)（PyPI 包 `kabi-discord-cli`，命令 `discord`），用账号的 **user token** 走 Discord HTTP API，本地优先同步进 SQLite。先跑 `agent-reach doctor --json` 看 discord 的 `active_backend`。
+
+> ⚠️ **封号风险**：user token 自动化违反 Discord ToS，可能触发风控封号。**只用专用小号**，不要用主账号。只能读到你账号有权限看到的服务器/频道。
+
+```bash
+# 列服务器 / 频道 / 服务器信息
+discord dc guilds --yaml
+discord dc channels <GUILD> --yaml
+discord dc info <GUILD> --yaml
+
+# 搜索某频道消息（优先指定 -c 频道，别全服扫）
+discord search "query" -c general --yaml
+
+# 读最近 / 今天的消息
+discord recent -c general -n 50 --yaml
+discord today -c general --yaml
+
+# 同步可访问的文本频道（首次引导）
+discord dc sync-all
+
+# 导出大数据集到文件
+discord export -c general -o /tmp/general.yaml
+```
+
+> **安装**：`uv tool install kabi-discord-cli`（或 `pipx install kabi-discord-cli`）。
+>
+> **认证**：`discord auth --save`（自动从本地 Discord/浏览器会话提取 user token）。`discord status` 退出码 0 = 已认证；非零输出 `not_authenticated` = 未登录。
+>
+> **输出格式**：用 `--yaml` / `--json` 获得结构化输出（非 TTY 默认即 YAML），`-n` 控制条数，对 AI agent 更友好。
+
+## Telegram (tg-cli，必须登录态)
+
+Telegram 走 [tg-cli](https://github.com/jackwener/tg-cli)（PyPI 包 `kabi-tg-cli`，命令 `tg`），用**你自己的 MTProto 用户账号**（不是 Bot API），能读到你加入的私有群/频道，本地优先同步进 SQLite。先跑 `agent-reach doctor --json` 看 telegram 的 `active_backend`。
+
+```bash
+# 列对话 / 当前用户
+tg chats --type group
+tg whoami --yaml
+
+# 拉历史、增量同步（查询走本地缓存，先 sync 保持新鲜）
+tg history CHAT -n 1000
+tg sync CHAT
+tg refresh                       # 推荐的每日刷新入口
+
+# 搜索存量缓存（支持 chat/sender/时间过滤、正则）
+tg search "query" -c "chat_name" --yaml
+tg search "Rust|Golang" --regex
+tg search "query" --sync-first --yaml   # 先刷新再查
+
+# 近实时缓存（后台监听，自动重连）
+tg listen --persist
+
+# 会话详情 / 导出
+tg info CHAT --yaml
+```
+
+> **安装**：`uv tool install kabi-tg-cli`（或 `pipx install kabi-tg-cli`）。
+>
+> **认证**：**首次需交互登录**——`tg chats` 会提示输入手机号（含国家码）+ 验证码，Agent 无法代填，让用户自己跑一次。自带 Telegram Desktop API 凭据，无需自建应用（也可用 `TG_API_ID` / `TG_API_HASH` 覆盖）。`tg status` 退出码 0 = 已登录。
+>
+> **输出格式**：用 `--yaml` / `--json`（非 TTY 默认即 YAML）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-reach"
-version = "1.5.0"
+version = "1.6.0"
 description = "Give your AI Agent eyes to see the entire internet. Search + Read 10+ platforms."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -173,6 +173,8 @@ def test_channel_can_handle_contract():
         "instagram": "https://www.instagram.com/openai/",
         "bilibili": "https://www.bilibili.com/video/BV1xx411",
         "xiaohongshu": "https://www.xiaohongshu.com/explore/123",
+        "discord": "https://discord.com/channels/123/456",
+        "telegram": "https://t.me/durov",
         "linkedin": "https://www.linkedin.com/in/test",
         "rss": "https://example.com/feed.xml",
         "xueqiu": "https://xueqiu.com/S/SH600519",

--- a/tests/test_discord_channel.py
+++ b/tests/test_discord_channel.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import Mock, patch
+
+from agent_reach.channels.discord import DiscordChannel
+
+
+def _cp(stdout="", stderr="", returncode=0):
+    m = Mock()
+    m.stdout = stdout
+    m.stderr = stderr
+    m.returncode = returncode
+    return m
+
+
+def test_can_handle_common_urls():
+    ch = DiscordChannel()
+    assert ch.can_handle("https://discord.com/channels/123/456")
+    assert ch.can_handle("https://discord.gg/abcdef")
+    assert ch.can_handle("https://discordapp.com/channels/1")
+    assert not ch.can_handle("https://t.me/some_channel")
+
+
+def test_check_discord_cli_found_and_auth_ok():
+    """discord found + `discord status` exit 0 → ok."""
+    channel = DiscordChannel()
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/discord" if name == "discord" else None), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: true\ndata:\n  authenticated: true\n", returncode=0),
+    ):
+        status, message = channel.check()
+    assert status == "ok"
+    assert "discord-cli" in message
+    assert "完整可用" in message
+    assert channel.active_backend == "discord-cli"
+
+
+def test_check_discord_cli_found_auth_missing():
+    """discord found + not_authenticated (non-zero exit) → warn about auth."""
+    channel = DiscordChannel()
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/discord" if name == "discord" else None), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: false\nerror:\n  code: not_authenticated\n", returncode=1),
+    ):
+        status, message = channel.check()
+    assert status == "warn"
+    assert "未认证" in message
+    assert "discord auth --save" in message
+    # 未认证是业务态：工具进程活着，后端仍归属 discord-cli
+    assert channel.active_backend == "discord-cli"
+
+
+def test_check_discord_cli_broken_reports_error_with_reinstall_hint():
+    """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
+    channel = DiscordChannel()
+    with patch(
+        "shutil.which",
+        side_effect=lambda name: "/usr/local/bin/discord" if name == "discord" else None,
+    ), patch("subprocess.run", side_effect=FileNotFoundError("/usr/local/bin/discord")):
+        status, message = channel.check()
+    assert status == "error"
+    assert "无法执行" in message
+    assert "uv tool install --force kabi-discord-cli" in message
+    assert "pipx reinstall kabi-discord-cli" in message
+    assert channel.active_backend is None
+
+
+def test_check_nothing_installed():
+    """No discord-cli → off with install hint."""
+    channel = DiscordChannel()
+    with patch("shutil.which", return_value=None):
+        status, message = channel.check()
+    assert status == "off"
+    assert "kabi-discord-cli" in message
+    assert channel.active_backend is None

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import Mock, patch
+
+from agent_reach.channels.telegram import TelegramChannel
+
+
+def _cp(stdout="", stderr="", returncode=0):
+    m = Mock()
+    m.stdout = stdout
+    m.stderr = stderr
+    m.returncode = returncode
+    return m
+
+
+def test_can_handle_common_urls():
+    ch = TelegramChannel()
+    assert ch.can_handle("https://t.me/durov")
+    assert ch.can_handle("https://t.me/s/durov")
+    assert ch.can_handle("https://telegram.me/joinchat/abc")
+    assert not ch.can_handle("https://discord.com/channels/1")
+
+
+def test_check_tg_cli_found_and_auth_ok():
+    """tg found + `tg status` exit 0 → ok."""
+    channel = TelegramChannel()
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/tg" if name == "tg" else None), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: true\ndata:\n  authenticated: true\n", returncode=0),
+    ):
+        status, message = channel.check()
+    assert status == "ok"
+    assert "tg-cli" in message
+    assert "完整可用" in message
+    assert channel.active_backend == "tg-cli"
+
+
+def test_check_tg_cli_found_not_logged_in():
+    """tg found + non-zero exit (no session) → warn about login."""
+    channel = TelegramChannel()
+    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/tg" if name == "tg" else None), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: false\nerror:\n  code: not_authenticated\n", returncode=1),
+    ):
+        status, message = channel.check()
+    assert status == "warn"
+    assert "未登录" in message
+    assert "tg chats" in message
+    assert channel.active_backend == "tg-cli"
+
+
+def test_check_tg_cli_broken_reports_error_with_reinstall_hint():
+    """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
+    channel = TelegramChannel()
+    with patch(
+        "shutil.which",
+        side_effect=lambda name: "/usr/local/bin/tg" if name == "tg" else None,
+    ), patch("subprocess.run", side_effect=FileNotFoundError("/usr/local/bin/tg")):
+        status, message = channel.check()
+    assert status == "error"
+    assert "无法执行" in message
+    assert "uv tool install --force kabi-tg-cli" in message
+    assert "pipx reinstall kabi-tg-cli" in message
+    assert channel.active_backend is None
+
+
+def test_check_nothing_installed():
+    """No tg-cli → off with install hint."""
+    channel = TelegramChannel()
+    with patch("shutil.which", return_value=None):
+        status, message = channel.check()
+    assert status == "off"
+    assert "kabi-tg-cli" in message
+    assert channel.active_backend is None


### PR DESCRIPTION
## 简介

新增 **Discord** 和 **Telegram** 两个渠道（tier-1），封装 [@jackwener](https://github.com/jackwener) 的本地优先 CLI——与本项目已在用的 `twitter-cli` / `bilibili-cli` / `xiaohongshu-cli` 同源：

- **Discord** — [`discord-cli`](https://github.com/jackwener/discord-cli)（`kabi-discord-cli`）：走 user token 的 Discord HTTP API；同步 / 搜索 / 导出你能访问的服务器与频道。
- **Telegram** — [`tg-cli`](https://github.com/jackwener/tg-cli)（`kabi-tg-cli`）：MTProto 用户账号（非 Bot API）；同步 / 搜索 / 导出 / 监听，含私有群。

## 设计

完全参照 `xiaohongshu.py` / `twitter.py`——同一套 `check()` 结构、`probe_command` 和后端覆盖（backend-override）契约。两者都以 `status` 退出码作为认证信号：`missing → off`、非零 → `warn`（附登录处方）、`0 → ok`。已接入 `doctor`、`install --channels`、两个语言版 `SKILL.md`、`references/social.md` 以及新增的配置指南。平台数 15 → 17。

顺带加固 `probe_command`：改用 `stdin=DEVNULL`，避免像 `tg status` 这类未配置时会交互式索要手机号的命令把 `doctor` 阻塞到超时。

## 说明

- 渠道测试覆盖 ok / 未认证 / 损坏 / 未安装；测试套件通过（3 个失败在 `main` 上已存在，与本 PR 无关）。两个渠道均已真机端到端验证（认证 → `ok` → 真实拉取）。
- ⚠️ Discord user token 自动化可能违反 Discord ToS——配置指南与 README 均建议使用专用小号。
