### PR TITLE
fix(cookie-extract): let --from-browser target a specific Chrome profile

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -89,11 +89,12 @@ def main():
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
                         help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
     p_conf.add_argument("--chrome-profile", metavar="PROFILE", default=None,
-                        help="Profile folder to extract from with --from-browser on a "
-                             "Chromium-based browser (e.g. 'Profile 1'), for when you keep "
+                        help="Profile folder to extract from with --from-browser on "
+                             "chrome/edge/brave (e.g. 'Profile 1'), for when you keep "
                              "burner/research accounts in a separate profile from your main "
-                             "one. Without this, extraction silently reads the 'Default' "
-                             "profile. Omit to be prompted when more than one profile exists.")
+                             "one. Without this, extraction defaults to the 'Default' profile; "
+                             "if several profiles exist you'll be prompted to pick one when "
+                             "running interactively, or asked to pass this flag otherwise.")
 
     # ── doctor ──
     p_doctor = sub.add_parser("doctor", help="Check platform availability")
@@ -1022,6 +1023,22 @@ def _detect_environment():
     return "server" if indicators >= 2 else "local"
 
 
+def _resolve_profile_choice(profiles, raw):
+    """Map a 1-based menu string to a profile folder name.
+
+    Returns the selected folder, or None if the input isn't a valid position.
+    Guards against Python's negative indexing: '0' or '-1' must be rejected,
+    not silently resolved to profiles[-1] (the last profile).
+    """
+    try:
+        n = int(raw)
+    except (ValueError, TypeError):
+        return None
+    if not 1 <= n <= len(profiles):
+        return None
+    return profiles[n - 1]["folder"]
+
+
 def _cmd_configure(args):
     """Set a config value and test it, or auto-extract from browser."""
     import shutil
@@ -1036,7 +1053,10 @@ def _cmd_configure(args):
         browser = args.from_browser
         profile = args.chrome_profile
 
-        if not profile and browser != "firefox":
+        # list_chrome_profiles() returns [] for browsers that don't support
+        # per-profile extraction (firefox, opera), so the picker is naturally
+        # skipped for them without a special-case.
+        if not profile:
             profiles = list_chrome_profiles(browser)
             if len(profiles) > 1:
                 if sys.stdin.isatty():
@@ -1044,11 +1064,14 @@ def _cmd_configure(args):
                     for i, p in enumerate(profiles, 1):
                         label = f"{p['name']} ({p['email']})" if p["email"] else p["name"]
                         print(f"  {i}. {label}  [{p['folder']}]")
-                    choice = input(f"Which profile has the accounts you want? [1-{len(profiles)}]: ").strip()
                     try:
