### PR TITLE
feat(channels): add Douyin (抖音) channel via yt-dlp + browser cookies

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 # Import all channels
 from .base import Channel
 from .bilibili import BilibiliChannel
+from .douyin import DouyinChannel
 from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
@@ -31,6 +32,7 @@ ALL_CHANNELS: List[Channel] = [
     FacebookChannel(),
     InstagramChannel(),
     BilibiliChannel(),
+    DouyinChannel(),
     XiaoHongShuChannel(),
     LinkedInChannel(),
     XiaoyuzhouChannel(),

--- a/agent_reach/channels/douyin.py
+++ b/agent_reach/channels/douyin.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""抖音 (Douyin) — yt-dlp + 浏览器 Cookie。
+
+抖音风控要求请求携带 Cookie（yt-dlp 裸连报 "Fresh cookies needed"），
+所以本频道在 yt-dlp 探活之外还要确认 Cookie 来源已配置：
+
+  - ``douyin_cookies_from``：浏览器名，yt-dlp ``--cookies-from-browser`` 直读
+  - ``douyin_cookies``：Cookie header 字符串，yt-dlp ``--add-headers`` 注入
+
+yt-dlp 持续维护且原生支持抖音（2026-07 桌面 Chrome 实测：元数据 + 音频
+均可取），满足频道回归标准 —— PR #347 移除旧抖音频道的原因是当时的
+上游工具停更，而非平台不可达。
+"""
+
+from agent_reach.probe import probe_command
+
+from .base import Channel
+
+_DOUYIN_HOSTS = ("douyin.com", "iesdouyin.com")
+
+
+def is_douyin_url(url: str) -> bool:
+    """Return True if url belongs to Douyin (incl. v.douyin.com short links)."""
+    from urllib.parse import urlparse
+
+    d = urlparse(url).netloc.lower()
+    return any(h in d for h in _DOUYIN_HOSTS)
+
+
+def douyin_cookie_args(config) -> list:
+    """Build yt-dlp CLI args carrying the configured Douyin cookies.
+
+    ``douyin_cookies_from``（浏览器名）优先于 ``douyin_cookies``（header
+    字符串）：浏览器直读始终拿到最新 Cookie，手动粘贴的字符串会过期。
+    """
+    if config is None:
+        return []
+    browser = config.get("douyin_cookies_from")
+    if browser:
+        return ["--cookies-from-browser", browser]
+    cookie = config.get("douyin_cookies")
+    if cookie:
+        return ["--add-headers", f"Cookie:{cookie}"]
+    return []
+
+
+class DouyinChannel(Channel):
+    name = "douyin"
+    description = "抖音视频"
+    backends = ["yt-dlp"]
+    tier = 1
+
+    def can_handle(self, url: str) -> bool:
+        return is_douyin_url(url)
+
+    def check(self, config=None):
+        # 真跑 yt-dlp --version 探活，区分未装 / venv 断链 / 跑不动
+        probe = probe_command("yt-dlp", ["--version"], timeout=10, package="yt-dlp")
+        if probe.status == "missing":
+            self.active_backend = None
+            return "off", "yt-dlp 未安装。安装：pip install yt-dlp"
+        if probe.status == "broken":
+            self.active_backend = None
+            return "error", f"yt-dlp 已安装但无法执行\n{probe.hint}"
+        if not probe.ok:  # timeout / error：装了但跑不动
+            self.active_backend = None
+            detail = probe.hint or probe.output or probe.status
+            return "error", f"yt-dlp 无法正常运行：{detail}"
+        # yt-dlp 本体是活的；Cookie 是否配置只影响 ok/warn，不影响后端归属
+        self.active_backend = "yt-dlp"
+        if not douyin_cookie_args(config):
+            return "warn", (
+                "yt-dlp 可用，但抖音风控要求登录态 Cookie（裸连报 Fresh cookies needed）。\n"
+                "  浏览器里登录过 douyin.com 后运行：\n"
+                "  agent-reach configure douyin-cookies chrome\n"
+                "  或：agent-reach configure --from-browser chrome"
+            )
+        return "ok", (
+            "可提取抖音视频元数据和音频（yt-dlp + Cookie）。"
+            "用法见 references/video.md 抖音小节"
+        )
+
+    def transcribe(self, url: str, *, provider: str = "auto", config=None) -> str:
+        """Download a Douyin video's audio and return its transcript.
+
+        Delegates to :func:`agent_reach.transcribe.transcribe`, which injects
+        the configured Douyin cookies into yt-dlp for Douyin URLs.
+        """
+        from agent_reach.transcribe import transcribe as _transcribe
+
+        return _transcribe(url, provider=provider, config=config)

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -75,14 +75,14 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,bilibili,douyin,linkedin,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
     p_conf.add_argument("key", nargs="?", default=None,
                         choices=["proxy", "github-token", "groq-key", "openai-key",
                                  "twitter-cookies", "youtube-cookies",
-                                 "xhs-cookies"],
+                                 "xhs-cookies", "douyin-cookies"],
                         help="What to configure (omit if using --from-browser)")
     p_conf.add_argument("value", nargs="*", help="The value(s) to set")
     p_conf.add_argument("--from-browser", metavar="BROWSER",
@@ -204,16 +204,17 @@ def _cmd_install(args):
         "bilibili":    _install_bili_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
+        # douyin: cookie-only, no install step (yt-dlp is a core dep)
         # linkedin: manual setup, no auto-install
     }
     OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
-    COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili"}
+    COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "douyin"}
 
     requested_channels = set()
     if args.channels:
         raw = [c.strip().lower() for c in args.channels.split(",") if c.strip()]
         if "all" in raw:
-            requested_channels = set(CHANNEL_INSTALLERS.keys()) | {"xueqiu", "linkedin"}
+            requested_channels = set(CHANNEL_INSTALLERS.keys()) | {"xueqiu", "douyin", "linkedin"}
         else:
             requested_channels = set(raw)
 
@@ -1116,6 +1117,9 @@ def _cmd_configure(args):
         print(f"✅ YouTube cookie source configured: {value}")
         print("   yt-dlp will use cookies from this browser for age-restricted/member videos.")
 
+    elif args.key == "douyin-cookies":
+        _configure_douyin_cookies(config, value)
+
     elif args.key == "xhs-cookies":
         _configure_xhs_cookies(value)
 
@@ -1170,6 +1174,43 @@ def _parse_twitter_cookie_input(value: str):
         ct0 = parts[1]
 
     return auth_token, ct0
+
+
+# Browsers yt-dlp's --cookies-from-browser can read.
+_DOUYIN_COOKIE_BROWSERS = {
+    "brave", "chrome", "chromium", "edge", "firefox",
+    "opera", "safari", "vivaldi", "whale",
+}
+
+
+def _configure_douyin_cookies(config, value):
+    """Configure Douyin cookies: browser name or raw Cookie header string.
+
+    A browser name is stored as ``douyin_cookies_from`` and read live by
+    yt-dlp on every call (never goes stale). A pasted header string is
+    stored as ``douyin_cookies`` and injected via ``--add-headers`` — it
+    works headless but expires with the session.
+    """
+    if "=" in value:
+        config.set("douyin_cookies", value)
+        config.delete("douyin_cookies_from")
+        print("✅ 抖音 Cookie 已保存（header 字符串）")
+        print("   注意：Cookie 会随会话过期，失效后请重新配置。")
+        return
+
+    browser = value.strip().lower()
+    if browser not in _DOUYIN_COOKIE_BROWSERS:
+        print(f"[X] 无法识别的值：{value}")
+        print("   用法（二选一）：")
+        print("   1. agent-reach configure douyin-cookies chrome   # 从浏览器实时读取（推荐）")
+        print('   2. agent-reach configure douyin-cookies "sessionid=xxx; msToken=yyy; ..."')
+        return
+
+    config.set("douyin_cookies_from", browser)
+    config.delete("douyin_cookies")
+    print(f"✅ 抖音 Cookie 来源已配置：{browser}")
+    print("   yt-dlp 将通过 --cookies-from-browser 实时读取该浏览器的登录态。")
+    print("   前提：该浏览器里已登录 douyin.com。")
 
 
 def _configure_xhs_cookies(value):

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -2,7 +2,7 @@
 """Auto-extract cookies from local browsers for all supported platforms.
 
 Supports: Chrome, Firefox, Edge, Brave, Opera
-Extracts: Twitter, XiaoHongShu, Bilibili cookies in one shot.
+Extracts: Twitter, XiaoHongShu, Bilibili, Xueqiu, Douyin cookies in one shot.
 
 Usage:
     agent-reach configure --from-browser chrome
@@ -35,6 +35,12 @@ PLATFORM_SPECS = [
         "domains": [".xueqiu.com", "xueqiu.com"],
         "cookies": None,  # grab all — xq_a_token + session cookies required
         "config_key": "xueqiu",
+    },
+    {
+        "name": "Douyin",
+        "domains": [".douyin.com"],
+        "cookies": None,  # grab all — sessionid + msToken etc. required
+        "config_key": "douyin",
     },
 ]
 
