### PR TITLE
fix(twitter): detect degraded search health

### DIFF
--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """Twitter/X — check if twitter-cli or bird CLI is available."""
 
-from .base import Channel
 from agent_reach.probe import probe_command
+
+from .base import Channel
 
 
 class TwitterChannel(Channel):
@@ -75,6 +76,12 @@ class TwitterChannel(Channel):
 
         output = probe.output
         if "ok: true" in output:
+            if "failed to init clienttransaction" in output.lower():
+                return "warn", (
+                    "twitter-cli 已认证，读取、时间线和用户查询可用；"
+                    "但搜索初始化失败，SearchTimeline 当前会返回 HTTP 404。"
+                    "优先改用 OpenCLI（复用浏览器登录态），或升级 twitter-cli 后重试"
+                )
             return "ok", (
                 "twitter-cli 完整可用（搜索、读推文、时间线、长文/Article、"
                 "用户查询、Thread）"

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -97,9 +97,11 @@ twitter likes
 ### search 失败时的重试链（按序执行，成功即停）
 
 1. 直接重试一次（偶发失败常见）：`twitter search "query" -n 10`
-2. 升级后再试：`pipx upgrade twitter-cli && twitter search "query" -n 10`
+2. 按实际安装器升级后再试：`uv tool upgrade twitter-cli || pipx upgrade twitter-cli`，然后重新执行搜索
 3. 换 OpenCLI 备选（桌面，复用浏览器登录态）：`opencli twitter search "query" -f yaml`
-4. 都不行就改用 `twitter feed` / `twitter user-posts @somebody` 等稳定命令绕路
+4. 若环境有已登录 X 的浏览器控制工具，打开
+   `https://x.com/search?q=URL_ENCODED_QUERY&src=typed_query&f=live` 读取结果
+5. 都不行就改用 `twitter feed` / `twitter user-posts @somebody` 等稳定命令绕路
 
 ### 重要注意事项
 
@@ -110,6 +112,8 @@ twitter likes
 > **IP 风控**: 不要在 VPS/数据中心 IP 上频繁调用，尤其是 followers/following，有封号风险。使用住宅代理或本地环境。
 >
 > **OpenCLI 备选**: 桌面装了 OpenCLI 的话，`opencli twitter search/article/user-posts -f yaml` 全套可用（浏览器登录态，无需 cookie 环境变量）。
+>
+> **doctor 判定**: `twitter status` 可能在认证正常时仍输出 `Failed to init ClientTransaction`。这代表读取类命令可用、但搜索会返回 HTTP 404；`agent-reach doctor` 会把它标为降级，并继续寻找 OpenCLI 等可用后端。
 >
 > **输出格式**: 建议用 `--yaml` 或 `--json` 获得结构化输出，对 AI agent 更友好。
 

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from agent_reach.channels.twitter import TwitterChannel
 
@@ -26,6 +26,30 @@ def test_check_twitter_cli_found_and_auth_ok():
     assert status == "ok"
     assert "twitter-cli" in message
     assert "完整可用" in message
+    assert channel.active_backend == "twitter-cli"
+
+
+def test_client_transaction_failure_marks_search_degraded():
+    """认证正常但 ClientTransaction 初始化失败 → 不得误报搜索完整可用。"""
+    channel = TwitterChannel()
+    with patch(
+        "shutil.which",
+        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
+    ), patch(
+        "subprocess.run",
+        return_value=_cp(
+            stdout="ok: true\nusername: testuser\n",
+            stderr=(
+                "WARNING twitter_cli.client: Failed to init ClientTransaction: "
+                "'NoneType' object has no attribute 'group'\n"
+            ),
+            returncode=0,
+        ),
+    ):
+        status, message = channel.check()
+    assert status == "warn"
+    assert "搜索初始化失败" in message
+    assert "HTTP 404" in message
     assert channel.active_backend == "twitter-cli"
 
 


### PR DESCRIPTION
## What changed

- Detect `Failed to init ClientTransaction` in `twitter status` and report twitter-cli as degraded instead of claiming search is fully available.
- Let the existing multi-backend selection continue to a healthy OpenCLI fallback when Twitter search is degraded.
- Update the Twitter retry chain for both uv/pipx installs and add a signed-in browser search fallback.
- Add a regression test for the false-positive doctor result.

## Root cause

`twitter status` can return `ok: true` while also warning that `ClientTransaction` initialization failed. X currently requires the resulting `x-client-transaction-id` for `SearchTimeline`, so `twitter search` returns HTTP 404 even though feed, user, and tweet reads still work. The upstream twitter-cli fix is tracked in public-clis/twitter-cli#71.

## Validation

- `uv run pytest tests/ -q` — 256 passed
- `uv run pytest tests/test_twitter_channel.py -q` — 11 passed
- `uv run ruff check agent_reach/channels/twitter.py tests/test_twitter_channel.py` — passed
- Installed twitter-cli PR #71 locally as 0.8.6 and verified `twitter search "OpenAI" -n 3 --json` returns live results
- `uv run python -m agent_reach.cli doctor --json` reports Twitter search healthy with the fixed CLI