-                        profile = profiles[int(choice) - 1]["folder"]
-                    except (ValueError, IndexError):
-                        print("Invalid choice, aborting.")
+                        choice = input(f"Which profile has the accounts you want? [1-{len(profiles)}]: ").strip()
+                    except EOFError:
+                        print("\nNo choice given, aborting.")
+                        return
+                    profile = _resolve_profile_choice(profiles, choice)
+                    if profile is None:
+                        print(f"Invalid choice (expected 1-{len(profiles)}), aborting.")
                         return
                 else:
                     folders = ", ".join(p["folder"] for p in profiles)

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -88,6 +88,12 @@ def main():
     p_conf.add_argument("--from-browser", metavar="BROWSER",
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
                         help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
+    p_conf.add_argument("--chrome-profile", metavar="PROFILE", default=None,
+                        help="Profile folder to extract from with --from-browser on a "
+                             "Chromium-based browser (e.g. 'Profile 1'), for when you keep "
+                             "burner/research accounts in a separate profile from your main "
+                             "one. Without this, extraction silently reads the 'Default' "
+                             "profile. Omit to be prompted when more than one profile exists.")
 
     # ── doctor ──
     p_doctor = sub.add_parser("doctor", help="Check platform availability")
@@ -1025,13 +1031,36 @@ def _cmd_configure(args):
 
     # ── Auto-extract from browser ──
     if args.from_browser:
-        from agent_reach.cookie_extract import configure_from_browser
+        from agent_reach.cookie_extract import configure_from_browser, list_chrome_profiles
 
         browser = args.from_browser
-        print(f"Extracting cookies from {browser}...")
+        profile = args.chrome_profile
+
+        if not profile and browser != "firefox":
+            profiles = list_chrome_profiles(browser)
+            if len(profiles) > 1:
+                if sys.stdin.isatty():
+                    print(f"Found {len(profiles)} {browser} profiles:")
+                    for i, p in enumerate(profiles, 1):
+                        label = f"{p['name']} ({p['email']})" if p["email"] else p["name"]
+                        print(f"  {i}. {label}  [{p['folder']}]")
+                    choice = input(f"Which profile has the accounts you want? [1-{len(profiles)}]: ").strip()
+                    try:
+                        profile = profiles[int(choice) - 1]["folder"]
+                    except (ValueError, IndexError):
+                        print("Invalid choice, aborting.")
+                        return
+                else:
+                    folders = ", ".join(p["folder"] for p in profiles)
+                    print(f"Found {len(profiles)} {browser} profiles ({folders}) and no "
+                          f"--chrome-profile was given — re-run with "
+                          f"--chrome-profile '<folder>' to pick one non-interactively.")
+                    return
+
+        print(f"Extracting cookies from {browser}" + (f" [{profile}]" if profile else "") + "...")
         print()
 
-        results = configure_from_browser(browser, config)
+        results = configure_from_browser(browser, config, profile=profile)
 
         found_any = False
         for platform, success, message in results:

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -8,7 +8,110 @@ Usage:
     agent-reach configure --from-browser chrome
 """
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
+
+# "User Data" root per Chromium-based browser, per OS. Mirrors the glob roots
+# browser_cookie3 uses internally (minus the trailing profile segment), so
+# profile selection stays consistent with the paths the library would have
+# picked itself.
+_CHROMIUM_USER_DATA_DIRS = {
+    "chrome": {
+        "darwin": "~/Library/Application Support/Google/Chrome",
+        "win32": ["Google", "Chrome", "User Data"],
+        "linux": "~/.config/google-chrome",
+    },
+    "edge": {
+        "darwin": "~/Library/Application Support/Microsoft Edge",
+        "win32": ["Microsoft", "Edge", "User Data"],
+        "linux": "~/.config/microsoft-edge",
+    },
+    "brave": {
+        "darwin": "~/Library/Application Support/BraveSoftware/Brave-Browser",
+        "win32": ["BraveSoftware", "Brave-Browser", "User Data"],
+        "linux": "~/.config/BraveSoftware/Brave-Browser",
+    },
+    "opera": {
+        "darwin": "~/Library/Application Support/com.operasoftware.Opera",
+        "win32": ["Opera Software", "Opera Stable"],
+        "linux": "~/.config/opera",
+    },
+}
+
+
+def _chromium_user_data_dir(browser: str) -> Optional[str]:
+    """Return the Chromium "User Data" root for *browser* on this OS, or
+    None if the browser isn't a supported Chromium-based one."""
+    import os
+    import sys
+
+    table = _CHROMIUM_USER_DATA_DIRS.get(browser)
+    if not table:
+        return None
+    if sys.platform == "darwin":
+        darwin_path = table["darwin"]
+        assert isinstance(darwin_path, str)
+        return os.path.expanduser(darwin_path)
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA", "")
+        if not local_appdata:
+            return None
+        win32_parts = table["win32"]
+        assert isinstance(win32_parts, list)
+        return os.path.join(local_appdata, *win32_parts)
+    linux_path = table["linux"]
+    assert isinstance(linux_path, str)
+    return os.path.expanduser(linux_path)
+
+
+def list_chrome_profiles(browser: str = "chrome") -> List[Dict[str, str]]:
+    """List installed profiles for a Chromium-based browser by reading its
+    ``Local State`` file — the same source Chrome's own profile picker uses.
+
+    Cookie-extraction libraries (rookiepy, browser_cookie3) silently resolve
+    to the "Default" profile whenever more than one profile exists, with no
+    way to target another one — this is how callers discover what else is
+    available and where its cookie database actually lives.
+
+    Returns a list of dicts: {"folder", "name", "email", "cookies_path"},
+    Default-profile first, sorted by folder name after that. Browsers with
+    no Local State file (not installed, or a non-Chromium browser) yield [].
+    """
+    import json
+    import os
+
+    user_data_dir = _chromium_user_data_dir(browser)
+    if not user_data_dir:
+        return []
+
+    local_state_path = os.path.join(user_data_dir, "Local State")
+    if not os.path.exists(local_state_path):
+        return []
+
+    try:
+        with open(local_state_path, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    info_cache = state.get("profile", {}).get("info_cache", {})
+    profiles = []
+    for folder, info in info_cache.items():
+        cookies_path = os.path.join(user_data_dir, folder, "Cookies")
+        if not os.path.exists(cookies_path):
+            # Chrome >= 96 moved the cookie DB under Network/ on some platforms.
+            cookies_path = os.path.join(user_data_dir, folder, "Network", "Cookies")
+        if not os.path.exists(cookies_path):
+            continue
+        profiles.append({
+            "folder": folder,
+            "name": info.get("name", folder),
+            "email": info.get("user_name", ""),
+            "cookies_path": cookies_path,
+        })
+
+    profiles.sort(key=lambda p: (p["folder"] != "Default", p["folder"]))
+    return profiles
+
 
 # Platform cookie specs: (platform_name, domain_pattern, needed_cookies)
 PLATFORM_SPECS = [
@@ -39,10 +142,18 @@ PLATFORM_SPECS = [
 ]
 
 
-def extract_all(browser: str = "chrome") -> Dict[str, dict]:
+def extract_all(browser: str = "chrome", profile: Optional[str] = None) -> Dict[str, dict]:
     """
     Extract cookies for all supported platforms from the specified browser.
-    
+
+    Args:
+        browser: chrome/firefox/edge/brave/opera.
+        profile: Chromium profile *folder* name (e.g. "Profile 1", as shown
+            by list_chrome_profiles()). When omitted, both rookiepy and
+            browser_cookie3 silently resolve to whichever profile they find
+            first — in practice always "Default" — even if you intended a
+            different one. Ignored for firefox.
+
     Returns:
         {
             "twitter": {"auth_token": "xxx", "ct0": "yyy"},
@@ -50,12 +161,40 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
             "bilibili": {"SESSDATA": "xxx", "bili_jct": "yyy"},
         }
     """
-    # Try rookiepy first (Rust-based, more stable), fallback to browser_cookie3
+    browser = browser.lower()
+    supported = ["chrome", "firefox", "edge", "brave", "opera"]
+    if browser not in supported:
+        raise ValueError(
+            f"Unsupported browser: {browser}. Supported: {', '.join(supported)}"
+        )
+
+    cookie_file = None
+    if profile:
+        if browser == "firefox":
+            raise ValueError(
+                "Profile selection is only supported for Chromium-based "
+                "browsers (chrome/edge/brave/opera), not firefox."
+            )
+        matches = [p for p in list_chrome_profiles(browser) if p["folder"] == profile]
+        if not matches:
+            available = ", ".join(p["folder"] for p in list_chrome_profiles(browser))
+            raise RuntimeError(
+                f"Profile '{profile}' not found for {browser}."
+                + (f" Available: {available}" if available else " No profiles found.")
+            )
+        cookie_file = matches[0]["cookies_path"]
+
+    # rookiepy (Rust-based, more stable) has no way to target a specific
+    # profile, so an explicit profile request always goes through
+    # browser_cookie3, which accepts a cookie_file= override.
     use_rookiepy = False
-    try:
-        import rookiepy
-        use_rookiepy = True
-    except ImportError:
+    if not cookie_file:
+        try:
+            import rookiepy
+            use_rookiepy = True
+        except ImportError:
+            pass
+    if not use_rookiepy:
         try:
             import browser_cookie3
         except ImportError:
@@ -64,13 +203,6 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
                 "Install: pip install rookiepy  (recommended)\n"
                 "     or: pip install browser-cookie3"
             )
-
-    browser = browser.lower()
-    supported = ["chrome", "firefox", "edge", "brave", "opera"]
-    if browser not in supported:
-        raise ValueError(
-            f"Unsupported browser: {browser}. Supported: {', '.join(supported)}"
-        )
 
     if use_rookiepy:
         # rookiepy returns list of dicts with name/value/domain/path keys
@@ -104,7 +236,10 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
             "opera": browser_cookie3.opera,
         }
         try:
-            cookie_jar = browser_funcs[browser]()
+            if cookie_file:
+                cookie_jar = browser_funcs[browser](cookie_file=cookie_file)
+            else:
+                cookie_jar = browser_funcs[browser]()
         except Exception as e:
             raise RuntimeError(
                 f"Could not read {browser} cookies: {e}\n"
@@ -229,16 +364,19 @@ def _sync_bird_env(auth_token: str, ct0: str) -> None:
 _sync_bird_credentials = _sync_bird_env
 
 
-def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
+def configure_from_browser(
+    browser: str, config, profile: Optional[str] = None
+) -> List[Tuple[str, bool, str]]:
     """
     Extract cookies and configure all found platforms.
-    
+
+    profile: optional Chromium profile folder (see list_chrome_profiles()).
     Returns list of (platform_name, success, message) tuples.
     """
     results_list = []
 
     try:
-        extracted = extract_all(browser)
+        extracted = extract_all(browser, profile=profile)
     except Exception as e:
         return [("Browser", False, str(e))]
 

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -10,10 +10,17 @@ Usage:
 
 from typing import Dict, List, Optional, Tuple
 
-# "User Data" root per Chromium-based browser, per OS. Mirrors the glob roots
-# browser_cookie3 uses internally (minus the trailing profile segment), so
-# profile selection stays consistent with the paths the library would have
+# "User Data" root per browser that lays profiles out the Chrome way
+# (Default/ + Profile N/ subfolders under one root), per OS. Mirrors the glob
+# roots browser_cookie3 uses internally (minus the trailing profile segment),
+# so profile selection stays consistent with the paths the library would have
 # picked itself.
+#
+# Opera is deliberately excluded: it is Chromium-based but does NOT use
+# Default/Profile N subfolders, and on Windows it stores under %APPDATA%
+# (Roaming) rather than %LOCALAPPDATA% — so the per-profile model here does not
+# apply. Opera still works for plain (non-profile) extraction via browser_cookie3;
+# it just can't be targeted with --chrome-profile.
 _CHROMIUM_USER_DATA_DIRS = {
     "chrome": {
         "darwin": "~/Library/Application Support/Google/Chrome",
@@ -30,12 +37,10 @@ _CHROMIUM_USER_DATA_DIRS = {
         "win32": ["BraveSoftware", "Brave-Browser", "User Data"],
         "linux": "~/.config/BraveSoftware/Brave-Browser",
     },
-    "opera": {
-        "darwin": "~/Library/Application Support/com.operasoftware.Opera",
-        "win32": ["Opera Software", "Opera Stable"],
-        "linux": "~/.config/opera",
-    },
 }
+
+#: Browsers whose cookies can be extracted from a named profile (see above).
+PROFILE_SELECTABLE_BROWSERS = tuple(_CHROMIUM_USER_DATA_DIRS)
 
 
 def _chromium_user_data_dir(browser: str) -> Optional[str]:
@@ -109,7 +114,15 @@ def list_chrome_profiles(browser: str = "chrome") -> List[Dict[str, str]]:
             "cookies_path": cookies_path,
         })
 
-    profiles.sort(key=lambda p: (p["folder"] != "Default", p["folder"]))
+    def _sort_key(p):
+        folder = p["folder"]
+        # Default first, then numerically by the "Profile N" number so
+        # "Profile 10" sorts after "Profile 2", not before it.
+        trailing = folder.rsplit(" ", 1)[-1]
+        number = int(trailing) if trailing.isdigit() else 0
+        return (folder != "Default", number, folder)
+
+    profiles.sort(key=_sort_key)
     return profiles
 
 
@@ -170,18 +183,20 @@ def extract_all(browser: str = "chrome", profile: Optional[str] = None) -> Dict[
 
     cookie_file = None
     if profile:
-        if browser == "firefox":
+        if browser not in PROFILE_SELECTABLE_BROWSERS:
             raise ValueError(
-                "Profile selection is only supported for Chromium-based "
-                "browsers (chrome/edge/brave/opera), not firefox."
+                "Profile selection is only supported for "
+                f"{'/'.join(PROFILE_SELECTABLE_BROWSERS)}, not {browser}."
             )
-        matches = [p for p in list_chrome_profiles(browser) if p["folder"] == profile]
+        profiles = list_chrome_profiles(browser)
+        matches = [p for p in profiles if p["folder"] == profile]
         if not matches:
-            available = ", ".join(p["folder"] for p in list_chrome_profiles(browser))
-            raise RuntimeError(
-                f"Profile '{profile}' not found for {browser}."
-                + (f" Available: {available}" if available else " No profiles found.")
+            available = ", ".join(p["folder"] for p in profiles)
+            hint = f" Available: {available}" if available else (
+                " No extractable profiles found (a profile you just created "
+                "has no cookies until you log into something in it)."
             )
+            raise RuntimeError(f"Profile '{profile}' not found for {browser}.{hint}")
         cookie_file = matches[0]["cookies_path"]
 
     # rookiepy (Rust-based, more stable) has no way to target a specific
@@ -198,6 +213,12 @@ def extract_all(browser: str = "chrome", profile: Optional[str] = None) -> Dict[
         try:
             import browser_cookie3
         except ImportError:
+            if cookie_file:  # profile requested — rookiepy can't do this
+                raise RuntimeError(
+                    f"Extracting from a specific profile ('{profile}') requires "
+                    "browser_cookie3 (rookiepy cannot target a profile).\n"
+                    "Install: pip install browser-cookie3"
+                )
             raise RuntimeError(
                 "Cookie extraction requires rookiepy or browser_cookie3.\n"
                 "Install: pip install rookiepy  (recommended)\n"

--- a/docs/install.md
+++ b/docs/install.md
@@ -145,6 +145,21 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 >
 > **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
 
+> 🧑‍💻 **多 Chrome 用户档案（profile）？** 如果你把研究/小号登录在**单独的 Chrome profile** 里（推荐做法，避免和主账号混用），用 `--chrome-profile` 指定从哪个 profile 提取。否则默认只读 `Default`，通常就是你的主账号：
+> ```bash
+> # 只有一个 profile：无需任何额外参数
+> agent-reach configure --from-browser chrome
+>
+> # 多个 profile：不加 --chrome-profile 时会先列出所有 profile 供你选择，
+> # 也可以直接指定 profile 的文件夹名（如 "Profile 1"）：
+> agent-reach configure --from-browser chrome --chrome-profile "Profile 1"
+> ```
+> profile 文件夹名是 `Default`、`Profile 1`、`Profile 2`… 这类固定名字（不是显示名）。查看方式二选一：
+> - 直接运行上面第一条命令，agent-reach 会列出每个 profile 的显示名、登录邮箱和文件夹名；
+> - 或在 Chrome 地址栏打开 `chrome://version`，看 **Profile Path** 末尾那一段。
+>
+> 仅 Chromium 内核浏览器（chrome/edge/brave/opera）支持按 profile 提取；Firefox 不支持。
+
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
 
@@ -338,6 +353,8 @@ If the user wants a different agent to handle it, let them choose.
 | `agent-reach watch` | Quick health + update check (for scheduled tasks) |
 | `agent-reach check-update` | Check for new versions |
 | `agent-reach configure twitter-cookies "..."` | Unlock Twitter search + posting |
+| `agent-reach configure --from-browser chrome` | Auto-extract cookies from Chrome (lists profiles if more than one) |
+| `agent-reach configure --from-browser chrome --chrome-profile "Profile 1"` | Extract from a specific Chrome profile (for burner accounts in a separate profile) |
 | `agent-reach configure proxy URL` | 保存代理地址（Agent 访问 Reddit/Twitter 等受限网络时读取它设置 HTTP_PROXY/HTTPS_PROXY，不是自动解锁开关） |
 | `agent-reach configure groq-key gsk_xxx` | Unlock Xiaoyuzhou podcast transcription |
 

--- a/tests/test_cookie_extract_profiles.py
+++ b/tests/test_cookie_extract_profiles.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""Cover the Chromium profile-selection fix for cookie_extract.py.
+
+Root cause: rookiepy and browser_cookie3 both resolve to the first matching
+Chrome profile path (always "Default" when it exists) with no way to target
+another profile from their public API. Anyone keeping research/burner
+social accounts logged into a *separate* Chrome profile would otherwise
+have `agent-reach configure --from-browser chrome` silently read cookies
+from their real "Default" profile instead of the one they intended.
+"""
+
+import json
+import sys
+
+import pytest
+
+from agent_reach.cookie_extract import extract_all, list_chrome_profiles
+
+
+def _chrome_user_data_dir(tmp_path):
+    if sys.platform == "darwin":
+        return tmp_path / "Library" / "Application Support" / "Google" / "Chrome"
+    return tmp_path / ".config" / "google-chrome"
+
+
+def _make_profile(user_data_dir, folder, name, email):
+    profile_dir = user_data_dir / folder
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "Cookies").write_text("", encoding="utf-8")
+    return {"name": name, "user_name": email}
+
+
+def _write_local_state(user_data_dir, info_cache):
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    (user_data_dir / "Local State").write_text(
+        json.dumps({"profile": {"info_cache": info_cache}}), encoding="utf-8"
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_list_chrome_profiles_reads_local_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_data_dir = _chrome_user_data_dir(tmp_path)
+    info_cache = {
+        "Default": _make_profile(user_data_dir, "Default", "Person 1", "real@gmail.com"),
+        "Profile 1": _make_profile(user_data_dir, "Profile 1", "Research", "burner@gmail.com"),
+    }
+    _write_local_state(user_data_dir, info_cache)
+
+    profiles = list_chrome_profiles("chrome")
+    folders = [p["folder"] for p in profiles]
+
+    assert folders[0] == "Default", "Default must sort first to keep the no-profile default behavior unchanged"
+    assert "Profile 1" in folders
+    research = next(p for p in profiles if p["folder"] == "Profile 1")
+    assert research["email"] == "burner@gmail.com"
+    assert research["cookies_path"] == str(user_data_dir / "Profile 1" / "Cookies")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_list_chrome_profiles_skips_entries_without_a_cookies_file(tmp_path, monkeypatch):
+    """info_cache can list profiles Chrome created but never actually used
+    (no Cookies db yet) — those aren't extractable and shouldn't be offered."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_data_dir = _chrome_user_data_dir(tmp_path)
+    info_cache = {
+        "Default": _make_profile(user_data_dir, "Default", "Person 1", "real@gmail.com"),
+        "Profile 1": {"name": "Empty", "user_name": ""},  # no Cookies file created
+    }
+    _write_local_state(user_data_dir, info_cache)
+
+    profiles = list_chrome_profiles("chrome")
+
+    assert [p["folder"] for p in profiles] == ["Default"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_list_chrome_profiles_empty_when_no_local_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert list_chrome_profiles("chrome") == []
+
+
+class _FakeBrowserCookie3:
+    """Stand-in for the browser_cookie3 module — only tracks what cookie_file
+    it was called with, so tests don't touch a real browser install."""
+
+    calls = []
+
+    @staticmethod
+    def chrome(cookie_file=None, domain_name="", key_file=None):
+        _FakeBrowserCookie3.calls.append(cookie_file)
+        return []
+
+    firefox = staticmethod(lambda cookie_file=None, domain_name="", key_file=None: [])
+    edge = staticmethod(lambda cookie_file=None, domain_name="", key_file=None: [])
+    brave = staticmethod(lambda cookie_file=None, domain_name="", key_file=None: [])
+    opera = staticmethod(lambda cookie_file=None, domain_name="", key_file=None: [])
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_extract_all_with_profile_targets_that_profiles_cookies_path(tmp_path, monkeypatch):
+    """The core regression check: passing profile= must make extract_all
+    read THAT profile's Cookies db, not whichever the library defaults to."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_data_dir = _chrome_user_data_dir(tmp_path)
+    info_cache = {
+        "Default": _make_profile(user_data_dir, "Default", "Person 1", "real@gmail.com"),
+        "Profile 1": _make_profile(user_data_dir, "Profile 1", "Research", "burner@gmail.com"),
+    }
+    _write_local_state(user_data_dir, info_cache)
+
+    _FakeBrowserCookie3.calls = []
+    monkeypatch.setitem(sys.modules, "browser_cookie3", _FakeBrowserCookie3)
+    monkeypatch.setitem(sys.modules, "rookiepy", None)  # not consulted when profile is given
+
+    extract_all("chrome", profile="Profile 1")
+
+    assert _FakeBrowserCookie3.calls == [str(user_data_dir / "Profile 1" / "Cookies")]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_extract_all_rejects_unknown_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_data_dir = _chrome_user_data_dir(tmp_path)
+    info_cache = {"Default": _make_profile(user_data_dir, "Default", "Person 1", "real@gmail.com")}
+    _write_local_state(user_data_dir, info_cache)
+
+    with pytest.raises(RuntimeError, match="not found"):
+        extract_all("chrome", profile="Profile 7")
+
+
+def test_extract_all_rejects_profile_for_firefox():
+    with pytest.raises(ValueError, match="Chromium-based"):
+        extract_all("firefox", profile="whatever")

--- a/tests/test_cookie_extract_profiles.py
+++ b/tests/test_cookie_extract_profiles.py
@@ -130,5 +130,29 @@ def test_extract_all_rejects_unknown_profile(tmp_path, monkeypatch):
 
 
 def test_extract_all_rejects_profile_for_firefox():
-    with pytest.raises(ValueError, match="Chromium-based"):
+    with pytest.raises(ValueError, match="only supported"):
         extract_all("firefox", profile="whatever")
+
+
+def test_extract_all_rejects_profile_for_opera():
+    """Opera is Chromium-based but doesn't use Default/Profile N folders, so
+    per-profile selection is unsupported and must fail with a clear message."""
+    with pytest.raises(ValueError, match="only supported"):
+        extract_all("opera", profile="whatever")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="path layout differs on Windows")
+def test_list_chrome_profiles_sorts_profile_numbers_numerically(tmp_path, monkeypatch):
+    """'Profile 10' must sort after 'Profile 2', not lexically before it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    user_data_dir = _chrome_user_data_dir(tmp_path)
+    info_cache = {
+        "Default": _make_profile(user_data_dir, "Default", "Main", "main@gmail.com"),
+        "Profile 10": _make_profile(user_data_dir, "Profile 10", "Ten", "ten@gmail.com"),
+        "Profile 2": _make_profile(user_data_dir, "Profile 2", "Two", "two@gmail.com"),
+    }
+    _write_local_state(user_data_dir, info_cache)
+
+    folders = [p["folder"] for p in list_chrome_profiles("chrome")]
+
+    assert folders == ["Default", "Profile 2", "Profile 10"]

--- a/tests/test_profile_picker.py
+++ b/tests/test_profile_picker.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Cover the interactive profile-picker input parsing in cli.py.
+
+The picker maps a 1-based menu number to a profile folder. The subtle bug it
+must guard against: Python negative indexing. `int("0") - 1 == -1` and
+`profiles[-1]` is a *valid* index, so a naive `profiles[int(choice) - 1]`
+silently selects the LAST profile (often a burner account) when the user types
+`0` instead of aborting — the exact wrong-account extraction --chrome-profile
+exists to prevent.
+"""
+
+from agent_reach.cli import _resolve_profile_choice
+
+PROFILES = [
+    {"folder": "Default"},
+    {"folder": "Profile 1"},
+    {"folder": "Profile 2"},
+]
+
+
+def test_valid_selection_maps_to_folder():
+    assert _resolve_profile_choice(PROFILES, "1") == "Default"
+    assert _resolve_profile_choice(PROFILES, "2") == "Profile 1"
+    assert _resolve_profile_choice(PROFILES, "3") == "Profile 2"
+
+
+def test_zero_is_rejected_not_treated_as_last():
+    # The regression: "0" → int-1 == -1 → profiles[-1] == "Profile 2" if unguarded.
+    assert _resolve_profile_choice(PROFILES, "0") is None
+
+
+def test_negative_is_rejected():
+    assert _resolve_profile_choice(PROFILES, "-1") is None
+    assert _resolve_profile_choice(PROFILES, "-2") is None
+
+
+def test_out_of_range_high_is_rejected():
+    assert _resolve_profile_choice(PROFILES, "4") is None
+    assert _resolve_profile_choice(PROFILES, "99") is None
+
+
+def test_non_numeric_is_rejected():
+    assert _resolve_profile_choice(PROFILES, "abc") is None
+    assert _resolve_profile_choice(PROFILES, "") is None
+    assert _resolve_profile_choice(PROFILES, "1.5") is None


### PR DESCRIPTION
## Problem

`agent-reach configure --from-browser chrome` (and the auto-import during install) silently reads cookies from the **Default** Chrome profile only, with no way to pick another profile.

Both extraction backends resolve to the first matching cookie DB and stop:
- `browser_cookie3`'s Chrome path list is `['.../Default/Cookies', '.../Profile */Cookies']` and it returns the first glob match (`next(...)`), so `Default` always wins when present.
- `rookiepy` does the same in its Rust `find_chrome_based_paths` (first existing path wins, early `return`), and exposes no profile parameter through its Python API.

This directly undercuts the project's own security guidance. The README and `docs/install.md` recommend using a **dedicated/secondary account** for cookie-auth platforms (Twitter, XHS, Reddit, etc.). The natural way to do that is a separate Chrome profile for burner accounts — but with this bug, extraction ignores that profile and grabs cookies from the user's real **Default** profile instead. The safe workflow the docs recommend can't actually be followed.

## Fix

- **`list_chrome_profiles(browser)`** — enumerates profiles from the browser's own `Local State` file (the same source Chrome's profile picker uses), returning each profile's folder, display name, account email, and exact `Cookies` DB path. Supports chrome/edge/brave/opera across macOS/Windows/Linux.
- **`extract_all()` / `configure_from_browser()`** — new optional `profile=` parameter. When set, it resolves that profile's exact cookie DB and routes through `browser_cookie3(cookie_file=...)` (rookiepy has no profile override). When omitted, behavior is **byte-for-byte unchanged** — no regression for existing users.
- **CLI `--chrome-profile` flag** — when multiple profiles exist and none is specified: prompts interactively (numbered list with name + email) at a TTY; otherwise lists the available folders and aborts rather than silently guessing.

## Tests

- `tests/test_cookie_extract_profiles.py` — profile discovery, missing/empty `Local State`, profiles without a `Cookies` DB yet, the core regression (right profile → right cookie path), and the two error paths (unknown profile, firefox+profile).
- Full existing suite still passes (202 passed on Python 3.12).

## Example

```
$ agent-reach configure --from-browser chrome
Found 2 chrome profiles:
  1. Lucas (main) (real@gmail.com)  [Default]
  2. Research (burner@gmail.com)  [Profile 1]
Which profile has the accounts you want? [1-2]: 2

# or non-interactively:
$ agent-reach configure --from-browser chrome --chrome-profile "Profile 1"
```