@@ -293,5 +299,18 @@ def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
             results_list.append(("Xueqiu", False,
                                  f"找到 {len(cookie_str.split(';'))} 个 Cookie 但缺少 xq_a_token，"
                                  f"请先在 {browser} 中登录 xueqiu.com"))
+
+    if "douyin" in extracted:
+        cookie_str = extracted["douyin"].get("cookie_string", "")
+        # Only save if sessionid is present — anonymous cookies are useless
+        if cookie_str and "sessionid" in cookie_str:
+            config.set("douyin_cookies", cookie_str)
+            config.delete("douyin_cookies_from")
+            n_cookies = len(cookie_str.split(";"))
+            results_list.append(("Douyin", True, f"{n_cookies} cookies (含 sessionid)"))
+        elif cookie_str:
+            results_list.append(("Douyin", False,
+                                 f"找到 {len(cookie_str.split(';'))} 个 Cookie 但缺少 sessionid，"
+                                 f"请先在 {browser} 中登录 douyin.com"))
 
     return results_list

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
+  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, 抖音/douyin, GitHub code search, 小宇宙播客,
   雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,7 +18,7 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/抖音/播客)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -33,7 +33,7 @@ triggers:
   - career: 招聘/职位/求职/linkedin/领英/找工作
   - dev: github/代码/仓库/gh/issue/pr/分支/commit
   - web: 网页/链接/文章/rss/读一下/打开这个
