### PR TITLE
test: stop the suite from writing skill files into the real $HOME

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Shared pytest fixtures.
+
+Sandboxes $HOME for every test. Several commands write into the user's
+home directory as a side effect — most notably `agent-reach doctor`, which
+auto-installs SKILL.md into every agent directory it finds
+(~/.claude/skills, ~/.agents/skills, ~/.openclaw/skills) and creates
+~/.agent-reach/ via Config(). Without this fixture, simply running the
+test suite mutates the developer's real home directory and can silently
+install/overwrite skill files for their live AI agents.
+
+`os.path.expanduser("~")` and `pathlib.Path.home()` resolve from HOME on
+POSIX and USERPROFILE on Windows, so redirecting those env vars contains
+every *runtime* home-directed write (e.g. the skill-dir installs) under a
+throwaway tmp dir. Config.CONFIG_DIR / CONFIG_FILE are the exception: they
+are class attributes bound to Path.home() at import time — before any
+fixture runs — so they must be re-pointed explicitly.
+"""
+
+import pytest
+
+from agent_reach.config import Config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows
+
+    config_dir = home / ".agent-reach"
+    monkeypatch.setattr(Config, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(Config, "CONFIG_FILE", config_dir / "config.yaml")
+    return home

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Guard against the test suite writing into the developer's real home.
+
+Running `agent-reach doctor` auto-installs SKILL.md into every agent
+directory it finds and creates ~/.agent-reach/ via Config(). Before the
+conftest `_isolate_home` fixture existed, `test_doctor_runs` called the
+real doctor against the real $HOME, silently installing skill files for
+the developer's live AI agents just by running `pytest`.
+
+These tests assert the isolation is actually in effect, so the leak
+cannot regress unnoticed: if the fixture is removed or stops redirecting
+$HOME, expanduser("~") reverts to the real home and these fail.
+"""
+
+import os
+from argparse import Namespace
+
+from agent_reach.config import Config
+
+
+def test_home_is_sandboxed(_isolate_home):
+    """expanduser and Config paths must resolve under the throwaway home."""
+    sandbox = str(_isolate_home)
+    assert os.path.expanduser("~") == sandbox
+    assert str(Config().config_dir).startswith(sandbox)
+
+
+def test_doctor_writes_stay_under_sandboxed_home(_isolate_home):
+    """Running doctor must not touch anything outside the sandbox home.
+
+    _install_skill only writes into agent dirs that already exist, so we
+    pre-create a Claude skills dir *inside* the sandbox and confirm the
+    skill lands there — proving the write is HOME-relative and therefore
+    contained by the fixture rather than escaping to the real home.
+    """
+    from agent_reach.cli import _cmd_doctor
+
+    claude_skills = _isolate_home / ".claude" / "skills"
+    claude_skills.mkdir(parents=True)
+
+    _cmd_doctor(Namespace(json=False))
+
+    installed = claude_skills / "agent-reach" / "SKILL.md"
+    assert installed.exists(), "skill should install under the sandboxed home"
+    # And the config dir Config() created is under the sandbox, not real ~.
+    assert str(Config().config_dir).startswith(str(_isolate_home))


### PR DESCRIPTION
## Problem

Running the test suite mutates the developer's real home directory.

`tests/test_cli.py::test_doctor_runs` invokes the real `agent-reach doctor`:

```python
def test_doctor_runs(self, capsys):
    with patch("sys.argv", ["agent-reach", "doctor"]):
        main()
    ...
```

`_cmd_doctor` calls `_install_skill(force=False)` ("Auto-install skill if not already present"), which installs `SKILL.md` into every agent directory it finds on the machine — `~/.claude/skills/agent-reach/`, `~/.agents/skills/agent-reach/`, `~/.openclaw/skills/agent-reach/` — and `Config()` creates `~/.agent-reach/`. The test patches only `sys.argv`, so all of that lands in the developer's **real** `$HOME`.

That means simply running `pytest` silently installs (or overwrites) skill files for the developer's live AI agents. A SKILL.md is standing instructions for an agent, so this isn't just stray files — it can change how the developer's Claude Code / OpenClaw behaves afterward. It's a surprising side effect, and the same pattern a malicious dependency could use to inject agent instructions via a test run.

The sibling test `test_doctor_preserves_existing_skill_install` already carefully sandboxes `expanduser` and the `Config` paths, so the need for isolation is understood — `test_doctor_runs` just lacked it, and nothing enforced it suite-wide.

## Fix

Rather than patch a single test, isolate `$HOME` for the whole suite so no test can leak into the real home:

- **`tests/conftest.py`** — autouse fixture redirecting `HOME`/`USERPROFILE` to a throwaway tmp dir. It also re-points `Config.CONFIG_DIR` / `Config.CONFIG_FILE`, which are class attributes bound to `Path.home()` at **import time** (before any fixture runs), so an env-var redirect alone wouldn't contain them.
- **`tests/test_home_isolation.py`** — asserts the isolation is actually in effect (expanduser + Config resolve under the sandbox; doctor's writes stay under it). If the fixture is ever removed or stops redirecting `$HOME`, these fail instead of silently leaking again.

## Verification

Full suite passes, and after running it the real `~/.claude/skills/agent-reach` and `~/.agent-reach` are **no longer created** (previously they were).

## Note (out of scope for this PR)

Arguably a diagnostic command (`doctor`) shouldn't install skills into the system at all as a side effect — that's a surprising mutation from a read-only-sounding command. Happy to follow up separately if the maintainers want to reconsider that behavior; this PR just stops the test suite from being affected by it.