-  - video: youtube/视频/播客/字幕/小宇宙/转录/yt
+  - video: youtube/视频/播客/字幕/小宇宙/转录/yt/抖音/douyin
   - finance: 雪球/股票/stock/xueqiu/行情/基金
 metadata:
   openclaw:
@@ -42,7 +42,7 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
@@ -66,7 +66,7 @@ metadata:
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
-| YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
+| YouTube/B站/抖音/播客字幕 | video | [references/video.md](references/video.md) |
 
 ## 零配置快速命令
 
@@ -130,7 +130,7 @@ agent-reach doctor --json
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS
-- [视频播客](references/video.md) — YouTube, B站, 小宇宙
+- [视频播客](references/video.md) — YouTube, B站, 抖音, 小宇宙
 
 ## 配置渠道
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -6,10 +6,10 @@ description: >
   web for X", "see what people say about X", "look this up".
 
   Also MUST USE when user mentions any platform or shares any URL/link:
-  Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
+  Twitter/X, Reddit, Facebook, Instagram, YouTube, Douyin, GitHub, Bilibili, XiaoHongShu,
   Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -23,7 +23,7 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
@@ -54,7 +54,7 @@ these platforms — do not invent your own approach.**
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
-| YouTube / Bilibili / podcast transcripts | video | [references/video.md](references/video.md) |
+| YouTube / Bilibili / Douyin / podcast transcripts | video | [references/video.md](references/video.md) |
 
 ## Zero-config quick commands
 
@@ -121,7 +121,7 @@ chains — note: reference docs are written in Chinese, commands are universal):
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS
-- [Video](references/video.md) — YouTube, Bilibili, Xiaoyuzhou
+- [Video](references/video.md) — YouTube, Bilibili, Douyin, Xiaoyuzhou
 
 ## Configure a channel
 

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -120,6 +120,49 @@ agent-reach doctor
 
 > 输出 Markdown 文件默认保存到 `/tmp/`。
 
+## 抖音 / Douyin（yt-dlp + 浏览器 Cookie）
+
+> ⚠️ **必须带 Cookie**：抖音风控会拦裸连 yt-dlp（报 `Fresh cookies needed`）。先在浏览器里登录 douyin.com，再配置 Cookie 来源（二选一）：
+>
+> ```bash
+> agent-reach configure douyin-cookies chrome   # 每次实时从浏览器读取（推荐）
+> agent-reach configure --from-browser chrome   # 或一次性提取存为 header 字符串
+> ```
+
+### URL 形态处理
+
+yt-dlp 只认规范视频链接。用户给的链接先转换：
+
+- `https://www.douyin.com/video/<视频ID>` — 可直接用
+- `https://v.douyin.com/xxxx/` 短链 — 可直接用（yt-dlp 会跟随跳转）
+- 用户主页带 `modal_id=<视频ID>` 参数的链接（如 `douyin.com/user/self?...&modal_id=7653652590353321258`）— 取 `modal_id` 拼成 `https://www.douyin.com/video/<视频ID>`
+
+### 获取视频元数据
+
+```bash
+yt-dlp --cookies-from-browser chrome --dump-json "https://www.douyin.com/video/视频ID"
+# 关键字段：title（标题）、description（文案+话题标签）、uploader、duration、like_count、comment_count
+```
+
+> 若配置的是 header 字符串（`douyin_cookies`）而非浏览器来源，改用：
+> `yt-dlp --add-headers "Cookie:$(agent-reach 配置里的 douyin_cookies)" ...`，或直接从 `~/.agent-reach/config.yaml` 读出该值拼接。
+
+### 下载音频 / 转写文稿
+
+```bash
+# 下音频（口播类视频提取内容的主路径——抖音视频没有字幕）
+yt-dlp --cookies-from-browser chrome -x --audio-format mp3 -o "/tmp/dy_%(id)s.%(ext)s" "URL"
+
+# 或直接转写（已配置 groq-key/openai-key 时；会自动带上抖音 Cookie）
+agent-reach transcribe "https://www.douyin.com/video/视频ID"
+```
+
+### 排错
+
+- `Fresh cookies (not necessarily logged in) are needed` → Cookie 缺失或失效。用 `--cookies-from-browser` 方式的基本不会遇到；header 字符串方式的需重新 `configure --from-browser`。
+- `Failed to parse JSON` + 上述报错同时出现 → 同上是 Cookie 问题，不是链接问题。
+- 浏览器直读在 macOS 首次可能弹钥匙串授权，属正常。
+
 ## 选择指南
 
 | 场景 | 推荐工具 |
@@ -127,5 +170,6 @@ agent-reach doctor
 | YouTube 字幕 | yt-dlp |
 | B站视频详情/搜索 | bili-cli |
 | B站字幕 | opencli bilibili subtitle |
+| 抖音元数据/音频 | yt-dlp + Cookie（见上） |
 | 播客转录 | 小宇宙 transcribe.sh |
 | 无字幕音视频 | agent-reach transcribe（B站音频先 `bili audio`） |

--- a/agent_reach/transcribe.py
+++ b/agent_reach/transcribe.py
@@ -122,7 +122,20 @@ def _assert_safe_public_url(url: str) -> None:
         raise TranscribeError("SSRF blocked: private/internal IP is not allowed")
 
 
-def download_audio(url: str, out_dir: Path) -> Path:
+def _platform_cookie_args(url: str, config: Optional[Config]) -> List[str]:
+    """Extra yt-dlp args carrying platform cookies for URL gated platforms.
+
+    Currently only Douyin: its risk control rejects cookie-less yt-dlp
+    requests ("Fresh cookies needed"). Other platforms need nothing extra.
+    """
+    from agent_reach.channels.douyin import douyin_cookie_args, is_douyin_url
+
+    if is_douyin_url(url):
+        return douyin_cookie_args(config)
+    return []
+
+
+def download_audio(url: str, out_dir: Path, config: Optional[Config] = None) -> Path:
     """Download audio with yt-dlp into out_dir; return the resulting file path."""
     _assert_safe_public_url(url)
     _require("yt-dlp")
@@ -137,6 +150,7 @@ def download_audio(url: str, out_dir: Path) -> Path:
             "0",
             "-o",
             str(template),
+            *_platform_cookie_args(url, config),
             "--",
             url,
         ],
@@ -288,7 +302,7 @@ def _transcribe_in_dir(source: str, order: List[str], cfg: Config, work_dir: Pat
     if src_path.is_file():
         audio = src_path
     else:
-        audio = download_audio(source, work_dir)
+        audio = download_audio(source, work_dir, config=cfg)
 
     compressed = compress_audio(audio, work_dir)
     if compressed.stat().st_size <= SIZE_LIMIT_BYTES:

--- a/tests/test_douyin_channel.py
+++ b/tests/test_douyin_channel.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Dedicated tests for the ``douyin`` channel.
+
+Douyin's readiness is layered like YouTube's: yt-dlp must probe alive
+(missing / broken / unrunnable are distinct), and on top of that Douyin's
+risk control demands cookies — so a healthy yt-dlp without a configured
+cookie source is ``warn``, not ``ok``. These tests stub ``probe_command``
+so every branch runs offline.
+"""
+
+from unittest.mock import patch
+
+from agent_reach.channels import douyin as dy
+from agent_reach.channels.douyin import DouyinChannel, douyin_cookie_args
+from agent_reach.probe import ProbeResult
+
+
+class _Cfg:
+    """Minimal config stand-in: just the ``get`` the channel uses."""
+
+    def __init__(self, data):
+        self._d = data
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+
+# --- can_handle / is_douyin_url ---
+
+def test_can_handle_matches_douyin_hosts():
+    ch = DouyinChannel()
+    for url in [
+        "https://www.douyin.com/video/7653652590353321258",
+        "https://www.douyin.com/user/self?modal_id=7653652590353321258",
+        "https://v.douyin.com/abcDEF/",
+        "https://www.iesdouyin.com/share/video/123",
+        "https://DOUYIN.COM/video/123",
+    ]:
+        assert ch.can_handle(url) is True, url
+    for url in [
+        "https://example.com",
+        "https://www.youtube.com/watch?v=abc",
+        "https://bilibili.com/video/BV1xx",
+        "",
+    ]:
+        assert ch.can_handle(url) is False, url
+
+
+# --- douyin_cookie_args ---
+
+def test_cookie_args_empty_without_config():
+    assert douyin_cookie_args(None) == []
+    assert douyin_cookie_args(_Cfg({})) == []
+
+
+def test_cookie_args_browser_source_wins():
+    cfg = _Cfg({"douyin_cookies_from": "chrome", "douyin_cookies": "sessionid=x"})
+    assert douyin_cookie_args(cfg) == ["--cookies-from-browser", "chrome"]
+
+
+def test_cookie_args_header_string_fallback():
+    cfg = _Cfg({"douyin_cookies": "sessionid=x; msToken=y"})
+    assert douyin_cookie_args(cfg) == ["--add-headers", "Cookie:sessionid=x; msToken=y"]
+
+
+# --- check ---
+
+def test_check_off_when_yt_dlp_missing():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command", return_value=ProbeResult("missing")):
+        status, msg = ch.check(_Cfg({}))
+    assert status == "off"
+    assert ch.active_backend is None
+
+
+def test_check_error_when_yt_dlp_broken():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command",
+                      return_value=ProbeResult("broken", hint="relink venv")):
+        status, msg = ch.check(_Cfg({}))
+    assert status == "error"
+    assert "relink venv" in msg
+    assert ch.active_backend is None
+
+
+def test_check_error_when_yt_dlp_unrunnable():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command",
+                      return_value=ProbeResult("timeout", hint="too slow")):
+        status, msg = ch.check(_Cfg({}))
+    assert status == "error"
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_yt_dlp_alive_but_no_cookies():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command", return_value=ProbeResult("ok")):
+        status, msg = ch.check(_Cfg({}))
+    assert status == "warn"
+    assert "douyin-cookies" in msg
+    # yt-dlp 本体是活的，后端归属不受 Cookie 缺失影响
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_warn_without_config_object():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command", return_value=ProbeResult("ok")):
+        status, msg = ch.check(None)
+    assert status == "warn"
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_ok_with_browser_cookie_source():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command", return_value=ProbeResult("ok")):
+        status, msg = ch.check(_Cfg({"douyin_cookies_from": "chrome"}))
+    assert status == "ok"
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_ok_with_header_string_cookies():
+    ch = DouyinChannel()
+    with patch.object(dy, "probe_command", return_value=ProbeResult("ok")):
+        status, msg = ch.check(_Cfg({"douyin_cookies": "sessionid=x"}))
+    assert status == "ok"
+    assert ch.active_backend == "yt-dlp"
+
+
+# --- channel metadata ---
+
+def test_channel_metadata():
+    ch = DouyinChannel()
+    assert ch.name == "douyin"
+    assert ch.tier == 1
+    assert ch.backends == ["yt-dlp"]
+
+
+# --- cookie_extract integration ---
+
+def test_platform_specs_include_douyin():
+    from agent_reach.cookie_extract import PLATFORM_SPECS
+
+    spec = next(s for s in PLATFORM_SPECS if s["config_key"] == "douyin")
+    assert ".douyin.com" in spec["domains"]
+
+
+class _RecordingCfg(_Cfg):
+    def __init__(self):
+        super().__init__({})
+        self.deleted = []
+
+    def set(self, key, value):
+        self._d[key] = value
+
+    def delete(self, key):
+        self.deleted.append(key)
+        self._d.pop(key, None)
+
+
+def test_configure_from_browser_saves_douyin_cookies_with_sessionid():
+    import agent_reach.cookie_extract as ce
+
+    cfg = _RecordingCfg()
+    extracted = {"douyin": {"cookie_string": "sessionid=abc; msToken=xyz"}}
+    with patch.object(ce, "extract_all", return_value=extracted):
+        results = ce.configure_from_browser("chrome", cfg)
+
+    assert cfg.get("douyin_cookies") == "sessionid=abc; msToken=xyz"
+    # 存 header 字符串时清掉浏览器来源，避免两份配置互相覆盖
+    assert "douyin_cookies_from" in cfg.deleted
+    assert any(name == "Douyin" and ok for name, ok, _ in results)
+
+
+def test_configure_from_browser_rejects_anonymous_douyin_cookies():
+    import agent_reach.cookie_extract as ce
+
+    cfg = _RecordingCfg()
+    extracted = {"douyin": {"cookie_string": "ttwid=anon; msToken=xyz"}}
+    with patch.object(ce, "extract_all", return_value=extracted):
+        results = ce.configure_from_browser("chrome", cfg)
+
+    assert cfg.get("douyin_cookies") is None
+    assert any(name == "Douyin" and not ok for name, ok, _ in results)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -243,7 +243,7 @@ class TestOrchestrator:
                     child.unlink()
                 self.path.rmdir()
 
-        def fake_download(source, out_dir):
+        def fake_download(source, out_dir, config=None):
             assert Path(out_dir) == tmp_path / "auto-work"
             audio = Path(out_dir) / "source.m4a"
             audio.write_bytes(b"audio")
@@ -273,7 +273,7 @@ class TestOrchestrator:
         fake_config.set("groq_api_key", "gsk_test")
         work = tmp_path / "caller-owned"
 
-        def fake_download(source, out_dir):
+        def fake_download(source, out_dir, config=None):
             audio = Path(out_dir) / "source.m4a"
             audio.write_bytes(b"audio")
             return audio
@@ -362,6 +362,62 @@ class TestDownloadAudioSafety:
         tr.download_audio("https://youtu.be/abc123", tmp_path)
 
         assert captured["cmd"][-1] == "https://youtu.be/abc123"
+
+
+# --- Platform cookie injection (Douyin) --------------------------------- #
+
+
+class TestPlatformCookieArgs:
+    def _run_download(self, monkeypatch, tmp_path, url, config=None):
+        monkeypatch.setattr(tr, "_require", lambda binary: None)
+        captured = {}
+
+        def fake_run(cmd, timeout=600):
+            captured["cmd"] = cmd
+            (tmp_path / "source.m4a").write_bytes(b"audio")
+
+        monkeypatch.setattr(tr, "_run", fake_run)
+        tr.download_audio(url, tmp_path, config=config)
+        return captured["cmd"]
+
+    def test_douyin_url_injects_browser_cookies(self, monkeypatch, tmp_path):
+        cfg = Config(config_path=tmp_path / "config.yaml")
+        cfg.set("douyin_cookies_from", "chrome")
+        cmd = self._run_download(
+            monkeypatch, tmp_path,
+            "https://www.douyin.com/video/7653652590353321258", config=cfg,
+        )
+        marker = cmd.index("--")
+        assert ["--cookies-from-browser", "chrome"] == cmd[marker - 2:marker]
+
+    def test_douyin_url_injects_header_string_cookies(self, monkeypatch, tmp_path):
+        cfg = Config(config_path=tmp_path / "config.yaml")
+        cfg.set("douyin_cookies", "sessionid=x; msToken=y")
+        cmd = self._run_download(
+            monkeypatch, tmp_path,
+            "https://www.douyin.com/video/7653652590353321258", config=cfg,
+        )
+        assert "--add-headers" in cmd
+        idx = cmd.index("--add-headers")
+        assert cmd[idx + 1] == "Cookie:sessionid=x; msToken=y"
+
+    def test_douyin_url_without_config_adds_nothing(self, monkeypatch, tmp_path):
+        cmd = self._run_download(
+            monkeypatch, tmp_path,
+            "https://www.douyin.com/video/7653652590353321258",
+        )
+        assert "--cookies-from-browser" not in cmd
+        assert "--add-headers" not in cmd
+
+    def test_non_douyin_url_adds_nothing_even_with_cookies(self, monkeypatch, tmp_path):
+        cfg = Config(config_path=tmp_path / "config.yaml")
+        cfg.set("douyin_cookies_from", "chrome")
+        cmd = self._run_download(
+            monkeypatch, tmp_path,
+            "https://www.youtube.com/watch?v=abc", config=cfg,
+        )
+        assert "--cookies-from-browser" not in cmd
+        assert "--add-headers" not in cmd
 
 
 # --- YouTubeChannel integration --------------------------------------- #


### PR DESCRIPTION
## Summary

Add Douyin (抖音) as a channel using **yt-dlp + browser cookies** — the #1 most requested missing platform (issues #494, #500, #510).

This is an alternative to the OpenCLI-based approach in #504: it needs no Chrome extension and reuses the yt-dlp infrastructure the project already ships for YouTube.

## Why yt-dlp meets the bar from #347

Douyin was removed in #347 because its then-upstream tool was archived. yt-dlp is actively maintained and natively supports Douyin — **live-verified 2026-07 on macOS desktop Chrome**: metadata (`--dump-json`) and audio extraction both work against a real video. The only requirement is cookies (Douyin risk control rejects cookie-less requests with `Fresh cookies needed`), which this PR wires into config + doctor + transcribe.

## Changes

- **`agent_reach/channels/douyin.py`**: `DouyinChannel` (tier 1, yt-dlp backend) matching `douyin.com` / `v.douyin.com` / `iesdouyin.com`. `check()` probes yt-dlp like YouTubeChannel, then layers cookie readiness: healthy yt-dlp without a configured cookie source → `warn` with setup instructions (not `ok`). Also exports `douyin_cookie_args()` / `is_douyin_url()` for reuse.
- **`cli.py`**: `agent-reach configure douyin-cookies` accepts either a browser name (stored as `douyin_cookies_from`, read live via `--cookies-from-browser`, never goes stale — recommended) or a raw Cookie header string (`douyin_cookies`, headless-capable but expires). `douyin` added to `--channels` help and `COOKIE_CHANNELS` (cookie-only, no installer, like xueqiu).
- **`cookie_extract.py`**: `--from-browser` now also extracts `douyin.com` cookies, saved only when `sessionid` is present (anonymous cookies are useless — same guard as xueqiu's `xq_a_token`).
- **`transcribe.py`**: `download_audio()` injects the configured Douyin cookies into yt-dlp for Douyin URLs only; all other platforms get byte-identical commands.
- **Skill docs**: `SKILL.md` / `SKILL_en.md` routing table + triggers; `references/video.md` gains a Douyin section covering URL shapes (incl. converting user-page `modal_id=` links to `/video/<id>`), metadata/audio extraction, and `Fresh cookies needed` troubleshooting.

## Tests

- `tests/test_douyin_channel.py` — 17 cases: URL matching, `douyin_cookie_args` precedence, yt-dlp missing/broken/unrunnable → off/error, cookies absent/present → warn/ok, cookie-extract `sessionid` guard.
- `tests/test_transcribe.py` — 4 new cases for cookie injection (browser source, header string, no-config no-op, non-Douyin no-op); two existing download fakes gain the new `config` kwarg.
- Full suite: **215 passed**. Ruff clean on all touched files (remaining cli.py warnings pre-date this PR).

## Notes

- `--from-browser` cookie extraction requires the existing optional `cookies` extra (`browser-cookie3`), unchanged by this PR; the browser-source path (`configure douyin-cookies chrome`) has no extra dependency.

Refs #494 #500 #510. Happy to reconcile with #504 if you prefer one approach — the two can also coexist (different backends).