### PR TITLE
security: harden credential boundaries and read-only diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📖 **Reddit** | —（没有零配置路径：匿名接口已被封） | 搜索 + 读帖子和评论 | 桌面装 OpenCLI 用浏览器登录态；或 rdt-cli + Cookie |
 | 📘 **Facebook** | — | 搜索、主页、Feed、群组列表 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
-| 📕 **小红书** | — | 搜索、阅读、评论 | 桌面装 OpenCLI（刷过小红书即可用）；服务器用 xiaohongshu-mcp 扫码 |
+| 📕 **小红书** | — | 搜索、阅读、评论 | OpenCLI 只用用户已有 Chrome 会话；MCP/存量工具用 Cookie-Editor |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
 | 📈 **雪球** | 股票行情、搜索股票、热门帖子、热门股票排行 | — | 告诉 Agent「帮我配雪球」 |
@@ -92,7 +92,9 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 
 > **不知道怎么配？不用查文档。** 直接告诉 Agent「帮我配 XXX」，它知道需要什么、会一步一步引导你。
 >
-> 🍪 需要 Cookie/登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram 等），优先让用户在自己的浏览器里登录。OpenCLI 复用 Chrome 登录态；传统 CLI 才需要 Cookie-Editor 导出 Cookie。
+> 🍪 Twitter 只接受用户通过 Cookie-Editor 手工导出的内容。Agent Reach 不替用户执行小红书登录，也不读取小红书浏览器 Cookie；OpenCLI 只使用用户已经存在且明确控制的 Chrome 会话。`agent-reach configure xhs-cookies` 不会把 Cookie 注入 OpenCLI / Chrome；没有现成会话时，改用 Cookie-Editor 导出后配置 xiaohongshu-mcp / 存量工具。
+>
+> Twitter Cookie 保存后仅供 `agent-reach doctor` 检查配置是否齐全；直接运行上游 `twitter` 命令前，仍需在当前进程环境中显式设置 `TWITTER_AUTH_TOKEN` 和 `TWITTER_CT0`。
 >
 > 🔒 Cookie 只存在你本地，不上传不外传。代码完全开源，随时可审查。
 > 💻 本地电脑不需要代理。代理只有部署在服务器上才需要（~$1/月）。
@@ -211,7 +213,7 @@ channels/
 | 搜全网 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI 语义搜索，MCP 接入免 Key |
 | GitHub | [gh CLI](https://cli.github.com) | — | 官方工具，认证后完整 API 能力 |
 | 读 RSS | [feedparser](https://github.com/kurtmckee/feedparser) | — | Python 生态标准选择 |
-| 小红书 | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)（服务器）▸ xhs-cli | xhs-cli 作者已转投 OpenCLI（24K Star）；浏览器登录态零摩擦 |
+| 小红书 | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)（服务器）▸ xhs-cli | OpenCLI 只用用户已有会话；其余后端用 Cookie-Editor 手工导出 |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | Jina Reader | MCP 服务，浏览器自动化 |
 
 > 📌 这些都是「当前选型」，基于真机实测定期复核。某条路失效了我们换下一条——`agent-reach doctor` 永远告诉你现在走的是哪条。

--- a/agent_reach/backends/opencli.py
+++ b/agent_reach/backends/opencli.py
@@ -7,8 +7,10 @@ zero per-platform configuration, desktop-only (no headless).
 
 Probing notes (verified live):
   - `opencli doctor` AUTO-STARTS the daemon — a side effect, so health
-    checks must use `opencli daemon status` (pure query) instead.
-  - Exit codes are always 0; status must be parsed from text output.
+    checks must never use it.
+  - Current OpenCLI startup also mutates ``~/.opencli`` before handling
+    ``daemon status``. Only ``--version`` is a side-effect-free CLI fast path;
+    live daemon state is read from its documented loopback ``/status`` API.
   - "Extension: disconnected" can mean a sleeping service worker, a disabled
     extension, or an extension that was never loaded. Disk files distinguish
     possible installation sources, but only a live daemon connection proves
@@ -16,7 +18,9 @@ Probing notes (verified live):
 """
 
 import glob
+import json
 import os
+import urllib.request
 from dataclasses import dataclass
 
 from agent_reach.probe import probe_command
@@ -43,6 +47,32 @@ _CHROME_PROFILE_ROOTS = (
 )
 
 _OPENCLI_UNPACKED_EXTENSION = "~/.opencli/extension"
+_OPENCLI_DAEMON_STATUS_URL = "http://127.0.0.1:19825/status"
+_MAX_DAEMON_STATUS_BYTES = 64 * 1024
+
+
+def _fetch_daemon_status(timeout: int = 2):
+    """Read OpenCLI's loopback status endpoint without starting the CLI."""
+    request = urllib.request.Request(
+        _OPENCLI_DAEMON_STATUS_URL,
+        headers={"X-OpenCLI": "1"},
+        method="GET",
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(request, timeout=min(timeout, 2)) as response:
+            raw = response.read(_MAX_DAEMON_STATUS_BYTES + 1)
+    except Exception:
+        return None
+    if len(raw) > _MAX_DAEMON_STATUS_BYTES:
+        return None
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("ok") is not True:
+        return None
+    return payload
 
 
 def _extension_installed_on_disk() -> bool:
@@ -118,23 +148,12 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
 
     st = OpenCLIStatus(installed=True, version=version_probe.output.strip())
 
-    daemon_probe = probe_command(
-        "opencli",
-        ["daemon", "status"],
-        timeout=timeout,
-        package=OPENCLI_PACKAGE,
-        remove_env=_UNSUPPORTED_APP_ENV,
-    )
-    output = daemon_probe.output if daemon_probe.ok else ""
-    # `opencli daemon status` prints lines like:
-    #   Daemon: running (PID 37389) / Daemon: not running
-    #   Extension: connected / Extension: disconnected
-    for line in output.splitlines():
-        line = line.strip().lower()
-        if line.startswith("daemon:"):
-            st.daemon_running = "not running" not in line and "running" in line
-        elif line.startswith("extension:"):
-            st.extension_connected = "disconnected" not in line and "connected" in line
+    daemon_status = _fetch_daemon_status(timeout)
+    if daemon_status is not None:
+        st.daemon_running = True
+        st.extension_connected = bool(
+            daemon_status.get("extensionConnected")
+        )
 
     if not st.extension_connected:
         st.extension_installed = _extension_installed_on_disk()

--- a/agent_reach/backends/opencli.py
+++ b/agent_reach/backends/opencli.py
@@ -9,11 +9,10 @@ Probing notes (verified live):
   - `opencli doctor` AUTO-STARTS the daemon — a side effect, so health
     checks must use `opencli daemon status` (pure query) instead.
   - Exit codes are always 0; status must be parsed from text output.
-  - "Extension: disconnected" does NOT mean unusable: the extension's
-    service worker sleeps and any real opencli command wakes it up
-    (verified: status flips disconnected→connected after one call).
-    Since daemon status can't tell "sleeping" from "never installed",
-    we check Chrome's Extensions directory on disk to disambiguate.
+  - "Extension: disconnected" can mean a sleeping service worker, a disabled
+    extension, or an extension that was never loaded. Disk files distinguish
+    possible installation sources, but only a live daemon connection proves
+    the browser actually loaded and enabled the extension.
 """
 
 import glob
@@ -28,31 +27,51 @@ OPENCLI_EXTENSION_URL = (
     f"https://chromewebstore.google.com/detail/opencli/{OPENCLI_EXTENSION_ID}"
 )
 
-#: Chrome-family profile roots that contain <Profile>/Extensions/<id>/
+# OpenCLIApp 0.1.35 injected this now-unsupported variable into every child.
+# OpenCLI >=1.8.5 rejects it before even handling ``--version``.  Doctor is a
+# read-only observer, so strip the stale app setting only from its child probes.
+_UNSUPPORTED_APP_ENV = ("OPENCLI_DAEMON_PORT",)
+
+#: Chromium-family profile roots that contain <Profile>/Extensions/<id>/
 _CHROME_PROFILE_ROOTS = (
     "~/Library/Application Support/Google/Chrome",  # macOS Chrome
     "~/Library/Application Support/Chromium",       # macOS Chromium
+    "~/Library/Application Support/Microsoft Edge",  # macOS Edge
     "~/.config/google-chrome",                      # Linux Chrome
     "~/.config/chromium",                           # Linux Chromium
+    "~/.config/microsoft-edge",                     # Linux Edge
 )
+
+_OPENCLI_UNPACKED_EXTENSION = "~/.opencli/extension"
 
 
 def _extension_installed_on_disk() -> bool:
-    """True if the OpenCLI extension exists in any Chrome profile.
+    """True if store-installed OpenCLI files exist in a browser profile.
 
-    Store-installed extensions always live under
-    <profile>/Extensions/<extension id>/ — this disambiguates a sleeping
-    service worker from a never-installed extension. Dev installs via
-    "Load unpacked" are not covered (those users can read `opencli doctor`).
+    This is disk evidence only: a user may have disabled or removed the
+    extension while stale files remain, so callers must not treat it as proof
+    that the extension is loaded, connected, or usable.
     """
     roots = [os.path.expanduser(p) for p in _CHROME_PROFILE_ROOTS]
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:  # Windows
         roots.append(os.path.join(local_app_data, "Google", "Chrome", "User Data"))
+        roots.append(os.path.join(local_app_data, "Microsoft", "Edge", "User Data"))
     for root in roots:
         if glob.glob(os.path.join(root, "*", "Extensions", OPENCLI_EXTENSION_ID)):
             return True
     return False
+
+
+def _unpacked_extension_files_present() -> bool:
+    """True when OpenCLI's unpacked extension source contains a manifest.
+
+    ``~/.opencli/extension`` is downloaded source, not browser state.  Its
+    existence never proves the user completed “Load unpacked” or left the
+    extension enabled.
+    """
+    unpacked = os.path.expanduser(_OPENCLI_UNPACKED_EXTENSION)
+    return os.path.isfile(os.path.join(unpacked, "manifest.json"))
 
 
 @dataclass
@@ -62,25 +81,28 @@ class OpenCLIStatus:
     daemon_running: bool = False
     extension_connected: bool = False
     extension_installed: bool = False
+    unpacked_extension_files: bool = False
     version: str = ""
     hint: str = ""
 
     @property
     def ready(self) -> bool:
-        """Usable now or on first call.
+        """True only when the backend is provably usable now.
 
-        A live connection counts, and so does an installed-but-sleeping
-        extension: its service worker wakes on the first real command.
+        Only a live daemon connection proves that a browser loaded and enabled
+        the extension. Disk files alone are deliberately not enough.
         """
-        return self.installed and not self.broken and (
-            self.extension_connected or self.extension_installed
-        )
+        return self.installed and not self.broken and self.extension_connected
 
 
 def opencli_status(timeout: int = 10) -> OpenCLIStatus:
     """Probe OpenCLI install + daemon/extension state without side effects."""
     version_probe = probe_command(
-        "opencli", ["--version"], timeout=timeout, package=OPENCLI_PACKAGE
+        "opencli",
+        ["--version"],
+        timeout=timeout,
+        package=OPENCLI_PACKAGE,
+        remove_env=_UNSUPPORTED_APP_ENV,
     )
     if version_probe.status == "missing":
         return OpenCLIStatus(installed=False)
@@ -97,7 +119,11 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
     st = OpenCLIStatus(installed=True, version=version_probe.output.strip())
 
     daemon_probe = probe_command(
-        "opencli", ["daemon", "status"], timeout=timeout, package=OPENCLI_PACKAGE
+        "opencli",
+        ["daemon", "status"],
+        timeout=timeout,
+        package=OPENCLI_PACKAGE,
+        remove_env=_UNSUPPORTED_APP_ENV,
     )
     output = daemon_probe.output if daemon_probe.ok else ""
     # `opencli daemon status` prints lines like:
@@ -112,11 +138,24 @@ def opencli_status(timeout: int = 10) -> OpenCLIStatus:
 
     if not st.extension_connected:
         st.extension_installed = _extension_installed_on_disk()
-        if not st.extension_installed:
+        st.unpacked_extension_files = _unpacked_extension_files_present()
+        if st.extension_installed:
             st.hint = (
-                "OpenCLI 已安装，但 Chrome 扩展未安装。\n"
-                f"  1. 安装扩展（需手动点一次）：{OPENCLI_EXTENSION_URL}\n"
-                "  2. 保持 Chrome 打开，运行 `opencli doctor` 验证"
+                "检测到 Chrome/Edge 的 OpenCLI 扩展文件，但扩展当前未连接；"
+                "仅凭磁盘文件无法确认它已加载或启用。\n"
+                "  打开浏览器扩展页确认 OpenCLI 已启用，再运行一个 opencli 命令验证"
+            )
+        elif st.unpacked_extension_files:
+            st.hint = (
+                "检测到 ~/.opencli/extension/ 源文件，但文件存在不代表已经在"
+                " Chrome/Edge 中“加载已解压的扩展程序”。\n"
+                "  请在浏览器扩展页加载并启用该目录，再运行一个 opencli 命令验证"
+            )
+        else:
+            st.hint = (
+                "OpenCLI 已安装，但未检测到已连接的浏览器扩展。\n"
+                f"  1. 安装并启用扩展（Chrome/Edge）：{OPENCLI_EXTENSION_URL}\n"
+                "  2. 保持浏览器打开，再运行一个 opencli 命令验证"
             )
     return st
 
@@ -129,8 +168,10 @@ def opencli_summary(st: OpenCLIStatus) -> str:
         return "OpenCLI 无法执行（node 环境损坏）"
     if st.extension_connected:
         return f"OpenCLI 可用（浏览器登录态，v{st.version}）"
-    if st.ready:
-        return "OpenCLI 可用（扩展睡眠中，调用时自动唤醒）"
+    if st.extension_installed:
+        return "OpenCLI 已安装，检测到扩展文件但当前未连接（无法确认已加载）"
+    if st.unpacked_extension_files:
+        return "OpenCLI 已安装，检测到 unpacked 源文件但尚未确认浏览器已加载"
     if st.daemon_running:
         return "OpenCLI 已安装，等待 Chrome 扩展安装"
     return "OpenCLI 已安装（daemon 未运行，使用时自动启动；需 Chrome 扩展）"

--- a/agent_reach/channels/_opencli_site.py
+++ b/agent_reach/channels/_opencli_site.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Shared channel helper for OpenCLI browser-session-only platforms."""
 
-from urllib.parse import urlparse
+from agent_reach.utils.url import host_matches
 
 from .base import Channel
 
@@ -22,8 +22,7 @@ class OpenCLISiteChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        domain = urlparse(url).netloc.lower()
-        return any(domain == d or domain.endswith(f".{d}") for d in self.domains)
+        return host_matches(url, *self.domains)
 
     def check(self, config=None):
         from agent_reach.backends import opencli_status

--- a/agent_reach/channels/_opencli_site.py
+++ b/agent_reach/channels/_opencli_site.py
@@ -38,10 +38,10 @@ class OpenCLISiteChannel(Channel):
         if st.broken:
             return "error", st.hint
 
-        self.active_backend = "OpenCLI"
         if st.ready:
-            return "ok", (
-                f"OpenCLI 可用（复用浏览器登录态）。用法：{self.usage}。"
-                f"若提示登录，请先在 Chrome 里登录 {self.login_hint}"
+            return "warn", (
+                f"OpenCLI 桥接已连接，但 {self.description} 的登录态和实际命令"
+                "未实时验证；Doctor 不执行平台命令，因此当前不标记为可用。"
+                f"需要时请先在 Chrome 里登录 {self.login_hint}"
             )
         return "warn", st.hint

--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -65,7 +65,7 @@ class BilibiliChannel(Channel):
         for wanted in ("ok", "warn"):
             for backend, status, message in findings:
                 if status == wanted:
-                    self.active_backend = backend
+                    self.active_backend = backend if status == "ok" else None
                     if broken_notes:
                         message += "\n[备选后端异常] " + "；".join(broken_notes)
                     return status, message
@@ -103,9 +103,9 @@ class BilibiliChannel(Channel):
         if st.broken:
             return "error", st.hint
         if st.ready:
-            return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
-                "opencli bilibili search/video/subtitle/ranking -f yaml"
+            return "warn", (
+                "OpenCLI 桥接已连接，但 Bilibili 页面、登录态和实际命令"
+                "未实时验证；Doctor 不执行平台命令，因此当前不标记为可用。"
             )
         return "warn", st.hint
 

--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -39,9 +39,9 @@ class BilibiliChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "bilibili.com" in d or "b23.tv" in d
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "bilibili.com", "b23.tv")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -4,6 +4,7 @@
 from agent_reach.probe import probe_command
 
 from .base import Channel
+from .mcporter import McporterConfigError, configured_server_names
 
 #: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
 _MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
@@ -20,7 +21,12 @@ class ExaSearchChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
+        probe = probe_command(
+            "mcporter",
+            ["config", "list", "--json"],
+            timeout=10,
+            package="mcporter",
+        )
         if probe.status == "missing":
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
@@ -31,7 +37,11 @@ class ExaSearchChannel(Channel):
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
             return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "exa" in probe.output.lower():
+        try:
+            server_names = configured_server_names(probe.output)
+        except McporterConfigError as exc:
+            return "error", f"mcporter 配置检查失败：{exc}"
+        if "exa" in server_names:
             self.active_backend = self.backends[0]
             return "ok", "全网语义搜索可用（免费，无需 API Key）"
         return "off", (

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 """Exa Search — check if mcporter + Exa MCP is available."""
 
-from agent_reach.probe import probe_command
+import shutil
 
 from .base import Channel
-from .mcporter import McporterConfigError, configured_server_names
-
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+from .mcporter import McporterConfigError, inspect_mcporter_config
 
 
 class ExaSearchChannel(Channel):
@@ -21,30 +18,27 @@ class ExaSearchChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command(
-            "mcporter",
-            ["config", "list", "--json"],
-            timeout=10,
-            package="mcporter",
-        )
-        if probe.status == "missing":
+        if not shutil.which("mcporter"):
             return "off", (
                 "需要 mcporter + Exa MCP。安装：\n"
                 "  npm install -g mcporter\n"
-                "  mcporter config add exa https://mcp.exa.ai/mcp"
+                "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
             )
-        if probe.status == "broken":
-            return "error", _MCPORTER_BROKEN_HINT
-        if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
         try:
-            server_names = configured_server_names(probe.output)
+            inspection = inspect_mcporter_config()
         except McporterConfigError as exc:
             return "error", f"mcporter 配置检查失败：{exc}"
-        if "exa" in server_names:
-            self.active_backend = self.backends[0]
-            return "ok", "全网语义搜索可用（免费，无需 API Key）"
+        if "exa" in inspection.server_names:
+            return "warn", (
+                "Exa 已写入 mcporter 配置，但 Doctor 未启动远端服务做"
+                "连通验证，不能仅凭配置宣称可用。"
+            )
+        if inspection.imports_unchecked:
+            return "warn", (
+                "mcporter 本地配置未发现 Exa；配置还启用了 editor imports，"
+                "Doctor 为避免扩大凭据读取范围没有展开，当前未验证。"
+            )
         return "off", (
             "mcporter 已装但 Exa 未配置。运行：\n"
-            "  mcporter config add exa https://mcp.exa.ai/mcp"
+            "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
         )

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -13,8 +13,9 @@ class GitHubChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "github.com" in urlparse(url).netloc.lower()
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "github.com")
 
     def check(self, config=None):
         # 真跑 gh auth status 探活。注意：未登录时 rc!=0 是正常业务态（warn），不是 error。

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -1,9 +1,95 @@
 # -*- coding: utf-8 -*-
 """GitHub — check if gh CLI is available."""
 
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
 from agent_reach.probe import probe_command
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    read_small_text_no_follow,
+)
 
 from .base import Channel
+
+_MAX_HOSTS_BYTES = 1024 * 1024
+_GH_READ_ONLY_ENV = {
+    # gh 2.92 creates ~/.local/state/gh/device-id even for `--version` unless
+    # telemetry is disabled. These are documented gh environment controls.
+    "GH_TELEMETRY": "false",
+    "DO_NOT_TRACK": "true",
+    "GH_NO_UPDATE_NOTIFIER": "1",
+    "GH_NO_EXTENSION_UPDATE_NOTIFIER": "1",
+}
+
+
+class GitHubConfigError(ValueError):
+    """Raised when gh credential metadata cannot be read safely."""
+
+
+def _gh_hosts_path() -> Path:
+    override = os.environ.get("GH_CONFIG_DIR")
+    if override:
+        return Path(os.path.abspath(os.path.expanduser(override))) / "hosts.yml"
+
+    xdg_config = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config:
+        return Path(xdg_config) / "gh" / "hosts.yml"
+
+    if os.name == "nt":
+        app_data = os.environ.get("APPDATA")
+        if app_data:
+            return Path(app_data) / "GitHub CLI" / "hosts.yml"
+
+    return Path.home() / ".config" / "gh" / "hosts.yml"
+
+
+def _saved_github_host_configured() -> bool:
+    """Inspect github.com's hosts.yml entry without executing gh."""
+    hosts_path = _gh_hosts_path()
+    try:
+        raw = read_small_text_no_follow(
+            hosts_path,
+            max_bytes=_MAX_HOSTS_BYTES,
+        )
+    except (OSError, PrivatePathError, UnicodeError) as exc:
+        raise GitHubConfigError("gh hosts.yml 无法安全读取") from exc
+    if raw is None:
+        return False
+    try:
+        payload = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise GitHubConfigError("gh hosts.yml 不是有效的 UTF-8 YAML") from exc
+    if payload is None:
+        return False
+    if not isinstance(payload, dict):
+        raise GitHubConfigError("gh hosts.yml 顶层必须是对象")
+
+    host = payload.get("github.com")
+    if host is None:
+        return False
+    if not isinstance(host, dict):
+        raise GitHubConfigError("gh hosts.yml 的 github.com 配置无效")
+
+    users = host.get("users")
+    if users is not None and not isinstance(users, dict):
+        raise GitHubConfigError("gh hosts.yml 的 users 配置无效")
+    return bool(host.get("oauth_token") or host.get("user") or users)
+
+
+def _explicit_github_credentials(config) -> bool:
+    if any(os.environ.get(name) for name in ("GH_TOKEN", "GITHUB_TOKEN")):
+        return True
+    if config is None:
+        return False
+    try:
+        return bool(config.get("github_token"))
+    except Exception as exc:
+        raise GitHubConfigError("Agent Reach 的 GitHub 配置无法读取") from exc
 
 
 class GitHubChannel(Channel):
@@ -18,26 +104,42 @@ class GitHubChannel(Channel):
         return host_matches(url, "github.com")
 
     def check(self, config=None):
-        # 真跑 gh auth status 探活。注意：未登录时 rc!=0 是正常业务态（warn），不是 error。
-        probe = probe_command("gh", ["auth", "status"], timeout=10, package="gh")
+        self.active_backend = None
+        probe = probe_command(
+            "gh",
+            ["--version"],
+            timeout=10,
+            package="gh",
+            env=_GH_READ_ONLY_ENV,
+        )
         if probe.status == "missing":
-            self.active_backend = None
             return "warn", "gh CLI 未安装。安装：https://cli.github.com"
         if probe.status == "broken":
-            # gh 是二进制安装（brew/官方包），不是 pip 包——处方不用 pipx/uv 文案
-            self.active_backend = None
             return "error", (
                 "gh 命令存在但无法执行——安装已损坏。重装即可修复：\n"
                 "  brew reinstall gh\n"
                 "或从 https://cli.github.com 重新安装 gh CLI"
             )
-        if probe.status == "timeout":
-            # gh 本体能启动（工具是活的），只是状态检查超时
-            self.active_backend = "gh CLI"
-            return "warn", "gh CLI 状态检查超时，运行 gh auth status 查看详情"
-        if probe.ok:
-            self.active_backend = "gh CLI"
-            return "ok", "完整可用（读取、搜索、Fork、Issue、PR 等）"
-        # rc != 0：gh 活着但未认证（gh auth status 的正常业务态）
-        self.active_backend = "gh CLI"
-        return "warn", "gh CLI 已安装但未认证。运行 gh auth login 可解锁完整功能"
+        if not probe.ok:
+            detail = probe.hint or probe.status
+            return "error", f"gh CLI 版本检查失败：{detail}"
+
+        try:
+            configured = _explicit_github_credentials(
+                config
+            ) or _saved_github_host_configured()
+        except GitHubConfigError as exc:
+            return "warn", (
+                f"gh CLI 可执行，但认证配置无法安全确认：{exc}。"
+                "Doctor 不执行会写 device-id 的 `gh auth status`，当前未验证。"
+            )
+
+        if configured:
+            return "warn", (
+                "gh CLI 可执行，且检测到显式认证配置；Doctor 不执行会写"
+                " device-id 的 `gh auth status`，因此未实时验证，未标记为可用。"
+            )
+        return "warn", (
+            "gh CLI 可执行，但未检测到显式认证配置。运行 `gh auth login` "
+            "完成登录；Doctor 不会自动执行 `gh auth status`。"
+        )

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -18,8 +18,9 @@ class LinkedInChannel(Channel):
     tier = 2
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        return "linkedin.com" in urlparse(url).netloc.lower()
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "linkedin.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 """LinkedIn — check if linkedin-scraper-mcp is available."""
 
-from agent_reach.probe import probe_command
+import shutil
 
 from .base import Channel
-from .mcporter import McporterConfigError, configured_server_names
+from .mcporter import McporterConfigError, inspect_mcporter_config
 
-#: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
-_MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
 _LINKEDIN_SERVER_NAMES = {"linkedin", "linkedin-scraper", "linkedin-scraper-mcp"}
 
 
@@ -24,32 +22,31 @@ class LinkedInChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command(
-            "mcporter",
-            ["config", "list", "--json"],
-            timeout=10,
-            package="mcporter",
-        )
-        if probe.status == "missing":
+        if not shutil.which("mcporter"):
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
                 "  pip install linkedin-scraper-mcp\n"
-                "  mcporter config add linkedin http://localhost:3000/mcp\n"
+                "  mcporter config add linkedin http://localhost:3000/mcp "
+                "--scope home\n"
                 "  详见 https://github.com/stickerdaniel/linkedin-mcp-server"
             )
-        if probe.status == "broken":
-            return "error", _MCPORTER_BROKEN_HINT
-        if not probe.ok:  # timeout / error
-            return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
         try:
-            server_names = configured_server_names(probe.output)
+            inspection = inspect_mcporter_config()
         except McporterConfigError as exc:
             return "error", f"mcporter 配置检查失败：{exc}"
-        if server_names & _LINKEDIN_SERVER_NAMES:
-            self.active_backend = "linkedin-scraper-mcp"
-            return "ok", "完整可用（Profile、公司、职位搜索）"
+        if inspection.server_names & _LINKEDIN_SERVER_NAMES:
+            return "warn", (
+                "LinkedIn MCP 已写入 mcporter 配置，但 Doctor 未启动本地"
+                "服务做连通验证，不能仅凭配置宣称完整可用。"
+            )
+        if inspection.imports_unchecked:
+            return "warn", (
+                "mcporter 本地配置未发现 LinkedIn MCP；配置还启用了 editor "
+                "imports，Doctor 为避免扩大凭据读取范围没有展开，当前未验证。"
+            )
         return "off", (
             "mcporter 已装但 LinkedIn MCP 未配置。运行：\n"
             "  pip install linkedin-scraper-mcp\n"
-            "  mcporter config add linkedin http://localhost:3000/mcp"
+            "  mcporter config add linkedin http://localhost:3000/mcp "
+            "--scope home"
         )

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -4,9 +4,11 @@
 from agent_reach.probe import probe_command
 
 from .base import Channel
+from .mcporter import McporterConfigError, configured_server_names
 
 #: mcporter 是 npm 包，断链处方与默认的 pipx/uv 不同
 _MCPORTER_BROKEN_HINT = "mcporter 无法执行（node 环境损坏），重装：\n  npm install -g mcporter"
+_LINKEDIN_SERVER_NAMES = {"linkedin", "linkedin-scraper", "linkedin-scraper-mcp"}
 
 
 class LinkedInChannel(Channel):
@@ -21,7 +23,12 @@ class LinkedInChannel(Channel):
 
     def check(self, config=None):
         self.active_backend = None
-        probe = probe_command("mcporter", ["config", "list"], timeout=10, package="mcporter")
+        probe = probe_command(
+            "mcporter",
+            ["config", "list", "--json"],
+            timeout=10,
+            package="mcporter",
+        )
         if probe.status == "missing":
             return "off", (
                 "基本内容可通过 Jina Reader 读取。完整功能需要：\n"
@@ -33,7 +40,11 @@ class LinkedInChannel(Channel):
             return "error", _MCPORTER_BROKEN_HINT
         if not probe.ok:  # timeout / error
             return "error", f"mcporter 执行异常：{probe.hint or probe.output or probe.status}"
-        if "linkedin" in probe.output.lower():
+        try:
+            server_names = configured_server_names(probe.output)
+        except McporterConfigError as exc:
+            return "error", f"mcporter 配置检查失败：{exc}"
+        if server_names & _LINKEDIN_SERVER_NAMES:
             self.active_backend = "linkedin-scraper-mcp"
             return "ok", "完整可用（Profile、公司、职位搜索）"
         return "off", (

--- a/agent_reach/channels/mcporter.py
+++ b/agent_reach/channels/mcporter.py
@@ -1,12 +1,133 @@
-"""Helpers for interpreting mcporter's machine-readable config output."""
+"""Read-only helpers for interpreting mcporter configuration."""
 
 from __future__ import annotations
 
 import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    read_small_text_no_follow,
+)
+
+_MAX_CONFIG_BYTES = 1024 * 1024
+_MISSING = object()
 
 
 class McporterConfigError(ValueError):
-    """Raised when mcporter's advertised JSON output is not trustworthy."""
+    """Raised when mcporter configuration is not trustworthy."""
+
+
+@dataclass(frozen=True)
+class McporterConfigInspection:
+    """Minimal, non-secret routing facts from one mcporter config layer."""
+
+    server_names: frozenset[str]
+    source: str | None
+    imports_unchecked: bool = False
+
+
+def inspect_mcporter_config(
+    root_dir: str | Path | None = None,
+) -> McporterConfigInspection:
+    """Read the effective local mcporter config without starting mcporter.
+
+    An explicit ``MCPORTER_CONFIG`` is a single layer. Otherwise mcporter
+    0.7.3 loads the first home config
+    (``~/.mcporter/mcporter.json`` / ``mcporter.jsonc``) and then
+    ``<cwd>/config/mcporter.json``; project entries override duplicate home
+    names. Only exact ``mcpServers`` keys are returned. Editor imports are
+    deliberately not opened because Doctor must not expand its
+    credential-read boundary.
+    """
+    selected_layers = _select_config_layers(root_dir)
+    if not selected_layers:
+        return McporterConfigInspection(frozenset(), None)
+
+    names = set()
+    imports_unchecked = False
+    sources = []
+    for config_path, source in selected_layers:
+        payload = _read_config_object(config_path)
+        servers = payload.get("mcpServers")
+        if not isinstance(servers, dict):
+            raise McporterConfigError("mcporter 配置缺少 mcpServers 对象")
+
+        for name, definition in servers.items():
+            if not isinstance(name, str) or not name.strip():
+                raise McporterConfigError("mcporter 配置包含无效的 server name")
+            if not isinstance(definition, dict):
+                raise McporterConfigError("mcporter server 定义必须是对象")
+            names.add(name.casefold())
+
+        imports = payload.get("imports", _MISSING)
+        if imports is _MISSING:
+            # mcporter defaults to importing supported editor configs when the
+            # key is omitted. Doctor intentionally does not open those files.
+            imports_unchecked = True
+        elif not isinstance(imports, list) or not all(
+            isinstance(item, str) for item in imports
+        ):
+            raise McporterConfigError("mcporter imports 必须是字符串列表")
+        elif imports:
+            imports_unchecked = True
+        sources.append(source)
+
+    return McporterConfigInspection(
+        frozenset(names),
+        "+".join(sources),
+        imports_unchecked=imports_unchecked,
+    )
+
+
+def _select_config_layers(
+    root_dir: str | Path | None,
+) -> list[tuple[Path, str]]:
+    root = Path(os.path.abspath(os.fspath(root_dir or Path.cwd())))
+    explicit = os.environ.get("MCPORTER_CONFIG", "").strip()
+    if explicit:
+        expanded = Path(os.path.expanduser(explicit))
+        if not expanded.is_absolute():
+            expanded = root / expanded
+        return [(Path(os.path.abspath(os.fspath(expanded))), "explicit")]
+
+    layers = []
+    home_base = Path.home() / ".mcporter"
+    for name in ("mcporter.json", "mcporter.jsonc"):
+        candidate = home_base / name
+        if os.path.lexists(candidate):
+            layers.append((candidate, "home"))
+            break
+
+    project_path = root / "config" / "mcporter.json"
+    if os.path.lexists(project_path):
+        layers.append((project_path, "project"))
+    return layers
+
+
+def _read_config_object(config_path: Path) -> dict:
+    try:
+        raw = read_small_text_no_follow(
+            config_path,
+            max_bytes=_MAX_CONFIG_BYTES,
+        )
+    except PrivatePathError as exc:
+        raise McporterConfigError(
+            f"mcporter 配置文件无法安全读取：{exc}"
+        ) from exc
+    except (OSError, UnicodeError) as exc:
+        raise McporterConfigError("mcporter 配置文件无法安全读取") from exc
+    if raw is None:
+        raise McporterConfigError("mcporter 配置文件不存在")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise McporterConfigError("mcporter 配置不是有效的 UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise McporterConfigError("mcporter 配置顶层必须是对象")
+    return payload
 
 
 def configured_server_names(output: str) -> set[str]:

--- a/agent_reach/channels/mcporter.py
+++ b/agent_reach/channels/mcporter.py
@@ -1,0 +1,31 @@
+"""Helpers for interpreting mcporter's machine-readable config output."""
+
+from __future__ import annotations
+
+import json
+
+
+class McporterConfigError(ValueError):
+    """Raised when mcporter's advertised JSON output is not trustworthy."""
+
+
+def configured_server_names(output: str) -> set[str]:
+    """Return exact configured server names from ``mcporter ... --json``.
+
+    Paths, descriptions, endpoints, and other metadata are deliberately
+    ignored: only each server object's ``name`` field is a routing signal.
+    """
+    try:
+        payload = json.loads(output)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise McporterConfigError("mcporter 返回的 JSON 无法解析") from exc
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("servers"), list):
+        raise McporterConfigError("mcporter JSON 缺少 servers 列表")
+
+    return {
+        name.casefold()
+        for server in payload["servers"]
+        if isinstance(server, dict)
+        if isinstance(name := server.get("name"), str) and name.strip()
+    }

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -11,26 +11,21 @@ logged-in session: OpenCLI reuses the browser's, rdt-cli imports cookies.
 
 import json
 import shutil
-import subprocess
+import time
+from pathlib import Path
 
-from agent_reach.utils.process import utf8_subprocess_env
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    read_small_text_no_follow,
+)
 
 from .base import Channel
 
 _CREDENTIAL_FILE = "~/.config/rdt-cli/credential.json"
+_CREDENTIAL_TTL_SECONDS = 7 * 86400
+_MAX_CREDENTIAL_BYTES = 1024 * 1024
 # Pinned to the 0.4.2 state — PyPI still only has 0.4.1 (upstream issue #10).
 _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66"
-
-#: shell 对"找到但不可执行/找不到"使用的退出码（对齐 agent_reach.probe）
-_BROKEN_EXIT_CODES = (126, 127)
-
-#: rdt 应从固定 git 源安装（PyPI 落后），断链处方与 probe 默认的 pipx/uv 不同
-_RDT_BROKEN_HINT = (
-    "rdt 命令存在但无法执行——通常是系统 Python 升级后 venv 解释器丢失。\n"
-    "PyPI 版本落后，推荐用固定 git 源强制重装：\n"
-    f"  pipx install --force '{_RDT_GIT_SOURCE}'"
-)
-
 
 class RedditChannel(Channel):
     name = "reddit"
@@ -60,7 +55,7 @@ class RedditChannel(Channel):
         for wanted in ("ok", "warn"):
             for backend, status, message in findings:
                 if status == wanted:
-                    self.active_backend = backend
+                    self.active_backend = backend if status == "ok" else None
                     return status, message
 
         if findings:
@@ -86,72 +81,64 @@ class RedditChannel(Channel):
         if st.broken:
             return "error", st.hint
         if st.ready:
-            return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
-                "opencli reddit search/read/subreddit/hot -f yaml"
+            return "warn", (
+                "OpenCLI 桥接已连接，但 Reddit 登录态和实际命令未实时验证；"
+                "Doctor 不执行平台命令，因此当前不标记为可用。"
             )
         return "warn", st.hint
 
     def _check_rdt(self):
-        """rdt-cli candidate. None = not installed."""
-        rdt = shutil.which("rdt")
-        if not rdt:
+        """Inspect rdt's saved credential without invoking its auto-refresh."""
+        if not shutil.which("rdt"):
             return None
 
-        # 不走 probe_command：实测 `rdt status --json` 成功时（rc=0）也会向 stderr
-        # 打网络重试日志，probe 把 stdout+stderr 合并后 JSON 解析必炸。
-        # 故保留手写 subprocess（stdout 单独捕获），但异常分类对齐 probe 语义：
-        # exec 失败/126/127 → broken（venv 断链处方），TimeoutExpired → 超时。
+        credential_path = Path.home() / ".config" / "rdt-cli" / "credential.json"
         try:
-            r = subprocess.run(
-                [rdt, "status", "--json"],
-                capture_output=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=10,
-                env=utf8_subprocess_env(),
+            payload = read_small_text_no_follow(
+                credential_path,
+                max_bytes=_MAX_CREDENTIAL_BYTES,
             )
-        except subprocess.TimeoutExpired:
-            return "error", "rdt 响应超时（>10s），Reddit 状态未知。稍后重试或运行 `rdt status` 查看详情"
+        except PrivatePathError as exc:
+            return "warn", (
+                f"rdt-cli 已安装，但 credential.json 无法安全读取：{exc}。"
+            )
         except OSError:
-            # 含 FileNotFoundError：which 命中但 exec 失败 = venv 断链（probe 的 broken）
-            return "error", _RDT_BROKEN_HINT
-
-        if r.returncode in _BROKEN_EXIT_CODES:
-            return "error", _RDT_BROKEN_HINT
-
-        if r.returncode != 0:
-            detail = (r.stderr or r.stdout or "").strip().splitlines()
-            tail = detail[-1] if detail else "无输出"
-            return "error", f"rdt 异常退出（exit {r.returncode}）：{tail}。运行 `rdt status` 查看详情"
-
-        # 进程正常退出 → rdt 本身是活的（无论登录与否）
-        try:
-            data = json.loads(r.stdout or "")
-        except json.JSONDecodeError:
-            data = None
-        if not isinstance(data, dict):
-            return "warn", "rdt-cli 可用但状态输出无法解析，运行 `rdt status` 查看登录状态"
-
-        info = data.get("data")
-        if not isinstance(info, dict):
-            info = {}
-        authenticated = info.get("authenticated", False)
-        username = info.get("username") or ""
-
-        if authenticated:
-            suffix = f"（已登录：{username}）" if username else ""
-            return "ok", (
-                f"rdt-cli 可用{suffix}（搜索帖子、阅读全文、查看评论；"
-                "上游 2026-03 起停更，桌面用户建议迁移到 OpenCLI）"
+            return "warn", (
+                "rdt-cli 已安装，但 credential.json 无法安全读取；"
+                "Doctor 未执行会自动刷新 Cookie 的 `rdt status`。"
             )
+        if payload is None:
+            return "warn", self._rdt_login_hint()
+        try:
+            data = json.loads(payload)
+        except (UnicodeError, json.JSONDecodeError, ValueError):
+            return "warn", (
+                "rdt-cli 已安装，但保存的 credential.json 无法安全解析；"
+                "Doctor 未执行会自动刷新 Cookie 的 `rdt status`。"
+            )
+        if not isinstance(data, dict):
+            return "warn", self._rdt_login_hint()
+        cookies = data.get("cookies")
+        if not isinstance(cookies, dict) or not cookies.get("reddit_session"):
+            return "warn", self._rdt_login_hint()
 
+        saved_at = data.get("saved_at")
+        if isinstance(saved_at, (int, float)) and (
+            time.time() - saved_at > _CREDENTIAL_TTL_SECONDS
+        ):
+            return "warn", (
+                "rdt-cli 已安装，保存的 Cookie 已超过 7 天；Doctor 不会让"
+                "上游自动读取浏览器或刷新文件，请用 Cookie-Editor 明确更新。"
+            )
         return "warn", (
-            "rdt-cli 已安装但未登录。Reddit 自 2024 年起要求认证，"
-            "未登录时所有请求均返回 403。\n\n"
-            "方法一（自动）：运行 `rdt login`\n"
-            "  先在浏览器登录 reddit.com，再运行此命令自动提取 Cookie。\n\n"
-            "方法二（手动，适用于 Chrome/Edge 127+ 无法自动提取时）：\n"
+            "rdt-cli 已安装并检测到显式保存的 Reddit Cookie；Doctor 为避免"
+            "上游自动刷新浏览器 Cookie，不执行 `rdt status`，因此未实时验证。"
+        )
+
+    @staticmethod
+    def _rdt_login_hint():
+        return (
+            "rdt-cli 已安装但没有可用的显式 Cookie。请使用 Cookie-Editor：\n"
             "  1. Chrome 应用商店安装 Cookie-Editor 扩展：\n"
             "     https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm\n"
             "  2. 在浏览器打开 reddit.com（确保已登录）\n"
@@ -160,5 +147,5 @@ class RedditChannel(Channel):
             '     {"cookies": {"reddit_session": "<粘贴 Value>"}, '
             '"source": "manual", "username": "<你的用户名>", '
             '"modhash": null, "saved_at": 0, "last_verified_at": null}\n\n'
-            "验证：`rdt status --json` 确认 authenticated: true"
+            "Doctor 不会运行会自动读取浏览器并写文件的 `rdt status`。"
         )

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -39,10 +39,9 @@ class RedditChannel(Channel):
     tier = 1  # no zero-config path exists — see module docstring
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
+        from agent_reach.utils.url import host_matches
 
-        d = urlparse(url).netloc.lower()
-        return "reddit.com" in d or "redd.it" in d
+        return host_matches(url, "reddit.com", "redd.it")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins."""

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -2,8 +2,8 @@
 """Twitter/X — check if twitter-cli or bird CLI is available."""
 
 import os
+import shutil
 
-from agent_reach.probe import probe_command
 from agent_reach.utils.url import host_matches
 
 from .base import Channel
@@ -67,7 +67,7 @@ class TwitterChannel(Channel):
         for wanted in ("ok", "warn"):
             for backend, status, message in findings:
                 if status == wanted:
-                    self.active_backend = backend
+                    self.active_backend = backend if status == "ok" else None
                     return status, message
 
         if findings:  # 只剩 broken/timeout 候选
@@ -81,43 +81,32 @@ class TwitterChannel(Channel):
         )
 
     def _check_twitter_cli(self, config=None):
-        """探测 twitter-cli。返回 None 表示未安装，否则返回 (status, message)。
+        """Inspect explicit credentials without starting twitter-cli.
 
-        `twitter status` 才是健康信号：已登录时输出 "ok: true"，
-        未登录时以非零退出码输出 "not_authenticated"——工具本身是活的，
-        所以 probe 的 error 状态也要看 output 内容再分类。
+        Upstream ``twitter status`` automatically reads browser cookies when
+        credentials are missing *or invalid*. Doctor cannot disable that
+        fallback, so executing it would violate the Cookie-Editor-only policy.
         """
-        probe = probe_command(
-            "twitter",
-            ["status"],
-            timeout=15,
-            retries=1,
-            package="twitter-cli",
-            env=twitter_cli_child_env(config),
-        )
-        if probe.status == "missing":
+        if not shutil.which("twitter"):
             return None
-        if probe.status == "broken":
-            return "error", "twitter-cli 命令存在但无法执行。\n" + probe.hint
-        if probe.status == "timeout":
-            return "error", "twitter-cli 健康检查超时（已重试 1 次）。\n" + probe.hint
 
-        output = probe.output
-        if "ok: true" in output:
-            return "ok", (
-                "twitter-cli 完整可用（搜索、读推文、时间线、长文/Article、"
-                "用户查询、Thread）"
-            )
-        if "not_authenticated" in output:
+        child_env = twitter_cli_child_env(config)
+        auth_token = os.environ.get("TWITTER_AUTH_TOKEN") or child_env.get(
+            "TWITTER_AUTH_TOKEN"
+        )
+        ct0 = os.environ.get("TWITTER_CT0") or child_env.get("TWITTER_CT0")
+        if auth_token and ct0:
             return "warn", (
-                "twitter-cli 已安装但未认证。设置方式：\n"
-                "  export TWITTER_AUTH_TOKEN=\"xxx\"\n"
-                "  export TWITTER_CT0=\"yyy\"\n"
-                "或确保已在浏览器中登录 x.com"
+                "twitter-cli 已安装，且 Cookie-Editor 凭据已配置；"
+                "Doctor 不会执行 `twitter status`，因为上游在验证失败时会"
+                "自动读取浏览器 Cookie。请在你明确同意时手动验证。"
             )
         return "warn", (
-            "twitter-cli 已安装但认证检查失败。运行：\n"
-            "  twitter -v status 查看详细信息"
+            "twitter-cli 已安装但没有完整的显式凭据。请用 Cookie-Editor "
+            "从 x.com 导出后运行：\n"
+            "  agent-reach configure twitter-cookies "
+            "'<Cookie-Editor Header String>'\n"
+            "Doctor 不会自动读取浏览器 Cookie。"
         )
 
     def _check_opencli(self):
@@ -130,45 +119,25 @@ class TwitterChannel(Channel):
         if st.broken:
             return "error", st.hint
         if st.ready:
-            return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
-                "opencli twitter search/article/user-posts -f yaml"
+            return "warn", (
+                "OpenCLI 桥接已连接，但 Twitter/X 登录态和实际命令未实时验证；"
+                "Doctor 不执行平台命令，因此当前不标记为可用。"
             )
         return "warn", st.hint
 
     def _check_bird(self):
-        """探测 bird/birdx（legacy 回退）。返回 None 表示均未安装，否则返回 (status, message)。"""
-        last_failure = None
+        """Inspect legacy bird credentials without launching browser fallback."""
         for cmd in ("bird", "birdx"):
-            probe = probe_command(
-                cmd, ["check"], timeout=15, retries=1, package="@steipete/bird"
-            )
-            if probe.status == "missing":
+            if not shutil.which(cmd):
                 continue
-            if probe.status == "broken":
-                last_failure = (
-                    "error",
-                    f"{cmd} 命令存在但无法执行（bird 是 npm 包，可用 "
-                    "npm install -g @steipete/bird 重装）。\n" + probe.hint,
-                )
-                continue  # bird 坏了再试 birdx
-            if probe.status == "timeout":
-                last_failure = (
-                    "error",
-                    f"{cmd} 健康检查超时（已重试 1 次）。\n" + probe.hint,
-                )
-                continue
-
-            output = probe.output
-            if probe.ok:
-                return "ok", "bird CLI 可用（读取、搜索推文，含长文/X Article）"
-            if "Missing credentials" in output or "missing" in output.lower():
-                return "warn", (
-                    "bird CLI 已安装但未配置认证。设置环境变量：\n"
-                    "  export AUTH_TOKEN=\"xxx\"\n"
-                    "  export CT0=\"yyy\""
+            if os.environ.get("AUTH_TOKEN") and os.environ.get("CT0"):
+                return (
+                    "warn",
+                    f"{cmd} 已安装且显式环境凭据存在；Doctor 为避免上游"
+                    "浏览器 Cookie 回退，不执行 `check`，未实时验证。",
                 )
             return "warn", (
-                "bird CLI 已安装但认证检查失败。"
+                f"{cmd} 已安装但未检测到显式 AUTH_TOKEN/CT0；"
+                "仅使用 Cookie-Editor 手动导出的凭据。"
             )
-        return last_failure
+        return None

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -1,8 +1,33 @@
 # -*- coding: utf-8 -*-
 """Twitter/X — check if twitter-cli or bird CLI is available."""
 
-from .base import Channel
+import os
+
 from agent_reach.probe import probe_command
+
+from .base import Channel
+
+
+def twitter_cli_child_env(config=None) -> dict[str, str]:
+    """Return saved credentials missing from the current process environment.
+
+    The returned mapping is meant for a single child process.  Existing shell
+    variables remain authoritative and ``os.environ`` is never mutated.
+    """
+    if config is None:
+        return {}
+
+    child_env = {}
+    for env_name, config_key in (
+        ("TWITTER_AUTH_TOKEN", "twitter_auth_token"),
+        ("TWITTER_CT0", "twitter_ct0"),
+    ):
+        if env_name in os.environ:
+            continue
+        value = config.get(config_key)
+        if value:
+            child_env[env_name] = str(value)
+    return child_env
 
 
 class TwitterChannel(Channel):
@@ -28,7 +53,7 @@ class TwitterChannel(Channel):
 
         for backend in self.ordered_backends(config):
             if backend == "twitter-cli":
-                result = self._check_twitter_cli()
+                result = self._check_twitter_cli(config)
             elif backend == "OpenCLI":
                 result = self._check_opencli()
             elif backend == "bird CLI (legacy)":
@@ -56,7 +81,7 @@ class TwitterChannel(Channel):
             "  uv tool install twitter-cli"
         )
 
-    def _check_twitter_cli(self):
+    def _check_twitter_cli(self, config=None):
         """探测 twitter-cli。返回 None 表示未安装，否则返回 (status, message)。
 
         `twitter status` 才是健康信号：已登录时输出 "ok: true"，
@@ -64,7 +89,12 @@ class TwitterChannel(Channel):
         所以 probe 的 error 状态也要看 output 内容再分类。
         """
         probe = probe_command(
-            "twitter", ["status"], timeout=15, retries=1, package="twitter-cli"
+            "twitter",
+            ["status"],
+            timeout=15,
+            retries=1,
+            package="twitter-cli",
+            env=twitter_cli_child_env(config),
         )
         if probe.status == "missing":
             return None

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -4,6 +4,7 @@
 import os
 
 from agent_reach.probe import probe_command
+from agent_reach.utils.url import host_matches
 
 from .base import Channel
 
@@ -37,9 +38,7 @@ class TwitterChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "x.com" in d or "twitter.com" in d
+        return host_matches(url, "x.com", "twitter.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -4,6 +4,9 @@
 import json
 import urllib.request
 from typing import Any
+
+from agent_reach.utils.text import scrub_url_credentials
+
 from .base import Channel
 
 _UA = "agent-reach/1.0"
@@ -28,9 +31,9 @@ class V2EXChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "v2ex.com" in d
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "v2ex.com")
 
     # ------------------------------------------------------------------ #
     # Health check
@@ -45,7 +48,10 @@ class V2EXChannel(Channel):
             return "ok", "公开 API 可用（热门主题、节点浏览、主题详情、用户信息）"
         except Exception as e:
             self.active_backend = None
-            return "warn", f"V2EX API 连接失败（可能需要代理）：{e}"
+            return (
+                "warn",
+                f"V2EX API 连接失败（可能需要代理）：{scrub_url_credentials(e)}",
+            )
 
     # ------------------------------------------------------------------ #
     # Data-fetching methods

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -4,19 +4,31 @@
 Backend order encodes the recommendation, and probing order makes the
 environment split automatic: OpenCLI needs a desktop Chrome so it simply
 never probes alive on a server, where xiaohongshu-mcp (self-contained
-headless browser) takes over. xhs-cli (upstream unmaintained since
+headless browser) takes over after an explicit Cookie-Editor import.
+xhs-cli (upstream unmaintained since
 2026-03) keeps working for existing installs as the last candidate.
 """
 
+import json
+import shutil
+import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 
-from agent_reach.probe import probe_command
+from agent_reach.backends import opencli_status
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    read_small_text_no_follow,
+)
 
 from .base import Channel
+from .mcporter import McporterConfigError, inspect_mcporter_config
 
 _MCP_ENDPOINT = "http://localhost:18060/mcp"
 _MCP_INSTALL_URL = "https://github.com/xpzouying/xiaohongshu-mcp"
+_XHS_COOKIE_TTL_SECONDS = 7 * 86400
+_MAX_XHS_COOKIE_BYTES = 1024 * 1024
 
 
 def _mcp_service_reachable(timeout: int = 3) -> bool:
@@ -181,7 +193,7 @@ class XiaoHongShuChannel(Channel):
         for wanted in ("ok", "warn"):
             for backend, status, message in findings:
                 if status == wanted:
-                    self.active_backend = backend
+                    self.active_backend = backend if status == "ok" else None
                     return status, message
 
         if findings:  # only broken candidates left
@@ -191,22 +203,22 @@ class XiaoHongShuChannel(Channel):
             "未安装任何小红书后端。推荐：\n"
             "  桌面：agent-reach install --channels opencli\n"
             "       （复用 Chrome 登录态，刷过小红书即零配置可用）\n"
-            f"  服务器：xiaohongshu-mcp（自带无头浏览器+扫码登录）：{_MCP_INSTALL_URL}"
+            f"  服务器：xiaohongshu-mcp：{_MCP_INSTALL_URL}\n"
+            "       登录只使用 Cookie-Editor 明确导出：\n"
+            "       agent-reach configure xhs-cookies '<Cookie-Editor export>'"
         )
 
     def _check_opencli(self):
         """OpenCLI candidate. None = not installed."""
-        from agent_reach.backends import opencli_status
-
         st = opencli_status()
         if not st.installed:
             return None
         if st.broken:
             return "error", st.hint
         if st.ready:
-            return "ok", (
-                "OpenCLI 可用（复用浏览器登录态）。用法："
-                "opencli xiaohongshu search/note/comments/feed -f yaml"
+            return "warn", (
+                "OpenCLI 桥接已连接，但小红书登录态和实际命令未实时验证；"
+                "Doctor 不执行平台命令，因此当前不标记为可用。"
             )
         return "warn", st.hint
 
@@ -214,45 +226,79 @@ class XiaoHongShuChannel(Channel):
         """xiaohongshu-mcp candidate. None = service not running."""
         if not _mcp_service_reachable():
             return None
-        mcporter = probe_command(
-            "mcporter", ["config", "list"], timeout=10, package="mcporter"
-        )
-        if mcporter.ok and "xiaohongshu" in mcporter.output:
-            return "ok", (
-                "xiaohongshu-mcp 服务运行中"
-                "（mcporter call 'xiaohongshu.search_feeds(keyword: \"...\")'）。"
-                "若未登录，让 agent 调 get_login_qrcode 扫码"
+        if not shutil.which("mcporter"):
+            return "warn", (
+                "xiaohongshu-mcp 服务可达，但 mcporter 未安装，Doctor 未接入"
+                "该服务。先安装：npm install -g mcporter"
+            )
+        try:
+            inspection = inspect_mcporter_config()
+        except McporterConfigError as exc:
+            return "error", f"mcporter 配置检查失败：{exc}"
+        if "xiaohongshu" in inspection.server_names:
+            return "warn", (
+                "xiaohongshu-mcp 服务可达且已接入 mcporter，但 Doctor "
+                "未验证登录态，不能据此宣称笔记功能可用。若未登录，用 "
+                "Cookie-Editor 导出后运行 agent-reach configure xhs-cookies"
+            )
+        if inspection.imports_unchecked:
+            return "warn", (
+                "xiaohongshu-mcp 服务可达；mcporter 本地配置未发现"
+                " xiaohongshu，且 editor imports 未展开，Doctor 当前未验证接入。"
             )
         return "warn", (
             "xiaohongshu-mcp 服务在跑但 mcporter 未接入。运行：\n"
-            f"  mcporter config add xiaohongshu {_MCP_ENDPOINT}"
+            f"  mcporter config add xiaohongshu {_MCP_ENDPOINT} --scope home"
         )
 
     def _check_xhs_cli(self):
-        """Legacy xhs-cli candidate. None = not installed."""
-        probe = probe_command(
-            "xhs", ["status"], timeout=10, package="xiaohongshu-cli"
-        )
-        if probe.status == "missing":
+        """Inspect saved xhs-cli cookies without invoking browser extraction."""
+        if not shutil.which("xhs"):
             return None
-        if probe.status == "broken":
-            return "error", "xhs 命令存在但无法执行\n" + probe.hint
-        if probe.status == "timeout":
-            return "warn", "xhs-cli 已安装但状态检测超时\n" + probe.hint
-
-        # 进程是活的（执行成功或运行后非零退出）——按输出内容分类
-        if probe.ok and "ok: true" in probe.output:
-            return "ok", (
-                "xhs-cli 可用（搜索、阅读、评论、热门；上游 2026-03 起停更，"
-                "桌面用户建议迁移到 OpenCLI）"
+        cookie_path = Path.home() / ".xiaohongshu-cli" / "cookies.json"
+        try:
+            payload = read_small_text_no_follow(
+                cookie_path,
+                max_bytes=_MAX_XHS_COOKIE_BYTES,
             )
-        if "not_authenticated" in probe.output or "expired" in probe.output:
+        except PrivatePathError as exc:
             return "warn", (
-                "xhs-cli 已安装但未登录。运行：\n"
-                "  xhs login\n"
-                "（自动从浏览器提取 Cookie，或扫码登录）"
+                f"xhs-cli 已安装，但 cookies.json 无法安全读取：{exc}。"
+            )
+        except OSError:
+            return "warn", (
+                "xhs-cli 已安装，但 cookies.json 无法安全读取；"
+                "Doctor 未执行会自动提取浏览器 Cookie 的 `xhs status`。"
+            )
+        if payload is None:
+            return self._xhs_cookie_hint()
+        try:
+            data = json.loads(payload)
+        except (UnicodeError, json.JSONDecodeError, ValueError):
+            return "warn", (
+                "xhs-cli 已安装，但保存的 cookies.json 无法安全解析；"
+                "Doctor 未执行会自动提取浏览器 Cookie 的 `xhs status`。"
+            )
+        if not isinstance(data, dict) or not data.get("a1"):
+            return self._xhs_cookie_hint()
+        saved_at = data.get("saved_at")
+        if isinstance(saved_at, (int, float)) and (
+            time.time() - saved_at > _XHS_COOKIE_TTL_SECONDS
+        ):
+            return "warn", (
+                "xhs-cli 已安装，保存的 Cookie 已超过 7 天；Doctor 不会让"
+                "上游自动读取浏览器或刷新文件，请用 Cookie-Editor 明确更新。"
             )
         return "warn", (
-            "xhs-cli 已安装但状态异常。运行：\n"
-            "  xhs -v status 查看详细信息"
+            "xhs-cli 已安装并检测到显式保存的 Cookie；Doctor 为避免上游"
+            "自动读取浏览器或改写 Cookie，不执行 `xhs status`，未实时验证。"
+        )
+
+    @staticmethod
+    def _xhs_cookie_hint():
+        return "warn", (
+            "xhs-cli 已安装但没有可用的显式 Cookie。不要运行会自动读取"
+            "浏览器的 `xhs login/status`；请迁移到 xiaohongshu-mcp，"
+            "再用 Cookie-Editor 导出并运行 "
+            "agent-reach configure xhs-cookies。"
         )

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -153,9 +153,9 @@ class XiaoHongShuChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaohongshu.com" in d or "xhslink.com" in d
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "xiaohongshu.com", "xhslink.com")
 
     def check(self, config=None):
         """Probe candidates in order; first fully-usable backend wins.

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -16,7 +16,6 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from agent_reach.backends import opencli_status
 from agent_reach.utils.paths import (
     PrivatePathError,
     read_small_text_no_follow,
@@ -210,6 +209,8 @@ class XiaoHongShuChannel(Channel):
 
     def _check_opencli(self):
         """OpenCLI candidate. None = not installed."""
+        from agent_reach.backends import opencli_status
+
         st = opencli_status()
         if not st.installed:
             return None

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -2,8 +2,10 @@
 """Xiaoyuzhou Podcast (小宇宙播客) — transcribe podcasts via Groq Whisper API."""
 
 import os
+
 from agent_reach.config import Config
 from agent_reach.probe import probe_command
+
 from .base import Channel
 
 
@@ -14,9 +16,9 @@ class XiaoyuzhouChannel(Channel):
     tier = 1
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
-        d = urlparse(url).netloc.lower()
-        return "xiaoyuzhoufm.com" in d
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "xiaoyuzhoufm.com")
 
     def check(self, config=None):
         self.active_backend = None

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -56,12 +56,12 @@ def _inject_cookie_string(cookie_str: str) -> None:
         _cookie_jar.set_cookie(cookie)
 
 
-def _load_cookies_from_config() -> bool:
+def _load_cookies_from_config(config=None) -> bool:
     """Try to load Xueqiu cookies from agent-reach config file (xueqiu_cookie key)."""
     try:
         from ..config import Config
 
-        cfg = Config()
+        cfg = config if config is not None else Config(read_only=True)
         cookie_str = cfg.get("xueqiu_cookie")
         if not cookie_str:
             return False
@@ -71,7 +71,7 @@ def _load_cookies_from_config() -> bool:
         return False
 
 
-def _ensure_cookies() -> None:
+def _ensure_cookies(config=None) -> None:
     """Populate session cookies without touching browser credential stores.
 
     Priority order:
@@ -82,7 +82,7 @@ def _ensure_cookies() -> None:
     global _cookies_initialized
     if _cookies_initialized:
         return
-    if _load_cookies_from_config():
+    if _load_cookies_from_config(config):
         _cookies_initialized = True
         return
     # Fallback: visit homepage to pick up acw_tc anti-DDoS cookie.
@@ -93,9 +93,9 @@ def _ensure_cookies() -> None:
     _cookies_initialized = True
 
 
-def _get_json(url: str) -> Any:
+def _get_json(url: str, config=None) -> Any:
     """Fetch *url* with Xueqiu session cookies and return parsed JSON."""
-    _ensure_cookies()
+    _ensure_cookies(config)
     req = urllib.request.Request(
         url, headers={"User-Agent": _UA, "Referer": _REFERER}
     )
@@ -135,7 +135,8 @@ class XueqiuChannel(Channel):
         try:
             data = _get_json(
                 "https://stock.xueqiu.com/v5/stock/quote.json"
-                "?symbol=SH601138&extend=detail"
+                "?symbol=SH601138&extend=detail",
+                config,
             )
             quote = (data.get("data") or {}).get("quote") or {}
             if quote:

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -71,53 +71,18 @@ def _load_cookies_from_config() -> bool:
         return False
 
 
-def _load_cookies_from_browser() -> bool:
-    """Try to silently load Xueqiu cookies from the local Chrome browser.
-
-    Only succeeds when browser_cookie3 is installed AND the user is logged in
-    (xq_a_token present).  Failures are silently ignored so that agents without
-    a local browser keep working.
-    """
-    try:
-        try:
-            import rookiepy
-            cookies = rookiepy.chrome([".xueqiu.com"])
-            if not any(c.get("name") == "xq_a_token" for c in cookies):
-                return False
-            for c in cookies:
-                name = c.get("name")
-                value = c.get("value")
-                if name and value is not None:
-                    _inject_cookie_string(f"{name}={value}")
-            return True
-        except ImportError:
-            import browser_cookie3
-            cookies = list(browser_cookie3.chrome(domain_name=".xueqiu.com"))
-            if not any(c.name == "xq_a_token" for c in cookies):
-                return False
-            for c in cookies:
-                _cookie_jar.set_cookie(c)
-            return True
-    except Exception:
-        return False
-
-
 def _ensure_cookies() -> None:
-    """Populate session cookies using the best available source.
+    """Populate session cookies without touching browser credential stores.
 
     Priority order:
     1. Saved cookie string in ~/.agent-reach/config.yaml  (set by configure --from-browser)
-    2. Live Chrome browser cookies via rookiepy/browser_cookie3 (if installed + logged in)
-    3. Homepage visit fallback                             (only yields anti-DDoS acw_tc,
-                                                           not enough for stock APIs)
+    2. Homepage visit fallback (only yields public session cookies and may not
+       be sufficient when Xueqiu requires a logged-in session)
     """
     global _cookies_initialized
     if _cookies_initialized:
         return
     if _load_cookies_from_config():
-        _cookies_initialized = True
-        return
-    if _load_cookies_from_browser():
         _cookies_initialized = True
         return
     # Fallback: visit homepage to pick up acw_tc anti-DDoS cookie.
@@ -168,17 +133,20 @@ class XueqiuChannel(Channel):
         self.active_backend = None
         try:
             data = _get_json(
-                "https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol=SH000001"
+                "https://stock.xueqiu.com/v5/stock/quote.json"
+                "?symbol=SH601138&extend=detail"
             )
-            items = (data.get("data") or {}).get("items") or []
-            if items:
+            quote = (data.get("data") or {}).get("quote") or {}
+            if quote:
                 self.active_backend = self.backends[0]
                 return "ok", "公开 API 可用（行情、搜索、热帖、热股）"
             return "warn", "API 响应异常（返回数据为空）"
         except Exception as e:
+            detail = str(e).rstrip(": ")
             return "warn", (
-                f"Xueqiu API 连接失败：{e}。"
-                "请先登录雪球后运行：agent-reach configure --from-browser chrome"
+                f"Xueqiu API 连接失败：{detail}。"
+                "如需登录 Cookie，请通过显式配置流程保存后重试；"
+                "doctor 不会自动读取浏览器 Cookie。"
             )
 
     # ------------------------------------------------------------------ #
@@ -193,13 +161,15 @@ class XueqiuChannel(Channel):
 
         Returns a dict with keys:
           symbol, name, current, percent, chg, high, low, open, last_close,
-          volume, amount, market_capital, turnover_rate, pe_ttm, timestamp
+          volume, amount, market_capital, turnover_rate, pe_ttm, pe_forecast,
+          pb, eps, timestamp
         """
+        encoded_symbol = urllib.parse.quote(symbol, safe="")
         data = _get_json(
-            f"https://stock.xueqiu.com/v5/stock/batch/quote.json?symbol={symbol}"
+            "https://stock.xueqiu.com/v5/stock/quote.json"
+            f"?symbol={encoded_symbol}&extend=detail"
         )
-        items = (data.get("data") or {}).get("items") or []
-        q = (items[0].get("quote") or {}) if items else {}
+        q = (data.get("data") or {}).get("quote") or {}
         return {
             "symbol": q.get("symbol", symbol),
             "name": q.get("name", ""),
@@ -215,6 +185,9 @@ class XueqiuChannel(Channel):
             "market_capital": q.get("market_capital"),
             "turnover_rate": q.get("turnover_rate"),
             "pe_ttm": q.get("pe_ttm"),
+            "pe_forecast": q.get("pe_forecast"),
+            "pb": q.get("pb"),
+            "eps": q.get("eps"),
             "timestamp": q.get("timestamp"),
         }
 

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -122,8 +122,9 @@ class XueqiuChannel(Channel):
     # ------------------------------------------------------------------ #
 
     def can_handle(self, url: str) -> bool:
-        d = urllib.parse.urlparse(url).netloc.lower()
-        return "xueqiu.com" in d
+        from agent_reach.utils.url import host_matches
+
+        return host_matches(url, "xueqiu.com")
 
     # ------------------------------------------------------------------ #
     # Health check
@@ -142,10 +143,13 @@ class XueqiuChannel(Channel):
                 return "ok", "公开 API 可用（行情、搜索、热帖、热股）"
             return "warn", "API 响应异常（返回数据为空）"
         except Exception as e:
-            detail = str(e).rstrip(": ")
+            from agent_reach.utils.text import scrub_url_credentials
+
+            detail = scrub_url_credentials(e).rstrip(": ")
             return "warn", (
                 f"Xueqiu API 连接失败：{detail}。"
-                "如需登录 Cookie，请通过显式配置流程保存后重试；"
+                "如需登录 Cookie，请运行：agent-reach configure "
+                "--from-browser chrome --platform xueqiu；"
                 "doctor 不会自动读取浏览器 Cookie。"
             )
 

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -11,6 +11,7 @@ from agent_reach.utils.text import read_utf8_text
 from .base import Channel
 
 _JS_RUNTIMES_SUPPORTED_FROM = (2025, 11, 12)
+_YTDLP_UPGRADE_COMMAND = 'python -m pip install -U "yt-dlp[default]"'
 
 
 def _parse_ytdlp_version(version: str):
@@ -74,12 +75,12 @@ class YouTubeChannel(Channel):
                     return "warn", (
                         "无法确认 yt-dlp 版本是否支持 JS runtime 配置。"
                         "请先升级并重新运行 doctor：\n"
-                        "  python -m pip install -U yt-dlp"
+                        f"  {_YTDLP_UPGRADE_COMMAND}"
                     )
                 if version < _JS_RUNTIMES_SUPPORTED_FROM:
                     return "warn", (
                         "yt-dlp 版本过旧，不支持 JS runtime 配置。请先升级并重新运行 doctor：\n"
-                        "  python -m pip install -U yt-dlp"
+                        f"  {_YTDLP_UPGRADE_COMMAND}"
                     )
                 return "warn", (
                     f"yt-dlp 已安装但未配置 JS runtime。运行：\n  {render_ytdlp_fix_command()}"

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """YouTube — check if yt-dlp is available with JS runtime."""
 
+import re
 import shutil
 
 from agent_reach.probe import probe_command
@@ -8,6 +9,14 @@ from agent_reach.utils.paths import get_ytdlp_config_path, render_ytdlp_fix_comm
 from agent_reach.utils.text import read_utf8_text
 
 from .base import Channel
+
+_JS_RUNTIMES_SUPPORTED_FROM = (2025, 11, 12)
+
+
+def _parse_ytdlp_version(version: str):
+    """Return a comparable stable yt-dlp release tuple, if recognised."""
+    match = re.fullmatch(r"\s*(\d{4})\.(\d{1,2})\.(\d{1,2})\s*", version)
+    return tuple(map(int, match.groups())) if match else None
 
 
 def _has_js_runtime_config(config_path) -> bool:
@@ -60,6 +69,18 @@ class YouTubeChannel(Channel):
         if not has_deno:
             ytdlp_config = get_ytdlp_config_path()
             if not _has_js_runtime_config(ytdlp_config):
+                version = _parse_ytdlp_version(probe.output)
+                if version is None:
+                    return "warn", (
+                        "无法确认 yt-dlp 版本是否支持 JS runtime 配置。"
+                        "请先升级并重新运行 doctor：\n"
+                        "  python -m pip install -U yt-dlp"
+                    )
+                if version < _JS_RUNTIMES_SUPPORTED_FROM:
+                    return "warn", (
+                        "yt-dlp 版本过旧，不支持 JS runtime 配置。请先升级并重新运行 doctor：\n"
+                        "  python -m pip install -U yt-dlp"
+                    )
                 return "warn", (
                     f"yt-dlp 已安装但未配置 JS runtime。运行：\n  {render_ytdlp_fix_command()}"
                 )
@@ -88,4 +109,3 @@ class YouTubeChannel(Channel):
         from agent_reach.transcribe import transcribe as _transcribe
 
         return _transcribe(url, provider=provider, config=config)
-

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -5,8 +5,12 @@ import re
 import shutil
 
 from agent_reach.probe import probe_command
-from agent_reach.utils.paths import get_ytdlp_config_path, render_ytdlp_fix_command
-from agent_reach.utils.text import read_utf8_text
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    get_ytdlp_config_path,
+    read_small_text_no_follow,
+    render_ytdlp_fix_command,
+)
 
 from .base import Channel
 
@@ -23,10 +27,12 @@ def _parse_ytdlp_version(version: str):
 def _has_js_runtime_config(config_path) -> bool:
     """Return whether yt-dlp config explicitly enables a JS runtime."""
     try:
-        if not config_path.exists():
-            return False
-        return "--js-runtimes" in read_utf8_text(config_path)
-    except OSError:
+        payload = read_small_text_no_follow(
+            config_path,
+            max_bytes=1024 * 1024,
+        )
+        return payload is not None and "--js-runtimes" in payload
+    except (OSError, UnicodeError, PrivatePathError):
         return False
 
 
@@ -46,10 +52,13 @@ class YouTubeChannel(Channel):
         probe = probe_command("yt-dlp", ["--version"], timeout=10, package="yt-dlp")
         if probe.status == "missing":
             self.active_backend = None
-            return "off", "yt-dlp 未安装。安装：pip install yt-dlp"
+            return "off", f"yt-dlp 未安装。安装：{_YTDLP_UPGRADE_COMMAND}"
         if probe.status == "broken":
             self.active_backend = None
-            return "error", f"yt-dlp 已安装但无法执行\n{probe.hint}"
+            return "error", (
+                "yt-dlp 已安装但无法执行。重装（含 JS 支持）：\n"
+                f"  {_YTDLP_UPGRADE_COMMAND}\n{probe.hint}"
+            )
         if not probe.ok:  # timeout / error：装了但跑不动
             self.active_backend = None
             detail = probe.hint or probe.output or probe.status
@@ -93,8 +102,17 @@ class YouTubeChannel(Channel):
             if config.is_configured("openai_whisper"):
                 providers.append("openai")
             if providers:
-                if not shutil.which("ffmpeg"):
-                    msg += "（音频转写需安装 ffmpeg）"
+                missing_media_tools = [
+                    tool
+                    for tool in ("ffmpeg", "ffprobe")
+                    if not shutil.which(tool)
+                ]
+                if missing_media_tools:
+                    msg += (
+                        "（音频转写需安装 "
+                        + "、".join(missing_media_tools)
+                        + "）"
+                    )
                 else:
                     msg += f"，可转写音频（{'→'.join(providers)}）"
         return "ok", msg

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -37,10 +37,9 @@ class YouTubeChannel(Channel):
     tier = 0
 
     def can_handle(self, url: str) -> bool:
-        from urllib.parse import urlparse
+        from agent_reach.utils.url import host_matches
 
-        d = urlparse(url).netloc.lower()
-        return "youtube.com" in d or "youtu.be" in d
+        return host_matches(url, "youtube.com", "youtu.be")
 
     def check(self, config=None):
         # 真跑 yt-dlp --version 探活，区分未装 / venv 断链 / 跑不动

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -158,6 +158,10 @@ def main():
                 f"{args.platform} requires Cookie-Editor export; use "
                 f"`agent-reach configure {manual_keys[args.platform]} ...`"
             )
+        if args.profile and args.from_browser not in {"chrome", "edge", "brave"}:
+            p_conf.error(
+                "--profile is supported only for Chrome/Edge/Brave"
+            )
         if args.sync_legacy_twitter:
             p_conf.error("--sync-legacy-twitter is only valid with twitter-cookies")
     elif args.command == "configure":
@@ -205,29 +209,14 @@ def main():
 def _cmd_install(args):
     """One-shot deterministic installer."""
     import os
+
     from agent_reach.config import Config
     from agent_reach.doctor import check_all, format_report
 
     safe_mode = args.safe
     dry_run = args.dry_run
 
-    config = Config()
-    print()
-    print("Agent Reach Installer")
-    print("=" * 40)
-
-    # Ensure tools directory exists (for upstream tool repos)
-    tools_dir = os.path.expanduser("~/.agent-reach/tools")
-    os.makedirs(tools_dir, exist_ok=True)
-
-    if dry_run:
-        print("DRY RUN — showing what would be done (no changes)")
-        print()
-    if safe_mode:
-        print("SAFE MODE — skipping automatic system changes")
-        print()
-
-    # ── Parse --channels ──
+    # Validate channel names before constructing config or changing the system.
     CHANNEL_INSTALLERS = {
         "twitter":     _install_twitter_deps,
         "xiaoyuzhou":  _install_xiaoyuzhou_deps,
@@ -240,16 +229,47 @@ def _cmd_install(args):
         # xueqiu: cookie-only, no install step
         # linkedin: manual setup, no auto-install
     }
+    supported_channels = set(CHANNEL_INSTALLERS) | {"xueqiu", "linkedin"}
+    raw_channels = [
+        channel.strip().lower()
+        for channel in args.channels.split(",")
+        if channel.strip()
+    ]
+    unknown_channels = set(raw_channels) - supported_channels - {"all"}
+    if unknown_channels:
+        supported = ", ".join(sorted(supported_channels | {"all"}))
+        unknown = ", ".join(sorted(unknown_channels))
+        print(
+            f"agent-reach install: error: unknown channel(s): {unknown}. "
+            f"Supported: {supported}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    if "all" in raw_channels:
+        requested_channels = supported_channels
+    else:
+        requested_channels = set(raw_channels)
+
+    config = Config(read_only=dry_run or safe_mode)
+    print()
+    print("Agent Reach Installer")
+    print("=" * 40)
+
+    if dry_run:
+        print("DRY RUN — showing what would be done (no changes)")
+        print()
+    if safe_mode:
+        print("SAFE MODE — skipping automatic system changes")
+        print()
+
+    # Only a real installation may create persistent directories.
+    if not dry_run and not safe_mode:
+        tools_dir = os.path.expanduser("~/.agent-reach/tools")
+        os.makedirs(tools_dir, exist_ok=True)
+
     OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
     COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "xiaohongshu"}
-
-    requested_channels = set()
-    if args.channels:
-        raw = [c.strip().lower() for c in args.channels.split(",") if c.strip()]
-        if "all" in raw:
-            requested_channels = set(CHANNEL_INSTALLERS.keys()) | {"xueqiu", "linkedin"}
-        else:
-            requested_channels = set(raw)
 
     # Auto-detect environment
     env = args.env
@@ -269,8 +289,9 @@ def _cmd_install(args):
 
     # Apply explicit flags
     if args.proxy:
-        if dry_run:
-            print(f"[dry-run] Would save network proxy")
+        if dry_run or safe_mode:
+            mode = "dry-run" if dry_run else "safe"
+            print(f"[{mode}] Would save network proxy")
         else:
             config.set("proxy", args.proxy)
             config.set("bilibili_proxy", args.proxy)  # legacy key
@@ -361,23 +382,29 @@ def _cmd_install(args):
         print(format_report(results))
         print()
 
-        # ── Install agent skill ──
-        _install_skill()
+        if safe_mode:
+            print(
+                "Safe mode check complete. No changes were made. "
+                f"{ok}/{total} channels active."
+            )
+        else:
+            # ── Install agent skill ──
+            _install_skill()
 
-        print(f"✅ Installation complete! {ok}/{total} channels active.")
+            print(f"✅ Installation complete! {ok}/{total} channels active.")
 
-        if not requested_channels:
-            # First install — hint about optional channels
+            if not requested_channels:
+                # First install — hint about optional channels
+                print()
+                print("More channels available! Use --channels to install:")
+                print("   agent-reach install --channels=twitter,xiaohongshu,reddit,facebook,instagram,...")
+                print("   agent-reach install --channels=all  (install everything)")
+
+            # Star reminder
             print()
-            print("More channels available! Use --channels to install:")
-            print("   agent-reach install --channels=twitter,xiaohongshu,reddit,facebook,instagram,...")
-            print("   agent-reach install --channels=all  (install everything)")
-
-        # Star reminder
-        print()
-        print("如果 Agent Reach 帮到了你，给个 Star 让更多人发现它吧：")
-        print("   https://github.com/Panniantong/Agent-Reach")
-        print("   只需一秒，对独立开发者意义很大。谢谢！")
+            print("如果 Agent Reach 帮到了你，给个 Star 让更多人发现它吧：")
+            print("   https://github.com/Panniantong/Agent-Reach")
+            print("   只需一秒，对独立开发者意义很大。谢谢！")
     else:
         print()
         print("Dry run complete. No changes were made.")
@@ -664,24 +691,82 @@ def _install_system_deps():
                 print("  -- undici install failed (optional — may not work behind proxies)")
 
     # ── yt-dlp JS runtime config (YouTube requires external JS runtime) ──
-    if shutil.which("node"):
-        from agent_reach.utils.paths import get_ytdlp_config_path
+    if shutil.which("deno"):
+        print("  ✅ yt-dlp can use the installed Deno JS runtime")
+    elif shutil.which("node"):
+        from agent_reach.channels.youtube import (
+            _JS_RUNTIMES_SUPPORTED_FROM,
+            _parse_ytdlp_version,
+        )
+        from agent_reach.utils.paths import (
+            PrivatePathError,
+            atomic_write_private_text,
+            get_ytdlp_config_path,
+            read_small_text_no_follow,
+        )
 
-        ytdlp_config = get_ytdlp_config_path()
-        needs_config = True
-        if ytdlp_config.exists():
-            with ytdlp_config.open("r", encoding="utf-8") as f:
-                if "--js-runtimes" in f.read():
-                    needs_config = False
-                    print("  ✅ yt-dlp JS runtime already configured")
-        if needs_config:
+        ytdlp_cmd = shutil.which("yt-dlp")
+        installed_version = None
+        if ytdlp_cmd:
             try:
-                ytdlp_config.parent.mkdir(parents=True, exist_ok=True)
-                with ytdlp_config.open("a", encoding="utf-8") as f:
-                    f.write("--js-runtimes node\n")
-                print("  ✅ yt-dlp configured to use Node.js as JS runtime (YouTube)")
-            except Exception:
-                print("  -- Could not configure yt-dlp JS runtime (YouTube may not work)")
+                version_result = subprocess.run(
+                    [ytdlp_cmd, "--version"],
+                    capture_output=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=10,
+                )
+                if version_result.returncode == 0:
+                    installed_version = _parse_ytdlp_version(
+                        version_result.stdout.strip()
+                    )
+            except (OSError, subprocess.TimeoutExpired):
+                installed_version = None
+
+        if (
+            installed_version is None
+            or installed_version < _JS_RUNTIMES_SUPPORTED_FROM
+        ):
+            print(
+                "  -- 未写入 yt-dlp JS runtime 配置：yt-dlp 缺失、过旧或"
+                "版本无法确认。先升级：python -m pip install -U "
+                '"yt-dlp[default]"'
+            )
+        else:
+            ytdlp_config = get_ytdlp_config_path()
+            try:
+                existing_config = read_small_text_no_follow(
+                    ytdlp_config,
+                    max_bytes=1024 * 1024,
+                )
+                if (
+                    existing_config is not None
+                    and "--js-runtimes" in existing_config
+                ):
+                    print("  ✅ yt-dlp JS runtime already configured")
+                else:
+                    existing_config = existing_config or ""
+                    separator = (
+                        ""
+                        if not existing_config
+                        or existing_config.endswith(("\n", "\r"))
+                        else "\n"
+                    )
+                    atomic_write_private_text(
+                        ytdlp_config,
+                        existing_config
+                        + separator
+                        + "--js-runtimes node\n",
+                    )
+                    print(
+                        "  ✅ yt-dlp configured to use Node.js as JS runtime "
+                        "(YouTube)"
+                    )
+            except (OSError, UnicodeError, ValueError, PrivatePathError):
+                print(
+                    "  -- Could not configure yt-dlp JS runtime "
+                    "(YouTube may not work)"
+                )
 
     # NOTE: twitter-cli, xiaoyuzhou, xhs-cli etc. are optional.
     # They are installed via --channels flag, not here.
@@ -758,8 +843,8 @@ def _install_xhs_deps():
     """Set up XiaoHongShu — backend depends on environment.
 
     Desktop: OpenCLI (reuses the browser session, zero config).
-    Server: xiaohongshu-mcp guide (self-contained headless browser + QR
-    login; we don't manage long-running services, so guide only).
+    Server: xiaohongshu-mcp guide with an explicit Cookie-Editor export;
+    we don't manage long-running services, so guide only.
     xhs-cli is no longer installed by default — upstream unmaintained
     since 2026-03; existing installs keep working as a fallback backend.
     """
@@ -767,12 +852,14 @@ def _install_xhs_deps():
 
     print("Setting up XiaoHongShu...")
     if _detect_environment() == "server":
-        print("  服务器环境推荐 xiaohongshu-mcp（自带无头浏览器，扫码登录）：")
+        print("  服务器环境推荐 xiaohongshu-mcp：")
         print("    1. 下载 binary：https://github.com/xpzouying/xiaohongshu-mcp/releases")
         print("       （建议放到 ~/.agent-reach/tools/ 下）")
         print("    2. 启动服务（首次运行会下载约 150MB 浏览器，请等待完成）")
-        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp --scope home")
-        print("    4. 验证：agent-reach doctor")
+        print("    3. 用 Cookie-Editor 从 xiaohongshu.com 明确导出 Cookie")
+        print("       agent-reach configure xhs-cookies '<Cookie-Editor JSON or Header String>'")
+        print("    4. 接入：mcporter config add xiaohongshu http://localhost:18060/mcp --scope home")
+        print("    5. 验证：agent-reach doctor")
         return
 
     _install_opencli_deps()
@@ -974,11 +1061,23 @@ def _install_mcporter():
 
     # Configure Exa MCP (free, no key needed)
     try:
-        r = subprocess.run(
-            ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=5
+        from agent_reach.channels.mcporter import (
+            McporterConfigError,
+            configured_server_names,
         )
-        if "exa" not in r.stdout:
-            subprocess.run(
+
+        r = subprocess.run(
+            ["mcporter", "config", "list", "--json"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if r.returncode != 0:
+            raise McporterConfigError("mcporter 配置查询失败")
+        server_names = configured_server_names(r.stdout)
+        if "exa" not in server_names:
+            add_result = subprocess.run(
                 [
                     "mcporter",
                     "config",
@@ -990,7 +1089,13 @@ def _install_mcporter():
                 ],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
-            print("  ✅ Exa search configured (free, no API key needed)")
+            if add_result.returncode == 0:
+                print("  ✅ Exa search configured (free, no API key needed)")
+            else:
+                print(
+                    "  [!]  Could not configure Exa. Run manually: "
+                    "mcporter config add exa https://mcp.exa.ai/mcp --scope home"
+                )
         else:
             print("  ✅ Exa search already configured")
     except Exception:
@@ -1059,6 +1164,8 @@ def _detect_environment():
 def _cmd_configure(args):
     """Set a config value and test it, or auto-extract from browser."""
     import shutil
+    from typing import cast
+
     from agent_reach.config import Config
 
     config = Config()
@@ -1072,12 +1179,22 @@ def _cmd_configure(args):
         print(f"Extracting {args.platform} cookies from {browser}...")
         print()
 
-        results = configure_from_browser(
-            browser,
-            config,
-            platform=platform,
-            profile=args.profile,
-        )
+        try:
+            results = configure_from_browser(
+                browser,
+                config,
+                platform=platform,
+                profile=args.profile,
+            )
+        except ValueError as exc:
+            from agent_reach.utils.text import scrub_url_credentials
+
+            print(
+                f"agent-reach configure: error: "
+                f"{scrub_url_credentials(exc)}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from None
 
         found_any = False
         for result in results:
@@ -1087,7 +1204,8 @@ def _cmd_configure(args):
                 message = result.message
                 targets = getattr(result, "targets", ())
             else:
-                result_platform, success, message = result
+                legacy_result = cast(tuple[str, bool, str], result)
+                result_platform, success, message = legacy_result
                 targets = ()
             if success:
                 print(f"  ✅ {result_platform}: {message}")
@@ -1102,6 +1220,7 @@ def _cmd_configure(args):
             print("✅ Cookies configured! Run `agent-reach doctor` to see updated status.")
         else:
             print(f"No cookies found. Make sure you're logged into the platforms in {browser}.")
+            raise SystemExit(1)
         return
 
     # ── Manual configure ──
@@ -1109,14 +1228,14 @@ def _cmd_configure(args):
         print("Usage: agent-reach configure <key> <value>")
         print(
             "   or: agent-reach configure --from-browser chrome "
-            "--platform twitter"
+            "--platform xueqiu"
         )
         return
 
     value = " ".join(args.value) if args.value else ""
     if not value:
         print(f"Missing value for {args.key}")
-        return
+        raise SystemExit(1)
 
     if args.key == "proxy":
         # Generic network proxy for restricted environments. Nothing reads
@@ -1138,51 +1257,48 @@ def _cmd_configure(args):
             config.set("twitter_auth_token", auth_token)
             config.set("twitter_ct0", ct0)
 
-            print("✅ Twitter cookies configured!")
+            print("✅ Twitter cookies 已保存到 ~/.agent-reach/config.yaml")
             if getattr(args, "sync_legacy_twitter", False):
                 from agent_reach.cookie_extract import (
                     _sync_bird_env,
                     _sync_xfetch_session,
                 )
 
-                _sync_xfetch_session(auth_token, ct0)
-                _sync_bird_env(auth_token, ct0)
-                print(
-                    "  Legacy copies written to "
-                    "~/.config/xfetch/session.json and "
-                    "~/.config/bird/credentials.env"
+                legacy_results = (
+                    (
+                        "~/.config/xfetch/session.json",
+                        _sync_xfetch_session(auth_token, ct0),
+                    ),
+                    (
+                        "~/.config/bird/credentials.env",
+                        _sync_bird_env(auth_token, ct0),
+                    ),
                 )
+                for path, success in legacy_results:
+                    outcome = "written" if success else "failed"
+                    print(f"  {outcome}: {path}")
+                if all(success for _, success in legacy_results):
+                    print("  Legacy copies written successfully.")
 
-            print("Testing Twitter access...", end=" ")
-            try:
-                import subprocess
-                twitter_bin = shutil.which("twitter")
-                if not twitter_bin:
-                    print("[!] twitter-cli not installed. Run: pipx install twitter-cli")
-                else:
-                    import os
-
-                    from agent_reach.channels.twitter import twitter_cli_child_env
-
-                    env = os.environ.copy()
-                    env.update(twitter_cli_child_env(config))
-                    result = subprocess.run(
-                        [twitter_bin, "status"],
-                        capture_output=True, encoding="utf-8", errors="replace", timeout=15,
-                        env=env,
-                    )
-                    output = (result.stdout or "") + (result.stderr or "")
-                    if "ok: true" in output:
-                        print("✅ Twitter access works!")
-                    else:
-                        print("[!] Auth check failed (cookies might be wrong)")
-            except Exception as e:
-                print(f"[X] Failed: {e}")
+            print(
+                "  凭据未实时验证：不会执行 `twitter status`，因为上游在"
+                "验证失败时会自动读取浏览器 Cookie。"
+            )
+            if not shutil.which("twitter"):
+                print(
+                    "  [!] twitter-cli 未安装。运行：pipx install twitter-cli"
+                )
+            else:
+                print(
+                    "  注意：独立 `twitter` 命令不会读取 Agent Reach 配置；"
+                    "直接使用时需显式设置 TWITTER_AUTH_TOKEN/TWITTER_CT0。"
+                )
         else:
             print("[X] Could not find auth_token and ct0 in your input.")
             print("   Accepted formats:")
             print("   1. agent-reach configure twitter-cookies AUTH_TOKEN CT0")
             print('   2. agent-reach configure twitter-cookies "auth_token=xxx; ct0=yyy; ..."')
+            raise SystemExit(1)
 
     elif args.key == "youtube-cookies":
         config.set("youtube_cookies_from", value)
@@ -1190,7 +1306,8 @@ def _cmd_configure(args):
         print("   yt-dlp will use cookies from this browser for age-restricted/member videos.")
 
     elif args.key == "xhs-cookies":
-        _configure_xhs_cookies(value)
+        if not _configure_xhs_cookies(value):
+            raise SystemExit(1)
 
     elif args.key == "github-token":
         config.set("github_token", value)
@@ -1210,11 +1327,12 @@ def _cmd_transcribe(args):
     from pathlib import Path
 
     from agent_reach.transcribe import TranscribeError, transcribe
+    from agent_reach.utils.text import scrub_url_credentials
 
     try:
         text = transcribe(args.source, provider=args.provider)
     except TranscribeError as e:
-        print(f"❌ {e}")
+        print(f"❌ {scrub_url_credentials(e)}")
         sys.exit(1)
 
     if args.output:
@@ -1245,7 +1363,7 @@ def _parse_twitter_cookie_input(value: str):
     return auth_token, ct0
 
 
-def _configure_xhs_cookies(value):
+def _configure_xhs_cookies(value) -> bool:
     """Import cookies into xiaohongshu-mcp Docker container.
 
     Accepts two formats:
@@ -1265,7 +1383,7 @@ def _configure_xhs_cookies(value):
     if not value:
         print("[X] Missing cookie value.")
         print("   Usage: agent-reach configure xhs-cookies '<cookie JSON or header string>'")
-        return
+        return False
 
     # Detect format and parse
     cookies_json = None
@@ -1275,20 +1393,54 @@ def _configure_xhs_cookies(value):
         try:
             parsed = json.loads(value)
             if isinstance(parsed, list) and parsed:
-                # Validate it looks like cookie objects
-                first = parsed[0]
-                if isinstance(first, dict) and "name" in first and "value" in first:
-                    cookies_json = json.dumps(parsed)
-                    print(f"  Parsed {len(parsed)} cookies from JSON format")
-                else:
-                    print("[X] JSON array doesn't contain cookie objects (need name/value fields)")
-                    return
+                from agent_reach.utils.url import domain_matches
+
+                valid_cookies = []
+                ignored_domains = 0
+                ignored_invalid = 0
+                for cookie in parsed:
+                    if (
+                        not isinstance(cookie, dict)
+                        or not isinstance(cookie.get("name"), str)
+                        or not cookie["name"]
+                        or not isinstance(cookie.get("value"), str)
+                    ):
+                        ignored_invalid += 1
+                        continue
+                    if not domain_matches(
+                        cookie.get("domain", ""),
+                        "xiaohongshu.com",
+                    ):
+                        ignored_domains += 1
+                        continue
+                    valid_cookies.append(cookie)
+
+                if ignored_domains:
+                    print(
+                        f"  [!] 已忽略 {ignored_domains} 个非 "
+                        "xiaohongshu.com 域 Cookie"
+                    )
+                if ignored_invalid:
+                    print(
+                        f"  [!] 已忽略 {ignored_invalid} 个格式无效的 Cookie"
+                    )
+                if not valid_cookies:
+                    print(
+                        "[X] Cookie-Editor JSON 中没有有效的 "
+                        "xiaohongshu.com 域 Cookie"
+                    )
+                    return False
+                cookies_json = json.dumps(valid_cookies)
+                print(
+                    f"  Parsed {len(valid_cookies)} "
+                    "xiaohongshu.com cookies from JSON format"
+                )
             else:
                 print("[X] Empty or invalid JSON array")
-                return
+                return False
         except json.JSONDecodeError as e:
             print(f"[X] Invalid JSON: {e}")
-            return
+            return False
 
     # Header String format: "key1=val1; key2=val2; ..."
     if cookies_json is None and "=" in value:
@@ -1318,49 +1470,38 @@ def _configure_xhs_cookies(value):
             print(f"  Parsed {len(cookies)} cookies from Header String format")
         else:
             print("[X] Could not parse any cookies from input")
-            return
+            return False
 
     if not cookies_json:
         print("[X] Could not parse cookies. Accepted formats:")
         print('   1. JSON array: \'[{"name":"x","value":"y","domain":".xiaohongshu.com",...}]\'')
         print('   2. Header String: "key1=val1; key2=val2; ..."')
-        return
+        return False
 
     # Find the container
     docker = shutil.which("docker")
     if not docker:
         # No Docker - write to a local file for manual import.
-        # Create with 0o600 atomically so the file is never world-readable
-        # between open() and a follow-up chmod() (same pattern Config.save()
-        # uses in config.py).
-        import stat
+        from pathlib import Path
 
-        from agent_reach.utils.paths import make_private_dir
+        from agent_reach.utils.paths import (
+            PrivatePathError,
+            atomic_write_private_text,
+        )
 
-        cookie_dir = make_private_dir(os.path.expanduser("~/.agent-reach"))
-        cookie_path = cookie_dir / "xhs-cookies.json"
+        cookie_path = (
+            Path(os.path.expanduser("~/.agent-reach"))
+            / "xhs-cookies.json"
+        )
         try:
-            fd = os.open(
-                str(cookie_path),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                stat.S_IRUSR | stat.S_IWUSR,  # 0o600
-            )
-            if os.name != "nt":
-                os.chmod(cookie_path, stat.S_IRUSR | stat.S_IWUSR)
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(cookies_json)
-        except OSError:
-            # Windows / unsupported flags — fall back to plain open + chmod.
-            with open(cookie_path, "w", encoding="utf-8") as f:
-                f.write(cookies_json)
-            try:
-                os.chmod(cookie_path, 0o600)
-            except OSError:
-                pass
+            atomic_write_private_text(cookie_path, cookies_json)
+        except (OSError, PrivatePathError) as exc:
+            print(f"[X] Could not save cookies safely: {exc}")
+            return False
         print(f"  Cookies saved to {cookie_path}")
         print("  Docker not found. Copy manually:")
         print(f"  docker cp {cookie_path} xiaohongshu-mcp:/app/data/cookies.json")
-        return
+        return True
 
     # Check if xiaohongshu-mcp container is running
     try:
@@ -1373,10 +1514,10 @@ def _configure_xhs_cookies(value):
             print("[X] xiaohongshu-mcp container is not running.")
             print("   Start it first:")
             print("   docker run -d --name xiaohongshu-mcp -p 18060:18060 xpzouying/xiaohongshu-mcp")
-            return
+            return False
     except Exception as e:
         print(f"[X] Could not check Docker: {e}")
-        return
+        return False
 
     # Find the cookies path inside the container
     try:
@@ -1406,7 +1547,7 @@ def _configure_xhs_cookies(value):
 
         if result.returncode != 0:
             print(f"[X] Failed to copy cookies: {result.stderr}")
-            return
+            return False
 
         print(f"✅ Cookies written to {container_name}:{cookie_path_in_container}")
         # Restart container so it reloads cookies from disk
@@ -1422,7 +1563,7 @@ def _configure_xhs_cookies(value):
             print(f"  Restart manually: docker restart {container_name}")
     except Exception as e:
         print(f"[X] Failed to write cookies: {e}")
-        return
+        return False
     finally:
         if tmp_path:
             try:
@@ -1451,6 +1592,7 @@ def _configure_xhs_cookies(value):
             print(f"[!] Could not verify: {e}")
     else:
         print("  (mcporter not found, skipping verification)")
+    return True
 
 
 def _cmd_uninstall(args):
@@ -1470,6 +1612,7 @@ def _cmd_uninstall(args):
         print()
 
     removed_any = False
+    mcporter_cleanup_skipped = False
 
     # ── 1. Config directory (~/.agent-reach/) ──
     config_dir = os.path.expanduser("~/.agent-reach")
@@ -1489,6 +1632,22 @@ def _cmd_uninstall(args):
             print(f"  Config directory not found (already clean): {config_dir}")
     else:
         print(f"  Skipping config directory (--keep-config): {config_dir}")
+
+    # Opt-in legacy copies may be shared with upstream tools. Without a
+    # provenance marker it would be unsafe to delete them automatically, so
+    # surface every exact path that may still contain Twitter credentials.
+    legacy_credential_paths = (
+        os.path.expanduser("~/.config/xfetch/session.json"),
+        os.path.expanduser("~/.config/bird/credentials.env"),
+    )
+    present_legacy_paths = [
+        path for path in legacy_credential_paths if os.path.lexists(path)
+    ]
+    if present_legacy_paths:
+        print("  [!] 检测到可选的 Twitter legacy 凭据副本；不会自动删除：")
+        for path in present_legacy_paths:
+            print(f"      {path}")
+        print("      若确认不再被 xfetch/bird 使用，请手动删除。")
 
     # ── 2. Skill files ──
     skill_dirs = [
@@ -1515,23 +1674,46 @@ def _cmd_uninstall(args):
 
     # ── 3. mcporter MCP entries ──
     if shutil.which("mcporter"):
-        for mcp_name in ("exa", "xiaohongshu"):
-            try:
-                r = subprocess.run(
-                    ["mcporter", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=10
+        from agent_reach.channels.mcporter import (
+            McporterConfigError,
+            configured_server_names,
+        )
+
+        try:
+            result = subprocess.run(
+                [
+                    "mcporter",
+                    "config",
+                    "list",
+                    "--json",
+                ],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+            if result.returncode != 0:
+                raise McporterConfigError("mcporter config query failed")
+            server_names = configured_server_names(result.stdout)
+        except (
+            McporterConfigError,
+            OSError,
+            subprocess.TimeoutExpired,
+        ):
+            mcporter_cleanup_skipped = True
+            print(
+                "  [!] 无法安全核验 mcporter 配置来源；"
+                "不会自动删除 exa/xiaohongshu 项。"
+            )
+        else:
+            for mcp_name in ("exa", "xiaohongshu"):
+                if mcp_name not in server_names:
+                    continue
+                mcporter_cleanup_skipped = True
+                print(
+                    f"  [!] mcporter entry {mcp_name} 来源无法证明由 "
+                    "Agent Reach 管理；已保留。若确认不再需要，请手动移除。"
                 )
-                if mcp_name in r.stdout:
-                    if dry_run:
-                        print(f"[dry-run] Would remove mcporter entry: {mcp_name}")
-                    else:
-                        subprocess.run(
-                            ["mcporter", "config", "remove", mcp_name],
-                            capture_output=True, encoding="utf-8", errors="replace", timeout=10,
-                        )
-                        print(f"  Removed mcporter entry: {mcp_name}")
-                        removed_any = True
-            except Exception:
-                pass
 
     # ── 4. Summary and optional steps ──
     print()
@@ -1541,6 +1723,8 @@ def _cmd_uninstall(args):
     else:
         if removed_any:
             print("Agent Reach data removed.")
+        elif mcporter_cleanup_skipped:
+            print("No proven Agent Reach-managed mcporter data was removed.")
         else:
             print("Nothing to remove — already clean.")
 
@@ -1594,10 +1778,21 @@ def _cmd_setup():
         print()
     else:
         try:
-            r = subprocess.run(
-                ["mcporter", "config", "list"], capture_output=True, encoding="utf-8", errors="replace", timeout=10
+            from agent_reach.channels.mcporter import (
+                McporterConfigError,
+                configured_server_names,
             )
-            if "exa" in r.stdout.lower():
+
+            r = subprocess.run(
+                ["mcporter", "config", "list", "--json"],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+            if r.returncode != 0:
+                raise McporterConfigError("mcporter 配置查询失败")
+            if "exa" in configured_server_names(r.stdout):
                 print("  当前状态: ✅ 已配置")
             else:
                 print("  当前状态: -- 未配置")
@@ -1860,7 +2055,7 @@ def _cmd_watch():
     from agent_reach.doctor import check_all
     from agent_reach import __version__
 
-    config = Config()
+    config = Config(read_only=True)
     issues = []
 
     # Check channels

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1161,9 +1161,11 @@ def _cmd_configure(args):
                     print("[!] twitter-cli not installed. Run: pipx install twitter-cli")
                 else:
                     import os
+
+                    from agent_reach.channels.twitter import twitter_cli_child_env
+
                     env = os.environ.copy()
-                    env["TWITTER_AUTH_TOKEN"] = auth_token
-                    env["TWITTER_CT0"] = ct0
+                    env.update(twitter_cli_child_env(config))
                     result = subprocess.run(
                         [twitter_bin, "status"],
                         capture_output=True, encoding="utf-8", errors="replace", timeout=15,
@@ -1559,7 +1561,7 @@ def _cmd_doctor(args=None):
         from rich import print as rprint
     except ImportError:
         rprint = print
-    config = Config()
+    config = Config(read_only=True)
     results = check_all(config)
 
     if args is not None and getattr(args, "json", False):

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -87,7 +87,21 @@ def main():
     p_conf.add_argument("value", nargs="*", help="The value(s) to set")
     p_conf.add_argument("--from-browser", metavar="BROWSER",
                         choices=["chrome", "firefox", "edge", "brave", "opera"],
-                        help="Auto-extract ALL platform cookies from browser (chrome/firefox/edge/brave/opera)")
+                        help="Extract cookies for one explicitly selected platform")
+    p_conf.add_argument(
+        "--platform",
+        choices=["twitter", "xiaohongshu", "bilibili", "xueqiu"],
+        help="Platform to import (required with --from-browser)",
+    )
+    p_conf.add_argument(
+        "--profile",
+        help="Exact browser profile; a missing profile fails instead of falling back",
+    )
+    p_conf.add_argument(
+        "--sync-legacy-twitter",
+        action="store_true",
+        help="With twitter-cookies, also write legacy xfetch/bird credential files",
+    )
 
     # ── doctor ──
     p_doctor = sub.add_parser("doctor", help="Check platform availability")
@@ -131,6 +145,26 @@ def main():
     sub.add_parser("version", help="Show version")
 
     args = parser.parse_args()
+
+    if args.command == "configure" and args.from_browser:
+        if not args.platform:
+            p_conf.error("--platform is required with --from-browser")
+        manual_keys = {
+            "twitter": "twitter-cookies",
+            "xiaohongshu": "xhs-cookies",
+        }
+        if args.platform in manual_keys:
+            p_conf.error(
+                f"{args.platform} requires Cookie-Editor export; use "
+                f"`agent-reach configure {manual_keys[args.platform]} ...`"
+            )
+        if args.sync_legacy_twitter:
+            p_conf.error("--sync-legacy-twitter is only valid with twitter-cookies")
+    elif args.command == "configure":
+        if args.profile or args.platform:
+            p_conf.error("--platform/--profile require --from-browser")
+        if args.sync_legacy_twitter and args.key != "twitter-cookies":
+            p_conf.error("--sync-legacy-twitter is only valid with twitter-cookies")
 
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
@@ -207,7 +241,7 @@ def _cmd_install(args):
         # linkedin: manual setup, no auto-install
     }
     OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
-    COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili"}
+    COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "xiaohongshu"}
 
     requested_channels = set()
     if args.channels:
@@ -280,34 +314,31 @@ def _cmd_install(args):
         print()
         print(f"[dry-run] Would install optional channels: {', '.join(sorted(requested_channels))}")
 
-    # ── Auto-import cookies (only if cookie-needing channels are requested) ──
+    # ── Cookie setup (explicit only — install never reads browser credentials) ──
     needs_cookies = bool(requested_channels & COOKIE_CHANNELS)
-    if env == "local" and needs_cookies and not safe_mode and not dry_run:
+    if env == "local" and needs_cookies and not dry_run:
         print()
-        print("Importing cookies from browser...")
-        print("  (macOS may ask for your login password to access the Keychain — this is normal,")
-        print("   it only happens once during install. Enter your password or click 'Allow'.)")
-        try:
-            from agent_reach.cookie_extract import configure_from_browser
-            results = configure_from_browser("chrome", config)
-            found = False
-            for platform, success, message in results:
-                if success:
-                    print(f"  ✅ {platform}: {message}")
-                    found = True
-            if not found:
-                results = configure_from_browser("firefox", config)
-                for platform, success, message in results:
-                    if success:
-                        print(f"  ✅ {platform}: {message}")
-                        found = True
-            if not found:
-                print("  -- No cookies found (normal if you haven't logged into these sites)")
-        except Exception:
-            print("  -- Could not read browser cookies (browser might be open or password was denied)")
+        print("Cookie login is never read automatically.")
+        print("Run only the platform command you intend to authorize:")
+        for channel in sorted(requested_channels & COOKIE_CHANNELS):
+            if channel == "twitter":
+                print(
+                    "  agent-reach configure twitter-cookies "
+                    "'<Cookie-Editor Header String>'"
+                )
+            elif channel == "xiaohongshu":
+                print(
+                    "  agent-reach configure xhs-cookies "
+                    "'<Cookie-Editor JSON or Header String>'"
+                )
+            else:
+                print(
+                    "  agent-reach configure --from-browser chrome "
+                    f"--platform {channel}"
+                )
     elif env == "local" and needs_cookies and dry_run:
         print()
-        print("[dry-run] Would try to import cookies from Chrome/Firefox")
+        print("[dry-run] Cookie import remains explicit; install will not read a browser")
 
     # Environment-specific advice
     if env == "server":
@@ -634,18 +665,19 @@ def _install_system_deps():
 
     # ── yt-dlp JS runtime config (YouTube requires external JS runtime) ──
     if shutil.which("node"):
-        ytdlp_config_dir = os.path.expanduser("~/.config/yt-dlp")
-        ytdlp_config = os.path.join(ytdlp_config_dir, "config")
+        from agent_reach.utils.paths import get_ytdlp_config_path
+
+        ytdlp_config = get_ytdlp_config_path()
         needs_config = True
-        if os.path.exists(ytdlp_config):
-            with open(ytdlp_config, "r") as f:
+        if ytdlp_config.exists():
+            with ytdlp_config.open("r", encoding="utf-8") as f:
                 if "--js-runtimes" in f.read():
                     needs_config = False
                     print("  ✅ yt-dlp JS runtime already configured")
         if needs_config:
             try:
-                os.makedirs(ytdlp_config_dir, exist_ok=True)
-                with open(ytdlp_config, "a") as f:
+                ytdlp_config.parent.mkdir(parents=True, exist_ok=True)
+                with ytdlp_config.open("a", encoding="utf-8") as f:
                     f.write("--js-runtimes node\n")
                 print("  ✅ yt-dlp configured to use Node.js as JS runtime (YouTube)")
             except Exception:
@@ -739,7 +771,7 @@ def _install_xhs_deps():
         print("    1. 下载 binary：https://github.com/xpzouying/xiaohongshu-mcp/releases")
         print("       （建议放到 ~/.agent-reach/tools/ 下）")
         print("    2. 启动服务（首次运行会下载约 150MB 浏览器，请等待完成）")
-        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp")
+        print("    3. 扫码登录后接入：mcporter config add xiaohongshu http://localhost:18060/mcp --scope home")
         print("    4. 验证：agent-reach doctor")
         return
 
@@ -947,14 +979,22 @@ def _install_mcporter():
         )
         if "exa" not in r.stdout:
             subprocess.run(
-                ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                [
+                    "mcporter",
+                    "config",
+                    "add",
+                    "exa",
+                    "https://mcp.exa.ai/mcp",
+                    "--scope",
+                    "home",
+                ],
                 capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             print("  ✅ Exa search configured (free, no API key needed)")
         else:
             print("  ✅ Exa search already configured")
     except Exception:
-        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  [!]  Could not configure Exa. Run manually: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
     # NOTE: xhs-cli is now optional, installed via --channels=xiaohongshu
 
@@ -967,11 +1007,11 @@ def _install_mcporter_safe():
 
     if shutil.which("mcporter"):
         print("  ✅ mcporter already installed")
-        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  To configure Exa search: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
     else:
         print("  -- mcporter not installed")
         print("  To install: npm install -g mcporter")
-        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  Then configure Exa: mcporter config add exa https://mcp.exa.ai/mcp --scope home")
 
 
 def _detect_environment():
@@ -1028,18 +1068,34 @@ def _cmd_configure(args):
         from agent_reach.cookie_extract import configure_from_browser
 
         browser = args.from_browser
-        print(f"Extracting cookies from {browser}...")
+        platform = "xhs" if args.platform == "xiaohongshu" else args.platform
+        print(f"Extracting {args.platform} cookies from {browser}...")
         print()
 
-        results = configure_from_browser(browser, config)
+        results = configure_from_browser(
+            browser,
+            config,
+            platform=platform,
+            profile=args.profile,
+        )
 
         found_any = False
-        for platform, success, message in results:
+        for result in results:
+            if hasattr(result, "platform"):
+                result_platform = result.platform
+                success = result.success
+                message = result.message
+                targets = getattr(result, "targets", ())
+            else:
+                result_platform, success, message = result
+                targets = ()
             if success:
-                print(f"  ✅ {platform}: {message}")
+                print(f"  ✅ {result_platform}: {message}")
+                if targets:
+                    print(f"     写入：{', '.join(targets)}")
                 found_any = True
             else:
-                print(f"  -- {platform}: {message}")
+                print(f"  -- {result_platform}: {message}")
 
         print()
         if found_any:
@@ -1051,7 +1107,10 @@ def _cmd_configure(args):
     # ── Manual configure ──
     if not args.key:
         print("Usage: agent-reach configure <key> <value>")
-        print("   or: agent-reach configure --from-browser chrome")
+        print(
+            "   or: agent-reach configure --from-browser chrome "
+            "--platform twitter"
+        )
         return
 
     value = " ".join(args.value) if args.value else ""
@@ -1079,8 +1138,20 @@ def _cmd_configure(args):
             config.set("twitter_auth_token", auth_token)
             config.set("twitter_ct0", ct0)
 
-            # Sync credentials to twitter-cli env
             print("✅ Twitter cookies configured!")
+            if getattr(args, "sync_legacy_twitter", False):
+                from agent_reach.cookie_extract import (
+                    _sync_bird_env,
+                    _sync_xfetch_session,
+                )
+
+                _sync_xfetch_session(auth_token, ct0)
+                _sync_bird_env(auth_token, ct0)
+                print(
+                    "  Legacy copies written to "
+                    "~/.config/xfetch/session.json and "
+                    "~/.config/bird/credentials.env"
+                )
 
             print("Testing Twitter access...", end=" ")
             try:
@@ -1184,6 +1255,7 @@ def _configure_xhs_cookies(value):
     Format: JSON array of {name, value, domain, path, expires, httpOnly, secure, sameSite}.
     """
     import json
+    import os
     import shutil
     import subprocess
 
@@ -1259,7 +1331,6 @@ def _configure_xhs_cookies(value):
         # Create with 0o600 atomically so the file is never world-readable
         # between open() and a follow-up chmod() (same pattern Config.save()
         # uses in config.py).
-        import os
         import stat
 
         from agent_reach.utils.paths import make_private_dir
@@ -1318,6 +1389,7 @@ def _configure_xhs_cookies(value):
         cookie_path_in_container = "/app/cookies.json"
 
     # Write cookies into the container
+    tmp_path = None
     try:
         # Write to temp file then docker cp
         import tempfile
@@ -1329,7 +1401,6 @@ def _configure_xhs_cookies(value):
             [docker, "cp", tmp_path, f"{container_name}:{cookie_path_in_container}"],
             capture_output=True, encoding="utf-8", timeout=10,
         )
-        os.unlink(tmp_path)
 
         if result.returncode != 0:
             print(f"[X] Failed to copy cookies: {result.stderr}")
@@ -1350,6 +1421,14 @@ def _configure_xhs_cookies(value):
     except Exception as e:
         print(f"[X] Failed to write cookies: {e}")
         return
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                print(f"  [!] Could not remove temporary cookie file: {e}")
 
     # Verify login status via mcporter
     mcporter = shutil.which("mcporter")
@@ -1489,9 +1568,6 @@ def _cmd_doctor(args=None):
 
     rprint(format_report(results))
 
-    # Auto-install skill if not already present (fixes #154)
-    _install_skill(force=False)
-
 
 def _cmd_setup():
     from agent_reach.config import Config
@@ -1512,7 +1588,7 @@ def _cmd_setup():
     if not shutil.which("mcporter"):
         print("  当前状态: -- mcporter 未安装")
         print("  安装：npm install -g mcporter")
-        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp")
+        print("  然后：mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
     else:
         try:
@@ -1526,17 +1602,25 @@ def _cmd_setup():
                 setup_now = input("  现在自动配置 Exa 吗？[Y/n]: ").strip().lower()
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
-                        ["mcporter", "config", "add", "exa", "https://mcp.exa.ai/mcp"],
+                        [
+                            "mcporter",
+                            "config",
+                            "add",
+                            "exa",
+                            "https://mcp.exa.ai/mcp",
+                            "--scope",
+                            "home",
+                        ],
                         capture_output=True, encoding="utf-8", errors="replace", timeout=10,
                     )
                     if add_r.returncode == 0:
                         print("  ✅ Exa 已配置")
                     else:
                         print("  [!] 自动配置失败，请手动执行：")
-                        print("     mcporter config add exa https://mcp.exa.ai/mcp")
+                        print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         except Exception:
             print("  [!] 无法检查 Exa 配置，请手动执行：")
-            print("     mcporter config add exa https://mcp.exa.ai/mcp")
+            print("     mcporter config add exa https://mcp.exa.ai/mcp --scope home")
         print()
 
     # Step 2: GitHub token

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -1,17 +1,89 @@
 # -*- coding: utf-8 -*-
 """Configuration management for Agent Reach.
 
-Stores settings in ~/.agent-reach/config.yaml.
-Auto-creates directory on first use.
+Stores settings in ~/.agent-reach/config.yaml. Reads never create files or
+directories; the private directory is created only on the first write.
 """
 
 import os
+import stat
+import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
 
 from agent_reach.utils.paths import make_private_dir
+
+
+class ConfigError(RuntimeError):
+    """Base class for configuration errors safe to show to the user."""
+
+
+class ConfigReadOnlyError(ConfigError):
+    """Raised when code tries to mutate an explicitly read-only config."""
+
+
+class ConfigSecurityError(ConfigError):
+    """Raised when a config path could redirect credential reads or writes."""
+
+
+def _reject_symlink(path: Path, label: str) -> None:
+    if path.is_symlink():
+        raise ConfigSecurityError(f"{label}不能是符号链接：{path}")
+
+
+def _atomic_write_yaml(target: Path, data: dict) -> None:
+    """Atomically replace ``target`` with owner-only YAML.
+
+    The temporary file lives beside the target so ``os.replace`` remains an
+    atomic same-filesystem operation. Existing symlinks are rejected rather
+    than followed or silently replaced.
+    """
+    _reject_symlink(target, "配置文件")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent),
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if os.name != "nt" and hasattr(os, "fchmod"):
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(
+                data,
+                handle,
+                default_flow_style=False,
+                allow_unicode=True,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        # Fail closed if a link appeared while serialization was in progress.
+        # A later race is still safe: os.replace replaces a directory entry and
+        # never follows the symlink into its target.
+        _reject_symlink(target, "配置文件")
+        os.replace(tmp_path, target)
+        if os.name != "nt":
+            os.chmod(target, stat.S_IRUSR | stat.S_IWUSR)
+
+        # Persist the rename where directory fsync is supported.
+        if os.name != "nt" and hasattr(os, "O_DIRECTORY"):
+            try:
+                dir_fd = os.open(target.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                pass
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 class Config:
@@ -29,48 +101,49 @@ class Config:
         "github_token": ["github_token"],
     }
 
-    def __init__(self, config_path: Optional[Path] = None):
+    def __init__(
+        self,
+        config_path: Optional[Path] = None,
+        *,
+        read_only: bool = False,
+    ):
         self.config_path = Path(config_path) if config_path else self.CONFIG_FILE
         self.config_dir = self.config_path.parent
+        self.read_only = read_only
         self.data: dict = {}
-        self._ensure_dir()
         self.load()
 
     def _ensure_dir(self):
         """Create config directory if it doesn't exist."""
+        _reject_symlink(self.config_dir, "配置目录")
         make_private_dir(self.config_dir)
+        _reject_symlink(self.config_dir, "配置目录")
 
     def load(self):
         """Load config from YAML file."""
+        _reject_symlink(self.config_dir, "配置目录")
+        _reject_symlink(self.config_path, "配置文件")
         if self.config_path.exists():
-            with open(self.config_path, "r", encoding="utf-8") as f:
-                self.data = yaml.safe_load(f) or {}
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                fd = os.open(self.config_path, flags)
+            except OSError as exc:
+                if self.config_path.is_symlink():
+                    raise ConfigSecurityError(
+                        f"配置文件不能是符号链接：{self.config_path}"
+                    ) from exc
+                raise
+            with os.fdopen(fd, "r", encoding="utf-8") as handle:
+                self.data = yaml.safe_load(handle) or {}
         else:
             self.data = {}
 
     def save(self):
-        """Save config to YAML file."""
+        """Save config atomically, refusing mutation in read-only mode."""
+        if self.read_only:
+            raise ConfigReadOnlyError("当前配置是只读的，不能保存")
         self._ensure_dir()
-        # Create file with restricted permissions from the start to avoid
-        # a race window where credentials are briefly world-readable.
-        try:
-            import stat
-            fd = os.open(
-                str(self.config_path),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                stat.S_IRUSR | stat.S_IWUSR,  # 0o600
-            )
-            if os.name != "nt":
-                os.chmod(self.config_path, stat.S_IRUSR | stat.S_IWUSR)
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                yaml.dump(self.data, f, default_flow_style=False, allow_unicode=True)
-        except OSError:
-            # Fallback for Windows or other edge cases where os.open flags
-            # are not fully supported.
-            with open(self.config_path, "w", encoding="utf-8") as f:
-                yaml.dump(self.data, f, default_flow_style=False, allow_unicode=True)
-            if os.name != "nt":
-                os.chmod(self.config_path, 0o600)
+        _atomic_write_yaml(self.config_path, self.data)
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a config value. Also checks environment variables (uppercase)."""
@@ -85,13 +158,32 @@ class Config:
 
     def set(self, key: str, value: Any):
         """Set a config value and save."""
+        if self.read_only:
+            raise ConfigReadOnlyError("当前配置是只读的，不能修改")
+        missing = object()
+        previous = self.data.get(key, missing)
         self.data[key] = value
-        self.save()
+        try:
+            self.save()
+        except BaseException:
+            if previous is missing:
+                self.data.pop(key, None)
+            else:
+                self.data[key] = previous
+            raise
 
     def delete(self, key: str):
         """Delete a config key and save."""
-        self.data.pop(key, None)
-        self.save()
+        if self.read_only:
+            raise ConfigReadOnlyError("当前配置是只读的，不能修改")
+        missing = object()
+        previous = self.data.pop(key, missing)
+        try:
+            self.save()
+        except BaseException:
+            if previous is not missing:
+                self.data[key] = previous
+            raise
 
     def is_configured(self, feature: str) -> bool:
         """Check if a feature has all required config."""

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -13,7 +13,14 @@ from typing import Any, Optional
 
 import yaml
 
-from agent_reach.utils.paths import make_private_dir
+from agent_reach.utils.paths import (
+    PrivatePathError,
+    ensure_no_symlink_path,
+    make_private_dir,
+    read_small_text_no_follow,
+)
+
+_MAX_CONFIG_BYTES = 1024 * 1024
 
 
 class ConfigError(RuntimeError):
@@ -29,8 +36,10 @@ class ConfigSecurityError(ConfigError):
 
 
 def _reject_symlink(path: Path, label: str) -> None:
-    if path.is_symlink():
-        raise ConfigSecurityError(f"{label}不能是符号链接：{path}")
+    try:
+        ensure_no_symlink_path(path, label)
+    except PrivatePathError as exc:
+        raise ConfigSecurityError(str(exc)) from exc
 
 
 def _atomic_write_yaml(target: Path, data: dict) -> None:
@@ -123,20 +132,21 @@ class Config:
         """Load config from YAML file."""
         _reject_symlink(self.config_dir, "配置目录")
         _reject_symlink(self.config_path, "配置文件")
-        if self.config_path.exists():
-            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-            try:
-                fd = os.open(self.config_path, flags)
-            except OSError as exc:
-                if self.config_path.is_symlink():
-                    raise ConfigSecurityError(
-                        f"配置文件不能是符号链接：{self.config_path}"
-                    ) from exc
-                raise
-            with os.fdopen(fd, "r", encoding="utf-8") as handle:
-                self.data = yaml.safe_load(handle) or {}
-        else:
+        try:
+            payload = read_small_text_no_follow(
+                self.config_path,
+                max_bytes=_MAX_CONFIG_BYTES,
+            )
+        except PrivatePathError as exc:
+            raise ConfigSecurityError(str(exc)) from exc
+        if payload is None:
             self.data = {}
+            return
+
+        loaded = yaml.safe_load(payload) or {}
+        if not isinstance(loaded, dict):
+            raise ConfigError("配置文件顶层必须是对象")
+        self.data = loaded
 
     def save(self):
         """Save config atomically, refusing mutation in read-only mode."""

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -1,76 +1,262 @@
 # -*- coding: utf-8 -*-
-"""Auto-extract cookies from local browsers for all supported platforms.
+"""Least-privilege cookie extraction from local browsers.
 
 Supports: Chrome, Firefox, Edge, Brave, Opera
-Extracts: Twitter, XiaoHongShu, Bilibili cookies in one shot.
+Extracts one explicitly requested platform at a time.
 
 Usage:
-    agent-reach configure --from-browser chrome
+    agent-reach configure --from-browser chrome --platform xueqiu
 """
 
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple, TypedDict
 
-# Platform cookie specs: (platform_name, domain_pattern, needed_cookies)
-PLATFORM_SPECS = [
+from agent_reach.utils.text import scrub_url_credentials
+from agent_reach.utils.url import domain_matches
+
+
+class PlatformSpec(TypedDict):
+    name: str
+    domains: Tuple[str, ...]
+    cookies: Optional[Tuple[str, ...]]
+    config_key: str
+
+
+class ChromiumPaths(TypedDict):
+    darwin: str
+    linux: str
+    win32: Tuple[str, ...]
+
+
+PLATFORM_SPECS: Tuple[PlatformSpec, ...] = (
     {
         "name": "Twitter/X",
-        "domains": [".x.com", ".twitter.com"],
-        "cookies": ["auth_token", "ct0"],
+        "domains": (".x.com", ".twitter.com"),
+        "cookies": ("auth_token", "ct0"),
         "config_key": "twitter",
     },
     {
         "name": "XiaoHongShu",
-        "domains": [".xiaohongshu.com"],
-        "cookies": None,  # None = grab all cookies as header string
+        "domains": (".xiaohongshu.com",),
+        "cookies": None,  # manual Cookie-Editor export only
         "config_key": "xhs",
     },
     {
         "name": "Bilibili",
-        "domains": [".bilibili.com"],
-        "cookies": ["SESSDATA", "bili_jct"],
+        "domains": (".bilibili.com",),
+        "cookies": ("SESSDATA", "bili_jct"),
         "config_key": "bilibili",
     },
     {
         "name": "Xueqiu",
-        "domains": [".xueqiu.com", "xueqiu.com"],
-        "cookies": None,  # grab all — xq_a_token + session cookies required
+        "domains": (".xueqiu.com",),
+        "cookies": ("xq_a_token",),
         "config_key": "xueqiu",
     },
-]
+)
+
+_PLATFORM_SPECS_BY_KEY: Dict[str, PlatformSpec] = {
+    spec["config_key"]: spec for spec in PLATFORM_SPECS
+}
+SUPPORTED_BROWSERS = ("chrome", "firefox", "edge", "brave", "opera")
+PROFILE_SELECTABLE_BROWSERS = ("chrome", "edge", "brave")
+_COOKIE_EDITOR_ONLY = {
+    "twitter": "twitter-cookies",
+    "xhs": "xhs-cookies",
+}
+
+_CHROMIUM_USER_DATA_DIRS: Dict[str, ChromiumPaths] = {
+    "chrome": {
+        "darwin": "~/Library/Application Support/Google/Chrome",
+        "linux": "~/.config/google-chrome",
+        "win32": ("Google", "Chrome", "User Data"),
+    },
+    "edge": {
+        "darwin": "~/Library/Application Support/Microsoft Edge",
+        "linux": "~/.config/microsoft-edge",
+        "win32": ("Microsoft", "Edge", "User Data"),
+    },
+    "brave": {
+        "darwin": "~/Library/Application Support/BraveSoftware/Brave-Browser",
+        "linux": "~/.config/BraveSoftware/Brave-Browser",
+        "win32": ("BraveSoftware", "Brave-Browser", "User Data"),
+    },
+}
 
 
-def extract_all(browser: str = "chrome") -> Dict[str, dict]:
+@dataclass(frozen=True)
+class BrowserConfigResult:
+    """One browser configuration outcome with non-secret write targets."""
+
+    platform: str
+    success: bool
+    message: str
+    targets: Tuple[str, ...] = ()
+
+    def __iter__(self) -> Iterator[object]:
+        """Preserve the historical three-value unpacking API."""
+        yield self.platform
+        yield self.success
+        yield self.message
+
+
+def _chromium_user_data_dir(browser: str) -> Optional[Path]:
+    """Return the browser's profile root on the current operating system."""
+    import os
+    import sys
+
+    paths = _CHROMIUM_USER_DATA_DIRS.get(browser)
+    if paths is None:
+        return None
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        if not local_appdata:
+            return None
+        return Path(local_appdata).joinpath(*paths["win32"])
+    path = paths["darwin"] if sys.platform == "darwin" else paths["linux"]
+    return Path(os.path.expanduser(path))
+
+
+def list_browser_profiles(browser: str = "chrome") -> List[Dict[str, str]]:
+    """List named Chromium profiles that contain a cookie database."""
+    browser = browser.lower()
+    root = _chromium_user_data_dir(browser)
+    if root is None:
+        return []
+    root = Path(root)
+    if not root.is_dir():
+        return []
+
+    profiles = []
+    for profile_dir in root.iterdir():
+        if not profile_dir.is_dir():
+            continue
+        cookie_file = profile_dir / "Network" / "Cookies"
+        if not cookie_file.is_file():
+            cookie_file = profile_dir / "Cookies"
+        if cookie_file.is_file():
+            profiles.append(
+                {
+                    "folder": profile_dir.name,
+                    "cookies_path": str(cookie_file),
+                }
+            )
+
+    def sort_key(item):
+        folder = item["folder"]
+        suffix = folder.rsplit(" ", 1)[-1]
+        number = int(suffix) if suffix.isdigit() else 0
+        return (folder != "Default", number, folder)
+
+    profiles.sort(key=sort_key)
+    return profiles
+
+
+def _profile_cookie_file(browser: str, profile: str) -> str:
+    """Resolve an explicit profile or fail without falling back to Default."""
+    if browser not in PROFILE_SELECTABLE_BROWSERS:
+        raise ValueError(
+            "Profile selection is supported only for "
+            f"{', '.join(PROFILE_SELECTABLE_BROWSERS)}, "
+            f"not {scrub_url_credentials(browser)}."
+        )
+
+    profiles = list_browser_profiles(browser)
+    for candidate in profiles:
+        if candidate["folder"] == profile:
+            return candidate["cookies_path"]
+
+    available = ", ".join(
+        scrub_url_credentials(item["folder"]) for item in profiles
+    )
+    hint = f" Available profiles: {available}." if available else ""
+    raise ValueError(
+        f"Profile '{scrub_url_credentials(profile)}' not found for "
+        f"{scrub_url_credentials(browser)}.{hint}"
+    )
+
+
+def _platform_spec(platform: Optional[str]) -> PlatformSpec:
+    """Return the one explicitly requested platform specification."""
+    if not platform:
+        raise ValueError(
+            "platform is required for browser-cookie extraction; "
+            f"choose one of: {', '.join(_PLATFORM_SPECS_BY_KEY)}"
+        )
+    key = platform.lower()
+    try:
+        return _PLATFORM_SPECS_BY_KEY[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported platform: {scrub_url_credentials(platform)}. "
+            f"Supported: {', '.join(_PLATFORM_SPECS_BY_KEY)}"
+        ) from exc
+
+
+def _require_browser_extractable(spec: PlatformSpec) -> None:
+    """Reject platforms whose project policy requires a manual cookie export."""
+    manual_key = _COOKIE_EDITOR_ONLY.get(spec["config_key"])
+    if manual_key:
+        raise ValueError(
+            f"Automatic browser extraction is disabled for {spec['name']}. "
+            "Export the required cookies with Cookie-Editor, then use "
+            f"`agent-reach configure {manual_key}`."
+        )
+
+
+def extract_all(
+    browser: str = "chrome",
+    *,
+    platform: Optional[str] = None,
+    profile: Optional[str] = None,
+) -> Dict[str, dict]:
     """
-    Extract cookies for all supported platforms from the specified browser.
-    
+    Extract cookies for one explicitly requested platform.
+
+    The legacy function name is retained for API compatibility, but an
+    all-platform read is intentionally no longer supported.
+
     Returns:
-        {
-            "twitter": {"auth_token": "xxx", "ct0": "yyy"},
-            "xhs": {"cookie_string": "a=1; b=2; ..."},
-            "bilibili": {"SESSDATA": "xxx", "bili_jct": "yyy"},
-        }
+        {"xueqiu": {"xq_a_token": "xxx"}}
     """
+    spec = _platform_spec(platform)
+    _require_browser_extractable(spec)
+    browser = browser.lower()
+    if browser not in SUPPORTED_BROWSERS:
+        raise ValueError(
+            f"Unsupported browser: {scrub_url_credentials(browser)}. "
+            f"Supported: {', '.join(SUPPORTED_BROWSERS)}"
+        )
+    cookie_file = _profile_cookie_file(browser, profile) if profile else None
+    needed_cookies = spec["cookies"]
+    if needed_cookies is None:
+        raise ValueError(
+            f"Automatic full-domain extraction is disabled for {spec['name']}."
+        )
+
     # Try rookiepy first (Rust-based, more stable), fallback to browser_cookie3
     use_rookiepy = False
-    try:
-        import rookiepy
-        use_rookiepy = True
-    except ImportError:
+    if cookie_file is None:
+        try:
+            import rookiepy
+            use_rookiepy = True
+        except ImportError:
+            pass
+    if not use_rookiepy:
         try:
             import browser_cookie3
         except ImportError:
-            raise RuntimeError(
-                "Cookie extraction requires rookiepy or browser_cookie3.\n"
-                "Install: pip install rookiepy  (recommended)\n"
-                "     or: pip install browser-cookie3"
+            profile_hint = (
+                f" for profile '{scrub_url_credentials(profile)}'"
+                if profile is not None
+                else ""
             )
-
-    browser = browser.lower()
-    supported = ["chrome", "firefox", "edge", "brave", "opera"]
-    if browser not in supported:
-        raise ValueError(
-            f"Unsupported browser: {browser}. Supported: {', '.join(supported)}"
-        )
+            raise RuntimeError(
+                f"Cookie extraction{profile_hint} requires browser_cookie3"
+                " (or rookiepy when no profile is selected).\n"
+                "Install: pip install browser-cookie3"
+            )
 
     if use_rookiepy:
         # rookiepy returns list of dicts with name/value/domain/path keys
@@ -82,7 +268,7 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
                 "brave": rookiepy.brave,
                 "opera": rookiepy.opera,
             }
-            raw_cookies = browser_funcs[browser]()
+            raw_cookies = browser_funcs[browser](list(spec["domains"]))
             # Wrap into objects with .name, .value, .domain for compatibility
             class _Cookie:
                 def __init__(self, d):
@@ -92,7 +278,8 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
             cookie_jar = [_Cookie(c) for c in raw_cookies]
         except Exception as e:
             raise RuntimeError(
-                f"Could not read {browser} cookies via rookiepy: {e}\n"
+                f"Could not read {browser} cookies via rookiepy: "
+                f"{scrub_url_credentials(e)}\n"
                 f"Make sure {browser} is closed and you have permission."
             )
     else:
@@ -104,44 +291,41 @@ def extract_all(browser: str = "chrome") -> Dict[str, dict]:
             "opera": browser_cookie3.opera,
         }
         try:
-            cookie_jar = browser_funcs[browser]()
+            cookie_jar = []
+            seen = set()
+            for domain in spec["domains"]:
+                kwargs = {"domain_name": domain}
+                if cookie_file is not None:
+                    kwargs["cookie_file"] = cookie_file
+                for cookie in browser_funcs[browser](**kwargs):
+                    identity = (
+                        getattr(cookie, "name", ""),
+                        getattr(cookie, "domain", ""),
+                        getattr(cookie, "path", ""),
+                        getattr(cookie, "value", ""),
+                    )
+                    if identity not in seen:
+                        seen.add(identity)
+                        cookie_jar.append(cookie)
         except Exception as e:
             raise RuntimeError(
-                f"Could not read {browser} cookies: {e}\n"
+                f"Could not read {browser} cookies: {scrub_url_credentials(e)}\n"
                 f"Make sure {browser} is closed and you have permission."
             )
 
     results = {}
 
-    for spec in PLATFORM_SPECS:
-        platform_cookies = {}
-        all_cookies_for_domain = []
+    platform_cookies = {}
+    for cookie in cookie_jar:
+        # Re-check returned cookies instead of trusting the backend filter.
+        if not domain_matches(cookie.domain, *spec["domains"]):
+            continue
 
-        for cookie in cookie_jar:
-            # Check if cookie belongs to this platform
-            domain_match = any(
-                cookie.domain.endswith(d) or cookie.domain == d.lstrip(".")
-                for d in spec["domains"]
-            )
-            if not domain_match:
-                continue
+        if cookie.name in needed_cookies:
+            platform_cookies[cookie.name] = cookie.value
 
-            all_cookies_for_domain.append(cookie)
-
-            if spec["cookies"] is not None:
-                if cookie.name in spec["cookies"]:
-                    platform_cookies[cookie.name] = cookie.value
-
-        if spec["cookies"] is None:
-            # Grab all as header string
-            if all_cookies_for_domain:
-                cookie_str = "; ".join(
-                    f"{c.name}={c.value}" for c in all_cookies_for_domain
-                )
-                results[spec["config_key"]] = {"cookie_string": cookie_str}
-        else:
-            if platform_cookies:
-                results[spec["config_key"]] = platform_cookies
+    if platform_cookies:
+        results[spec["config_key"]] = platform_cookies
 
     return results
 
@@ -173,7 +357,7 @@ def _open_owner_only(path: str):
         return handle
 
 
-def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
+def _sync_xfetch_session(auth_token: str, ct0: str) -> bool:
     """Sync Twitter credentials to ~/.config/xfetch/session.json (legacy xreach compat)."""
     import json
     import os
@@ -195,12 +379,13 @@ def _sync_xfetch_session(auth_token: str, ct0: str) -> None:
         session_data["ct0"] = ct0
         with _open_owner_only(session_path) as sf:
             json.dump(session_data, sf, indent=2)
+        return True
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, xfetch sync is best-effort
-        pass
+        return False
 
 
-def _sync_bird_env(auth_token: str, ct0: str) -> None:
+def _sync_bird_env(auth_token: str, ct0: str) -> bool:
     """Write Twitter credentials to ~/.config/bird/credentials.env for bird CLI.
 
     bird reads AUTH_TOKEN and CT0 from environment variables. This writes a
@@ -220,78 +405,106 @@ def _sync_bird_env(auth_token: str, ct0: str) -> None:
         with _open_owner_only(env_path) as f:
             f.write(f"AUTH_TOKEN={shlex.quote(auth_token)}\n")
             f.write(f"CT0={shlex.quote(ct0)}\n")
+        return True
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, bird env sync is best-effort
-        pass
+        return False
 
 
 # Alias for callers expecting the name _sync_bird_credentials
 _sync_bird_credentials = _sync_bird_env
 
 
-def configure_from_browser(browser: str, config) -> List[Tuple[str, bool, str]]:
+def configure_from_browser(
+    browser: str,
+    config,
+    *,
+    platform: Optional[str] = None,
+    profile: Optional[str] = None,
+) -> List[BrowserConfigResult]:
     """
-    Extract cookies and configure all found platforms.
-    
-    Returns list of (platform_name, success, message) tuples.
+    Extract and configure exactly one explicitly selected platform.
+
+    Result objects still unpack as ``(platform, success, message)`` and expose
+    a ``targets`` attribute so the CLI can disclose every non-secret config key
+    or legacy path written.
     """
-    results_list = []
+    spec = _platform_spec(platform)
+    _require_browser_extractable(spec)
+    results_list: List[BrowserConfigResult] = []
 
     try:
-        extracted = extract_all(browser)
+        extracted = extract_all(
+            browser,
+            platform=spec["config_key"],
+            profile=profile,
+        )
+    except ValueError:
+        raise
     except Exception as e:
-        return [("Browser", False, str(e))]
+        return [
+            BrowserConfigResult(
+                "Browser", False, scrub_url_credentials(e)
+            )
+        ]
 
-    if not extracted:
-        return [("All platforms", False,
-                 f"No platform cookies found in {browser}. "
-                 f"Make sure you're logged into Twitter, XiaoHongShu, etc. in {browser}.")]
+    config_key = spec["config_key"]
+    if config_key not in extracted:
+        return [
+            BrowserConfigResult(
+                spec["name"],
+                False,
+                f"No {spec['name']} cookies found in {browser}. "
+                f"Make sure you're logged into the selected platform.",
+            )
+        ]
 
-    # Configure each found platform
-    if "twitter" in extracted:
-        tc = extracted["twitter"]
-        if "auth_token" in tc and "ct0" in tc:
-            config.set("twitter_auth_token", tc["auth_token"])
-            config.set("twitter_ct0", tc["ct0"])
-            # Legacy sync (best-effort)
-            _sync_xfetch_session(tc["auth_token"], tc["ct0"])
-            results_list.append(("Twitter/X", True, "auth_token + ct0"))
-        else:
-            found = ", ".join(tc.keys())
-            missing = [k for k in ["auth_token", "ct0"] if k not in tc]
-            results_list.append(("Twitter/X", False,
-                                 f"Found {found}, but missing: {', '.join(missing)}. "
-                                 f"Make sure you're logged into x.com in {browser}."))
-
-    if "xhs" in extracted:
-        cookie_str = extracted["xhs"].get("cookie_string", "")
-        if cookie_str:
-            config.set("xhs_cookie", cookie_str)
-            n_cookies = len(cookie_str.split(";"))
-            results_list.append(("XiaoHongShu", True, f"{n_cookies} cookies"))
-
-    if "bilibili" in extracted:
+    if config_key == "bilibili":
         bc = extracted["bilibili"]
         if "SESSDATA" in bc:
             config.set("bilibili_sessdata", bc["SESSDATA"])
+            targets = ["bilibili_sessdata"]
             if "bili_jct" in bc:
                 config.set("bilibili_csrf", bc["bili_jct"])
-            results_list.append(("Bilibili", True, "SESSDATA" +
-                                 (" + bili_jct" if "bili_jct" in bc else "")))
+                targets.append("bilibili_csrf")
+            results_list.append(
+                BrowserConfigResult(
+                    "Bilibili",
+                    True,
+                    "SESSDATA" + (" + bili_jct" if "bili_jct" in bc else ""),
+                    tuple(targets),
+                )
+            )
         else:
-            results_list.append(("Bilibili", False,
-                                 f"No SESSDATA found. Make sure you're logged into bilibili.com in {browser}."))
+            results_list.append(
+                BrowserConfigResult(
+                    "Bilibili",
+                    False,
+                    f"No SESSDATA found. "
+                    f"Make sure you're logged into bilibili.com in {browser}.",
+                )
+            )
 
-    if "xueqiu" in extracted:
-        cookie_str = extracted["xueqiu"].get("cookie_string", "")
-        # Only save if xq_a_token is present — anonymous cookies are useless
-        if cookie_str and "xq_a_token" in cookie_str:
+    elif config_key == "xueqiu":
+        token = extracted["xueqiu"].get("xq_a_token", "")
+        if token:
+            cookie_str = f"xq_a_token={token}"
             config.set("xueqiu_cookie", cookie_str)
-            n_cookies = len(cookie_str.split(";"))
-            results_list.append(("Xueqiu", True, f"{n_cookies} cookies (含 xq_a_token)"))
-        elif cookie_str:
-            results_list.append(("Xueqiu", False,
-                                 f"找到 {len(cookie_str.split(';'))} 个 Cookie 但缺少 xq_a_token，"
-                                 f"请先在 {browser} 中登录 xueqiu.com"))
+            results_list.append(
+                BrowserConfigResult(
+                    "Xueqiu",
+                    True,
+                    "xq_a_token",
+                    ("xueqiu_cookie",),
+                )
+            )
+        else:
+            results_list.append(
+                BrowserConfigResult(
+                    "Xueqiu",
+                    False,
+                    f"未找到 xq_a_token，请先在 {browser} 中登录 xueqiu.com",
+                )
+            )
 
     return results_list

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -61,6 +61,7 @@ _PLATFORM_SPECS_BY_KEY: Dict[str, PlatformSpec] = {
 }
 SUPPORTED_BROWSERS = ("chrome", "firefox", "edge", "brave", "opera")
 PROFILE_SELECTABLE_BROWSERS = ("chrome", "edge", "brave")
+_MAX_XFETCH_SESSION_BYTES = 64 * 1024
 _COOKIE_EDITOR_ONLY = {
     "twitter": "twitter-cookies",
     "xhs": "xhs-cookies",
@@ -330,31 +331,22 @@ def extract_all(
     return results
 
 
-def _open_owner_only(path: str):
-    """Open *path* for writing, atomically creating it with mode 0o600.
+def _read_xfetch_session(path: Path) -> dict:
+    """Read a small regular legacy session file without following symlinks."""
+    import json
 
-    Mirrors the pattern used by Config.save() in config.py: O_WRONLY|O_CREAT|
-    O_TRUNC + an explicit mode argument so the file is never briefly
-    world-readable between open() and a later os.chmod(). On Windows (or any
-    OS that rejects the open flags) we fall back to a plain open().
-    """
-    import os
-    import stat
+    from agent_reach.utils.paths import read_small_text_no_follow
 
-    try:
-        fd = os.open(
-            path,
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            stat.S_IRUSR | stat.S_IWUSR,  # 0o600
-        )
-        if os.name != "nt":
-            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-        return os.fdopen(fd, "w", encoding="utf-8")
-    except OSError:
-        handle = open(path, "w", encoding="utf-8")
-        if os.name != "nt":
-            os.chmod(path, 0o600)
-        return handle
+    payload = read_small_text_no_follow(
+        path,
+        max_bytes=_MAX_XFETCH_SESSION_BYTES,
+    )
+    if payload is None:
+        return {}
+    loaded = json.loads(payload)
+    if not isinstance(loaded, dict):
+        raise ValueError("xfetch 会话文件必须是 JSON object")
+    return loaded
 
 
 def _sync_xfetch_session(auth_token: str, ct0: str) -> bool:
@@ -363,22 +355,21 @@ def _sync_xfetch_session(auth_token: str, ct0: str) -> bool:
     import os
 
     try:
-        from agent_reach.utils.paths import make_private_dir
+        from agent_reach.utils.paths import (
+            atomic_write_private_text,
+            make_private_dir,
+        )
 
         xfetch_dir = os.path.join(os.path.expanduser("~"), ".config", "xfetch")
         make_private_dir(xfetch_dir)
-        session_path = os.path.join(xfetch_dir, "session.json")
-        session_data: dict = {}
-        if os.path.exists(session_path):
-            try:
-                with open(session_path, "r", encoding="utf-8") as sf:
-                    session_data = json.load(sf)
-            except (json.JSONDecodeError, OSError):
-                session_data = {}
+        session_path = Path(xfetch_dir) / "session.json"
+        session_data = _read_xfetch_session(session_path)
         session_data["authToken"] = auth_token
         session_data["ct0"] = ct0
-        with _open_owner_only(session_path) as sf:
-            json.dump(session_data, sf, indent=2)
+        atomic_write_private_text(
+            session_path,
+            json.dumps(session_data, indent=2),
+        )
         return True
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, xfetch sync is best-effort
@@ -397,14 +388,19 @@ def _sync_bird_env(auth_token: str, ct0: str) -> bool:
     import shlex
 
     try:
-        from agent_reach.utils.paths import make_private_dir
+        from agent_reach.utils.paths import (
+            atomic_write_private_text,
+            make_private_dir,
+        )
 
         bird_dir = os.path.join(os.path.expanduser("~"), ".config", "bird")
         make_private_dir(bird_dir)
         env_path = os.path.join(bird_dir, "credentials.env")
-        with _open_owner_only(env_path) as f:
-            f.write(f"AUTH_TOKEN={shlex.quote(auth_token)}\n")
-            f.write(f"CT0={shlex.quote(ct0)}\n")
+        atomic_write_private_text(
+            env_path,
+            f"AUTH_TOKEN={shlex.quote(auth_token)}\n"
+            f"CT0={shlex.quote(ct0)}\n",
+        )
         return True
     except Exception:
         # Non-fatal: agent-reach config is the source of truth, bird env sync is best-effort

--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -5,8 +5,12 @@ Each channel knows how to check itself. Doctor just collects the results.
 """
 
 from typing import Dict
-from agent_reach.config import Config
+
+from rich.markup import escape
+
 from agent_reach.channels import get_all_channels
+from agent_reach.config import Config
+from agent_reach.utils.text import scrub_url_credentials
 
 
 def check_all(config: Config) -> Dict[str, dict]:
@@ -23,7 +27,13 @@ def check_all(config: Config) -> Dict[str, dict]:
         except Exception as e:  # noqa: BLE001 — doctor must survive any channel
             # Channels are registry singletons: a stale active_backend from a
             # previous check must not leak into an errored result.
-            status, message, active = "error", f"体检异常：{e}", None
+            status = "error"
+            message = f"体检异常：{e}"
+            active = None
+        # Doctor is the final output boundary for both expected channel
+        # messages and unexpected exceptions. Upstream probe output can echo a
+        # configured URL, so scrub every path before JSON/text rendering.
+        message = scrub_url_credentials(message)
         results[ch.name] = {
             "status": status,
             "name": ch.description,
@@ -46,11 +56,6 @@ def _name_msg(r: dict, escape) -> str:
 
 def format_report(results: Dict[str, dict]) -> str:
     """Format results as a readable text report (with Rich markup)."""
-    try:
-        from rich.markup import escape
-    except ImportError:
-        escape = lambda x: x
-
     lines = []
     lines.append("[bold cyan]Agent Reach 状态[/bold cyan]")
     lines.append("[cyan]" + "=" * 40 + "[/cyan]")
@@ -107,7 +112,6 @@ def format_report(results: Dict[str, dict]) -> str:
         )
 
     # Security check: config file permissions (Unix only)
-    import os
     import stat
     import sys
 

--- a/agent_reach/guides/setup-exa.md
+++ b/agent_reach/guides/setup-exa.md
@@ -17,7 +17,7 @@ npm install -g mcporter
 
 ### 2. 注册 Exa MCP
 ```bash
-mcporter config add exa https://mcp.exa.ai/mcp
+mcporter config add exa https://mcp.exa.ai/mcp --scope home
 ```
 
 ### 3. 验证

--- a/agent_reach/guides/setup-twitter.md
+++ b/agent_reach/guides/setup-twitter.md
@@ -42,7 +42,14 @@ twitter search "test" -n 1
 agent-reach configure twitter-cookies "粘贴的 cookie JSON"
 ```
 
-这会自动提取 `auth_token` 和 `ct0`，并写入环境变量。
+这会提取 `auth_token` 和 `ct0`，安全保存到
+`~/.agent-reach/config.yaml`。之后 `agent-reach doctor` 会只把凭据注入
+自己的 `twitter status` 子进程，不会修改当前 Shell 的环境变量。
+
+`twitter` 是独立的上游命令，不会读取 Agent Reach 的配置文件。直接运行
+`twitter search/read/...` 时，需要让 twitter-cli 从浏览器登录态提取，
+或按下节在当前 Shell 设置环境变量；已经存在的环境变量优先于 Agent Reach
+保存的值。
 
 ## 手动设置 Cookie
 
@@ -53,8 +60,8 @@ agent-reach configure twitter-cookies "粘贴的 cookie JSON"
 2. 设置环境变量：
 
 ```bash
-export AUTH_TOKEN="你的auth_token"
-export CT0="你的ct0"
+export TWITTER_AUTH_TOKEN="你的auth_token"
+export TWITTER_CT0="你的ct0"
 ```
 
 3. 测试：

--- a/agent_reach/guides/setup-twitter.md
+++ b/agent_reach/guides/setup-twitter.md
@@ -25,31 +25,43 @@ which twitter && echo "installed" || echo "not installed"
 pipx install twitter-cli
 ```
 
-3. 测试是否配置好：
+3. 确认命令已安装（此时不做认证请求）：
 
 ```bash
-twitter search "test" -n 1
+twitter --help
 ```
 
 ## 获取 Cookie（Cookie-Editor 方式，推荐）
 
 1. 安装 [Cookie-Editor](https://cookie-editor.com/) 浏览器扩展
 2. 登录 x.com
-3. 点击 Cookie-Editor 图标 → Export → 复制全部
+3. 点击 Cookie-Editor 图标 → Export → Header String
 4. 运行配置命令：
 
 ```bash
-agent-reach configure twitter-cookies "粘贴的 cookie JSON"
+agent-reach configure twitter-cookies "粘贴的 Header String"
 ```
 
 这会提取 `auth_token` 和 `ct0`，安全保存到
-`~/.agent-reach/config.yaml`。之后 `agent-reach doctor` 会只把凭据注入
-自己的 `twitter status` 子进程，不会修改当前 Shell 的环境变量。
+`~/.agent-reach/config.yaml`，供 `agent-reach doctor` 检查显式凭据是否齐全。
+`doctor` 不会执行 `twitter status`，不会实时验证账号是否可用，也不会修改当前 Shell。
+
+默认只写 `~/.agent-reach/config.yaml`。只有用户明确同意复制凭据并显式增加
+`--sync-legacy-twitter` 时，才会额外写入：
+
+- `~/.config/xfetch/session.json`
+- `~/.config/bird/credentials.env`
+
+```bash
+agent-reach configure twitter-cookies "粘贴的 Header String" --sync-legacy-twitter
+```
+
+`agent-reach uninstall` 只会提醒这些 legacy 副本，不会自动删除。需要清理时，
+先让用户确认，再手工删除上述两个文件。
 
 `twitter` 是独立的上游命令，不会读取 Agent Reach 的配置文件。直接运行
-`twitter search/read/...` 时，需要让 twitter-cli 从浏览器登录态提取，
-或按下节在当前 Shell 设置环境变量；已经存在的环境变量优先于 Agent Reach
-保存的值。
+`twitter status/search/read/...` 时，必须按下节在当前 Shell 或子进程环境中
+显式设置 `TWITTER_AUTH_TOKEN` 和 `TWITTER_CT0`。不要依赖自动读取浏览器 Cookie。
 
 ## 手动设置 Cookie
 

--- a/agent_reach/guides/setup-xiaohongshu.md
+++ b/agent_reach/guides/setup-xiaohongshu.md
@@ -79,7 +79,7 @@ docker run -d \
   -p 18060:18060 \
   xpzouying/xiaohongshu-mcp
 
-mcporter config add xiaohongshu http://localhost:18060/mcp
+mcporter config add xiaohongshu http://localhost:18060/mcp --scope home
 ```
 
 xhs-cli 是当前推荐方案，不需要 Docker，安装更简单。

--- a/agent_reach/guides/setup-xiaohongshu.md
+++ b/agent_reach/guides/setup-xiaohongshu.md
@@ -1,47 +1,42 @@
 # 小红书配置指南
 
 ## 功能说明
-读取和搜索小红书笔记。通过 [xhs-cli](https://github.com/jackwener/xiaohongshu-cli)（⭐1.5K，pipx 一行安装）实现。
+读取和搜索小红书笔记。桌面优先使用 OpenCLI，服务器使用
+[xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)；
+xhs-cli 仅作为已安装用户的存量备选。
 
 ## 前置条件
-- Python 3.10+（pipx 安装）
-- 浏览器已登录 xiaohongshu.com（用于导出 Cookie）
+- OpenCLI：用户已经存在且明确控制的 Chrome 小红书会话
+- xiaohongshu-mcp / 存量工具：Cookie-Editor 浏览器扩展
 
-## Agent 可自动完成的步骤
+## 认证边界
 
-### 1. 安装 xhs-cli
+Agent Reach 不替用户执行小红书登录，也不读取浏览器 Cookie。
+
+OpenCLI 只使用用户已经存在且明确控制的 Chrome 会话。
+`agent-reach configure xhs-cookies` 不会把 Cookie 注入 OpenCLI 或 Chrome。
+如果没有现成会话，不要自动登录；改用 Cookie-Editor 手工导出后配置
+xiaohongshu-mcp 或存量工具：
+
+1. 在 Chrome 中安装 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 扩展
+2. 用户自行在 xiaohongshu.com 准备要导出的会话
+3. 点击 Cookie-Editor 图标 → Export → Header String
+4. 把导出的字符串发给 Agent，运行：
+
 ```bash
-pipx install xiaohongshu-cli
-```
-
-### 2. 登录（从浏览器提取 Cookie）
-```bash
-xhs login
-```
-
-> 这会自动从浏览器提取 Cookie。如果自动提取失败，可以手动导入（见下方）。
-
-### 3. 验证
-```bash
+agent-reach configure xhs-cookies "导出的 Cookie Header String"
 agent-reach doctor
 ```
 
-应该看到小红书显示为 ✅。
+该显式命令会保存/导入用户提供的 xiaohongshu.com 同域 Cookie 集；执行前请
+确认 Cookie 名称和范围。非 xiaohongshu.com 域 Cookie 会被忽略。
 
-## 需要用户手动做的步骤
-
-如果 `xhs login` 自动提取失败，需要手动导入 cookies：
-
-> **推荐方式：Cookie-Editor 浏览器导出（最可靠）**
->
-> 1. 在 Chrome 中安装 [Cookie-Editor](https://chromewebstore.google.com/detail/cookie-editor/hlkenndednhfkekhgcdicdfddnkalmdm) 扩展
-> 2. 浏览器登录 xiaohongshu.com
-> 3. 点击 Cookie-Editor 图标 → Export → Header String
-> 4. 把导出的字符串发给 Agent，运行：`agent-reach configure xhs-cookies "导出的cookie字符串"`
->
-> **注意**：不要依赖 QR 扫码登录，Cookie-Editor 导出方式最简单可靠。
+如果 xiaohongshu-mcp 容器正在运行，配置命令会把 Cookie 导入容器；否则会写入
+owner-only 的本地文件，并打印后续手工导入路径。
 
 ## 使用示例
+
+先按 `agent-reach doctor --json` 的 `active_backend` 选择命令。存量 xhs-cli 示例：
 
 搜索笔记：
 ```bash
@@ -61,7 +56,8 @@ xhs comments NOTE_ID
 ## 常见问题
 
 **Q: Cookie 过期了？**
-A: 重新运行 `xhs login` 或通过 Cookie-Editor 重新导出。
+A: 重新通过 Cookie-Editor 手工导出，再运行
+`agent-reach configure xhs-cookies "新的 Cookie Header String"`。
 
 **Q: 小红书提示 IP 风险？**
 A: 推荐使用住宅代理：`export HTTP_PROXY="http://user:pass@ip:port"`。
@@ -69,7 +65,7 @@ A: 推荐使用住宅代理：`export HTTP_PROXY="http://user:pass@ip:port"`。
 **Q: xhs-cli 不支持我的系统？**
 A: 确保 Python 3.10+ 和 pipx 已安装。运行 `pipx install xiaohongshu-cli` 即可。
 
-## 备选方案：Docker MCP
+## 服务器方案：Docker MCP
 
 如果你已经在使用 [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) Docker 方案，它也能正常工作：
 
@@ -82,4 +78,4 @@ docker run -d \
 mcporter config add xiaohongshu http://localhost:18060/mcp --scope home
 ```
 
-xhs-cli 是当前推荐方案，不需要 Docker，安装更简单。
+该服务器后端使用上面的 Cookie-Editor 手工导出流程。

--- a/agent_reach/integrations/mcp_server.py
+++ b/agent_reach/integrations/mcp_server.py
@@ -14,11 +14,13 @@ import sys
 
 from agent_reach.config import Config
 from agent_reach.core import AgentReach
+from agent_reach.utils.text import scrub_url_credentials
 
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
-    from mcp.types import Tool, TextContent
+    from mcp.types import TextContent, Tool
+
     HAS_MCP = True
 except ImportError:
     HAS_MCP = False
@@ -30,7 +32,7 @@ def create_server():
         sys.exit(1)
 
     server = Server("agent-reach")
-    config = Config()
+    config = Config(read_only=True)
     eyes = AgentReach(config)
 
     @server.list_tools()
@@ -52,7 +54,12 @@ def create_server():
             text = json.dumps(result, ensure_ascii=False, indent=2) if isinstance(result, (dict, list)) else str(result)
             return [TextContent(type="text", text=text)]
         except Exception as e:
-            return [TextContent(type="text", text=f"Error: {str(e)}")]
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: {scrub_url_credentials(e)}",
+                )
+            ]
 
     return server
 

--- a/agent_reach/probe.py
+++ b/agent_reach/probe.py
@@ -16,7 +16,7 @@ not just file existence.
 import shutil
 import subprocess
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Mapping, Optional, Sequence
 
 from agent_reach.utils.process import utf8_subprocess_env
 
@@ -50,6 +50,8 @@ def probe_command(
     timeout: int = 10,
     retries: int = 0,
     package: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    remove_env: Sequence[str] = (),
 ) -> ProbeResult:
     """Actually execute `cmd *args` and classify the result.
 
@@ -59,6 +61,8 @@ def probe_command(
 
     package: pip/pipx package name used in the broken-install hint
              (defaults to cmd).
+    env: values added only to the probed child process.
+    remove_env: inherited variables removed only from the child process.
     """
     path = shutil.which(cmd)
     if not path:
@@ -66,25 +70,38 @@ def probe_command(
 
     last: Optional[ProbeResult] = None
     for _ in range(retries + 1):
-        last = _run_once(path, args, timeout, package or cmd)
+        last = _run_once(path, args, timeout, package or cmd, env, remove_env)
         if last.ok:
             return last
         # missing/broken won't heal between retries — only transient
         # failures (timeout/error) are worth a second attempt
         if last.status in ("missing", "broken"):
             return last
+    assert last is not None  # retries + 1 always executes at least once
     return last
 
 
-def _run_once(path: str, args: Sequence[str], timeout: int, package: str) -> ProbeResult:
+def _run_once(
+    path: str,
+    args: Sequence[str],
+    timeout: int,
+    package: str,
+    env: Optional[Mapping[str, str]] = None,
+    remove_env: Sequence[str] = (),
+) -> ProbeResult:
     try:
+        subprocess_env = utf8_subprocess_env()
+        for key in remove_env:
+            subprocess_env.pop(key, None)
+        if env:
+            subprocess_env.update(env)
         r = subprocess.run(
             [path, *args],
             capture_output=True,
             encoding="utf-8",
             errors="replace",
             timeout=timeout,
-            env=utf8_subprocess_env(),
+            env=subprocess_env,
         )
     except FileNotFoundError:
         # which() found it but exec failed: the shebang interpreter is gone

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -92,6 +92,15 @@ bili search "query" --type video -n 5
 
 ## 需登录态的平台（按 doctor 的 active_backend 选命令）
 
+Twitter 注意：`agent-reach configure twitter-cookies` 保存的 Cookie 只供
+`doctor` 检查配置是否齐全；`doctor` 不执行 `twitter status`，也不会设置当前
+Shell。直接运行 `twitter` 前，必须在子进程环境中显式提供
+`TWITTER_AUTH_TOKEN` 和 `TWITTER_CT0`，不得在日志或命令回显中暴露值。
+
+小红书注意：Agent Reach 不替用户登录，也不读取浏览器 Cookie。OpenCLI 只用
+用户已有且明确控制的 Chrome 会话；没有现成会话时不要自动登录，改用
+Cookie-Editor 手工导出后配置 xiaohongshu-mcp / 存量工具。
+
 ```bash
 # Twitter 搜索（twitter-cli 首选；失败重试链见 social.md）
 twitter search "query" -n 10

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -80,6 +80,17 @@ bili search "query" --type video -n 5
 
 ## Login-backed platforms (pick by doctor's active_backend)
 
+Twitter boundary: cookies saved by `agent-reach configure twitter-cookies`
+are used only by `doctor` to check whether explicit credentials are present.
+`doctor` does not run `twitter status` or configure the current shell. Before
+calling `twitter` directly, explicitly provide `TWITTER_AUTH_TOKEN` and
+`TWITTER_CT0` in the child-process environment without logging their values.
+
+XiaoHongShu boundary: Agent Reach must not log the user in or read browser
+cookies. OpenCLI may use only an existing Chrome session explicitly controlled
+by the user. If none exists, do not automate login; use a manual Cookie-Editor
+export with xiaohongshu-mcp or a legacy tool instead.
+
 ```bash
 # Twitter search (twitter-cli preferred; retry chain in social.md)
 twitter search "query" -n 10

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -6,7 +6,7 @@
 
 小红书有三个后端，**先跑 `agent-reach doctor --json` 看 xiaohongshu 的 `active_backend` 是哪个**，再用对应命令组。
 
-### 后端 A：OpenCLI（桌面首选，复用浏览器登录态）
+### 后端 A：OpenCLI（桌面首选）
 
 ```bash
 # 搜索笔记
@@ -25,14 +25,20 @@ opencli xiaohongshu feed -f yaml
 opencli xiaohongshu user USER_ID -f yaml
 ```
 
-> 要求 Chrome 打开且装了 OpenCLI 扩展。报 AUTH_REQUIRED 说明浏览器里没登录小红书，让用户在 Chrome 里登录一次即可。
+> 要求 Chrome 打开且装了 OpenCLI 扩展。OpenCLI 只使用用户已经存在且明确控制
+> 的 Chrome 会话；Agent Reach 不替用户登录，也不读取浏览器 Cookie。
+> `agent-reach configure xhs-cookies` 不会把 Cookie 注入 OpenCLI。
+> 如果没有现成会话，不要自动登录；改走后端 B/C，并按对应的
+> Cookie-Editor 手工导出流程配置。
 
 ### 后端 B：xiaohongshu-mcp（服务器场景）
 
 ```bash
-# 未登录时：先查状态，再取二维码给用户扫
+# 认证前先让用户用 Cookie-Editor 手工导出，再显式导入
+agent-reach configure xhs-cookies "导出的 Cookie Header String"
+
+# 只读检查当前状态
 mcporter call 'xiaohongshu.check_login_status()' --timeout 120000
-mcporter call 'xiaohongshu.get_login_qrcode()' --timeout 120000
 
 # 搜索
 mcporter call 'xiaohongshu.search_feeds(keyword: "query")' --timeout 120000
@@ -41,7 +47,10 @@ mcporter call 'xiaohongshu.search_feeds(keyword: "query")' --timeout 120000
 mcporter call 'xiaohongshu.get_feed_detail(feed_id: "...", xsec_token: "...")' --timeout 120000
 ```
 
-> 首次调用会自动下载约 150MB 无头浏览器，务必带 `--timeout 120000`。未登录时 search 会挂死，先 check_login_status。
+> 首次调用会自动下载约 150MB 无头浏览器，务必带 `--timeout 120000`。
+> 认证只走 Cookie-Editor 手工导出；导入后先运行 `check_login_status`。
+> 该显式命令会保存/导入用户提供的 xiaohongshu.com 同域 Cookie 集，用户应
+> 确认范围；非 xiaohongshu.com 域 Cookie 会被忽略。
 
 ### 后端 C：xhs-cli（存量备选，上游 2026-03 起停更）
 
@@ -57,6 +66,10 @@ xhs feed                    # 推荐
 
 ### 通用注意事项
 
+> **认证边界**: Agent Reach 不得替用户执行小红书登录，也不得读取浏览器
+> Cookie。OpenCLI 只能使用用户已有且明确控制的 Chrome 会话；
+> xiaohongshu-mcp / 存量工具使用 Cookie-Editor 手工导出。
+>
 > **xsec_token 限制**: 小红书强制 xsec_token 机制，**不能直接用裸 note_id 去读**。正确流程：先搜索/feed 拿结果，再用结果中的完整 URL/ID 去读。三个后端都一样。
 >
 > **频率控制**: 高频请求（批量搜索、深翻评论）会触发验证码，平台限制无法绕过。每次操作间隔 2-3 秒。
@@ -64,6 +77,18 @@ xhs feed                    # 推荐
 > **写操作（发帖/评论/点赞）**: 建议只读。xhs-cli v0.6.x 写操作可能因签名问题返回 406。
 
 ## Twitter/X (twitter-cli)
+
+### 认证前置条件
+
+`agent-reach configure twitter-cookies "..."` 保存的 Cookie 只供
+`agent-reach doctor` 检查显式凭据是否齐全。`doctor` 不执行上游
+`twitter status`，也不会设置当前 Shell。运行下面任何 `twitter` 命令前，
+必须在同一个 Shell 或子进程环境中显式提供：
+
+```bash
+export TWITTER_AUTH_TOKEN="..."
+export TWITTER_CT0="..."
+```
 
 ### 稳定命令
 
@@ -105,7 +130,8 @@ twitter likes
 
 > **安装**: `pipx install twitter-cli`（确保 v0.8.5+）
 >
-> **认证**: 推荐用 Cookie-Editor 导出后设置环境变量 `TWITTER_AUTH_TOKEN` + `TWITTER_CT0`。自动提取在 SSH/Docker/无头环境不可用。
+> **认证**: 只用 Cookie-Editor 手工导出，再显式设置环境变量
+> `TWITTER_AUTH_TOKEN` + `TWITTER_CT0`；不要依赖自动浏览器读取。
 >
 > **IP 风控**: 不要在 VPS/数据中心 IP 上频繁调用，尤其是 followers/following，有封号风险。使用住宅代理或本地环境。
 >

--- a/agent_reach/transcribe.py
+++ b/agent_reach/transcribe.py
@@ -28,6 +28,9 @@ from agent_reach.config import Config
 # Whisper API limit is 25MB; leave headroom for multipart overhead.
 SIZE_LIMIT_BYTES = 24 * 1024 * 1024
 CHUNK_SECONDS = 600  # 10 min — small enough that boundary cuts rarely lose meaning
+MAX_SOURCE_BYTES = 512 * 1024 * 1024
+MAX_CHUNKS = 24  # 4 hours at the standard 10-minute segment size
+MAX_TOTAL_CHUNK_BYTES = 96 * 1024 * 1024
 
 PROVIDERS = {
     "groq": {
@@ -64,6 +67,15 @@ _BLOCKED_HOSTS = {
 def _require(binary: str) -> None:
     if not shutil.which(binary):
         raise MissingDependency(f"{binary} not found in PATH")
+
+
+def _require_size_at_most(path: Path, limit: int, label: str) -> int:
+    """Return file size or fail before expensive downstream processing."""
+    size = path.stat().st_size
+    if size > limit:
+        limit_mib = limit / (1024 * 1024)
+        raise TranscribeError(f"{label} exceeds safety limit of {limit_mib:g} MiB")
+    return size
 
 
 def _run(cmd: List[str], timeout: int = 600) -> None:
@@ -135,6 +147,9 @@ def download_audio(url: str, out_dir: Path) -> Path:
             "m4a",
             "--audio-quality",
             "0",
+            "--no-playlist",
+            "--max-filesize",
+            str(MAX_SOURCE_BYTES),
             "-o",
             str(template),
             "--",
@@ -144,8 +159,13 @@ def download_audio(url: str, out_dir: Path) -> Path:
     )
     files = sorted(out_dir.glob("source.*"))
     if not files:
-        raise TranscribeError("yt-dlp produced no output file")
-    return files[0]
+        limit_mib = MAX_SOURCE_BYTES // (1024 * 1024)
+        raise TranscribeError(
+            f"yt-dlp produced no output file (source may exceed {limit_mib} MiB limit)"
+        )
+    audio = files[0]
+    _require_size_at_most(audio, MAX_SOURCE_BYTES, "downloaded source")
+    return audio
 
 
 def compress_audio(src: Path, out_dir: Path) -> Path:
@@ -290,11 +310,30 @@ def _transcribe_in_dir(source: str, order: List[str], cfg: Config, work_dir: Pat
     else:
         audio = download_audio(source, work_dir)
 
+    _require_size_at_most(audio, MAX_SOURCE_BYTES, "source")
     compressed = compress_audio(audio, work_dir)
     if compressed.stat().st_size <= SIZE_LIMIT_BYTES:
         chunks = [compressed]
     else:
         chunks = chunk_audio(compressed, work_dir)
+
+    if len(chunks) > MAX_CHUNKS:
+        max_minutes = MAX_CHUNKS * CHUNK_SECONDS // 60
+        raise TranscribeError(
+            f"audio produced {len(chunks)} chunks; safety limit is "
+            f"{MAX_CHUNKS} (~{max_minutes} minutes)"
+        )
+    chunk_sizes = [
+        _require_size_at_most(chunk, SIZE_LIMIT_BYTES, f"chunk {chunk.name}")
+        for chunk in chunks
+    ]
+    total_chunk_bytes = sum(chunk_sizes)
+    if total_chunk_bytes > MAX_TOTAL_CHUNK_BYTES:
+        limit_mib = MAX_TOTAL_CHUNK_BYTES / (1024 * 1024)
+        raise TranscribeError(
+            f"audio chunks total {total_chunk_bytes} bytes; "
+            f"safety limit is {limit_mib:g} MiB"
+        )
 
     pieces: List[str] = []
     for chunk in chunks:

--- a/agent_reach/transcribe.py
+++ b/agent_reach/transcribe.py
@@ -14,6 +14,7 @@ Designed to be importable from channels (e.g. YouTubeChannel.transcribe).
 from __future__ import annotations
 
 import ipaddress
+import math
 import shutil
 import subprocess
 import tempfile
@@ -31,6 +32,8 @@ CHUNK_SECONDS = 600  # 10 min — small enough that boundary cuts rarely lose me
 MAX_SOURCE_BYTES = 512 * 1024 * 1024
 MAX_CHUNKS = 24  # 4 hours at the standard 10-minute segment size
 MAX_TOTAL_CHUNK_BYTES = 96 * 1024 * 1024
+MAX_AUDIO_SECONDS = MAX_CHUNKS * CHUNK_SECONDS
+FFPROBE_TIMEOUT_SECONDS = 30
 
 PROVIDERS = {
     "groq": {
@@ -76,6 +79,68 @@ def _require_size_at_most(path: Path, limit: int, label: str) -> int:
         limit_mib = limit / (1024 * 1024)
         raise TranscribeError(f"{label} exceeds safety limit of {limit_mib:g} MiB")
     return size
+
+
+def _probe_audio_duration(path: Path) -> float:
+    """Return duration in seconds or fail closed before media generation."""
+    _require("ffprobe")
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        "-i",
+        str(path),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=FFPROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise TranscribeError(
+            "ffprobe timed out while reading audio duration "
+            f"after {FFPROBE_TIMEOUT_SECONDS}s"
+        ) from None
+    except OSError as exc:
+        raise TranscribeError(
+            f"ffprobe could not read audio duration: {exc}"
+        ) from exc
+
+    if proc.returncode != 0:
+        detail = proc.stderr.strip()[:300] or "unknown ffprobe error"
+        raise TranscribeError(
+            f"ffprobe failed while reading audio duration: {detail}"
+        )
+
+    raw_duration = proc.stdout.strip()
+    try:
+        duration = float(raw_duration)
+    except (TypeError, ValueError):
+        raise TranscribeError(
+            "ffprobe could not parse a valid audio duration"
+        ) from None
+    if not math.isfinite(duration) or duration <= 0:
+        raise TranscribeError(
+            "ffprobe could not parse a valid positive audio duration"
+        )
+    return duration
+
+
+def _require_duration_within_budget(path: Path) -> float:
+    """Reject audio that cannot fit within the bounded chunk budget."""
+    duration = _probe_audio_duration(path)
+    if duration > MAX_AUDIO_SECONDS:
+        max_minutes = MAX_AUDIO_SECONDS // 60
+        raise TranscribeError(
+            f"audio duration exceeds safety limit of {max_minutes} minutes"
+        )
+    return duration
 
 
 def _run(cmd: List[str], timeout: int = 600) -> None:
@@ -180,6 +245,8 @@ def compress_audio(src: Path, out_dir: Path) -> Path:
             "-y",
             "-i",
             str(src),
+            "-t",
+            str(MAX_AUDIO_SECONDS),
             "-vn",
             "-ac",
             "1",
@@ -195,6 +262,17 @@ def compress_audio(src: Path, out_dir: Path) -> Path:
 
 def chunk_audio(src: Path, out_dir: Path, segment_seconds: int = CHUNK_SECONDS) -> List[Path]:
     """Split src into segments. Re-encodes each segment so cuts align to keyframes."""
+    if segment_seconds <= 0:
+        raise TranscribeError("chunk segment duration must be positive")
+    possible_chunks = (
+        MAX_AUDIO_SECONDS + segment_seconds - 1
+    ) // segment_seconds
+    if possible_chunks > MAX_CHUNKS:
+        raise TranscribeError(
+            f"chunk generation safety limit is {MAX_CHUNKS}; "
+            f"segment duration {segment_seconds}s could create "
+            f"{possible_chunks} chunks"
+        )
     _require("ffmpeg")
     pattern = out_dir / "chunk_%03d.m4a"
     _run(
@@ -205,6 +283,8 @@ def chunk_audio(src: Path, out_dir: Path, segment_seconds: int = CHUNK_SECONDS) 
             "-y",
             "-i",
             str(src),
+            "-t",
+            str(MAX_AUDIO_SECONDS),
             "-f",
             "segment",
             "-segment_time",
@@ -311,6 +391,7 @@ def _transcribe_in_dir(source: str, order: List[str], cfg: Config, work_dir: Pat
         audio = download_audio(source, work_dir)
 
     _require_size_at_most(audio, MAX_SOURCE_BYTES, "source")
+    _require_duration_within_budget(audio)
     compressed = compress_audio(audio, work_dir)
     if compressed.stat().st_size <= SIZE_LIMIT_BYTES:
         chunks = [compressed]

--- a/agent_reach/utils/paths.py
+++ b/agent_reach/utils/paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -47,8 +48,12 @@ def render_ytdlp_fix_command() -> str:
             "  Add-Content -Path $cfg -Value '--js-runtimes node'\n"
             "}"
         )
+    config_dir = shlex.quote(str(config_path.parent))
+    config_file = shlex.quote(str(config_path))
     return (
-        f"mkdir -p '{config_path.parent}' && "
-        f"grep -qxF -- '--js-runtimes node' '{config_path}' 2>/dev/null || "
-        f"printf '%s\n' '--js-runtimes node' >> '{config_path}'"
+        f"mkdir -p {config_dir} && "
+        "{ "
+        f"grep -qxF -- '--js-runtimes node' {config_file} 2>/dev/null || "
+        f"printf '%s\\n' '--js-runtimes node' >> {config_file}; "
+        "}"
     )

--- a/agent_reach/utils/paths.py
+++ b/agent_reach/utils/paths.py
@@ -4,30 +4,179 @@ from __future__ import annotations
 
 import os
 import shlex
+import stat
 import sys
+import tempfile
 from pathlib import Path
+
+
+class PrivatePathError(RuntimeError):
+    """Raised when a private write could be redirected through a symlink."""
+
+
+def ensure_no_symlink_path(path: str | Path, label: str = "路径") -> Path:
+    """Reject any existing symlink component without resolving the path."""
+    target = Path(path)
+    absolute = Path(os.path.abspath(os.fspath(target)))
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        try:
+            mode = os.lstat(current).st_mode
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(mode):
+            raise PrivatePathError(f"{label}不能经过符号链接：{current}")
+    return target
 
 
 def make_private_dir(path: str | Path) -> Path:
     """Create a directory restricted to the current user where supported."""
-    target = Path(path)
+    target = ensure_no_symlink_path(path, "私密目录")
     target.mkdir(mode=0o700, parents=True, exist_ok=True)
+    ensure_no_symlink_path(target, "私密目录")
     if sys.platform != "win32":
-        os.chmod(target, 0o700)
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        dir_fd = os.open(target, flags)
+        try:
+            ensure_no_symlink_path(target, "私密目录")
+            if hasattr(os, "fchmod"):
+                os.fchmod(dir_fd, 0o700)
+        finally:
+            os.close(dir_fd)
     return target
 
 
-def get_ytdlp_config_dir() -> Path:
-    """Return the recommended yt-dlp user config directory for this OS."""
+def atomic_write_private_text(
+    path: str | Path,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+) -> Path:
+    """Atomically replace a private text file without following symlinks.
 
-    if sys.platform == "win32":
-        appdata = os.environ.get("APPDATA")
-        if appdata:
-            return Path(appdata) / "yt-dlp"
-        return Path.home() / "AppData" / "Roaming" / "yt-dlp"
-    if sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / "yt-dlp"
-    return Path.home() / ".config" / "yt-dlp"
+    The parent is owner-only, the temporary file is created beside the target
+    with mode ``0o600``, and both the parent and target are checked before the
+    final rename. ``os.replace`` replaces a late target symlink itself rather
+    than following it into another file.
+    """
+    target = Path(path)
+    parent = target.parent
+    ensure_no_symlink_path(parent, "父目录")
+    make_private_dir(parent)
+    ensure_no_symlink_path(parent, "父目录")
+    ensure_no_symlink_path(target, "目标文件")
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(parent),
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        if os.name != "nt" and hasattr(os, "fchmod"):
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        handle = os.fdopen(fd, "w", encoding=encoding)
+        fd = -1
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        ensure_no_symlink_path(parent, "父目录")
+        ensure_no_symlink_path(target, "目标文件")
+        os.replace(tmp_path, target)
+
+        if os.name != "nt" and hasattr(os, "O_DIRECTORY"):
+            try:
+                dir_fd = os.open(
+                    parent,
+                    os.O_RDONLY
+                    | os.O_DIRECTORY
+                    | getattr(os, "O_NOFOLLOW", 0),
+                )
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+            except OSError:
+                pass
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def read_small_text_no_follow(
+    path: str | Path,
+    *,
+    max_bytes: int,
+    encoding: str = "utf-8",
+) -> str | None:
+    """Read a bounded regular file while refusing every symlink component."""
+    if max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+
+    target = ensure_no_symlink_path(path, "读取路径")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(target, flags)
+    except FileNotFoundError:
+        return None
+
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise PrivatePathError(f"读取目标不是常规文件：{target}")
+        if file_stat.st_size > max_bytes:
+            raise PrivatePathError(f"读取目标超过大小上限：{target}")
+
+        chunks = []
+        remaining = max_bytes + 1
+        while remaining:
+            chunk = os.read(fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        if len(payload) > max_bytes:
+            raise PrivatePathError(f"读取目标超过大小上限：{target}")
+        ensure_no_symlink_path(target, "读取路径")
+    finally:
+        os.close(fd)
+    return payload.decode(encoding)
+
+
+def get_ytdlp_config_dir() -> Path:
+    """Return yt-dlp's first user config directory.
+
+    yt-dlp checks ``$XDG_CONFIG_HOME/yt-dlp`` first on every supported
+    platform, falling back to ``~/.config/yt-dlp`` when the variable is not
+    set. Writing anywhere else can make Agent Reach and Doctor agree with each
+    other while the real yt-dlp process silently ignores the setting.
+    """
+
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_home = Path(xdg_config_home) if xdg_config_home else Path.home() / ".config"
+    return config_home / "yt-dlp"
 
 
 def get_ytdlp_config_path() -> Path:

--- a/agent_reach/utils/text.py
+++ b/agent_reach/utils/text.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+_URL_CREDENTIALS_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.\-]{0,19}://)[^/\s@]+@"
+)
+_BARE_USERINFO_RE = re.compile(
+    r"(?<![A-Za-z0-9._%+\-])[^:/\s@]+:[^/\s@]+@(?=[A-Za-z0-9.\-\[])"
+)
+_URL_QUERY_SECRET_RE = re.compile(
+    r"([?&#](?:"
+    r"access[_-]?token|auth[_-]?token|token|bearer|"
+    r"api[_-]?key|key|password|passwd|secret|"
+    r"signature|sig|session(?:id)?|cookie|credential"
+    r")=)[^&#\s]*",
+    re.IGNORECASE,
+)
+
+
+def scrub_url_credentials(text: object) -> str:
+    """Redact URL userinfo and sensitive query/fragment values from text."""
+    scrubbed = _URL_CREDENTIALS_RE.sub(r"\1***@", str(text))
+    scrubbed = _BARE_USERINFO_RE.sub("***@", scrubbed)
+    return _URL_QUERY_SECRET_RE.sub(r"\1***", scrubbed)
 
 
 def read_utf8_text(path: str | Path, default: str = "") -> str:

--- a/agent_reach/utils/url.py
+++ b/agent_reach/utils/url.py
@@ -1,0 +1,38 @@
+"""Security helpers for untrusted URLs."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+def domain_matches(host: str, *domains: str) -> bool:
+    """Match a hostname/cookie domain exactly or as a real subdomain."""
+    normalized_host = str(host or "").lower().lstrip(".").rstrip(".")
+    if not normalized_host:
+        return False
+    for domain in domains:
+        allowed = domain.lower().lstrip(".").rstrip(".")
+        if normalized_host == allowed or normalized_host.endswith("." + allowed):
+            return True
+    return False
+
+
+def host_matches(url: str, *domains: str) -> bool:
+    """Return whether *url* has an exact allowed host or a real subdomain.
+
+    Only HTTP(S) URLs without userinfo are accepted. Using ``hostname`` rather
+    than substring matching prevents lookalikes such as ``x.com.evil.test`` and
+    userinfo disguises such as ``x.com@evil.test``.
+    """
+    try:
+        parsed = urlsplit(url)
+        host = (parsed.hostname or "").lower().rstrip(".")
+    except (TypeError, ValueError):
+        return False
+
+    if parsed.scheme.lower() not in {"http", "https"}:
+        return False
+    if not host or parsed.username is not None or parsed.password is not None:
+        return False
+
+    return domain_matches(host, *domains)

--- a/agent_reach/utils/url.py
+++ b/agent_reach/utils/url.py
@@ -27,6 +27,10 @@ def host_matches(url: str, *domains: str) -> bool:
     try:
         parsed = urlsplit(url)
         host = (parsed.hostname or "").lower().rstrip(".")
+        # ``hostname`` is permissive: malformed or out-of-range ports only
+        # raise when ``port`` is accessed. Force that validation here so
+        # hostile authorities fail closed.
+        _ = parsed.port
     except (TypeError, ValueError):
         return False
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,8 @@ python-dotenv==1.2.1
 loguru==0.7.3
 PyYAML==6.0.3
 rich==14.3.2
-yt-dlp==2025.5.22
+yt-dlp==2026.07.04
+yt-dlp-ejs==0.8.0
 
 pytest==8.0.0
 ruff==0.15.1

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -73,7 +73,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 |----------|-------------|:-----:|-------|
 | 🌐 **Web** | Read | Zero config | Any URL → clean Markdown ([Jina Reader](https://github.com/jina-ai/reader) ⭐9.8K) |
 | 🐦 **Twitter/X** | Read · Search | Cookie | Cookie unlocks search, timeline, tweet reading, articles ([twitter-cli](https://github.com/public-clis/twitter-cli)) |
-| 📕 **XiaoHongShu** | Read · Search · Comments | OpenCLI / MCP | Desktop: [OpenCLI](https://github.com/jackwener/opencli) (reuses browser session); Server: [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) (QR login); legacy xhs-cli still works |
+| 📕 **XiaoHongShu** | Read · Search · Comments | OpenCLI / MCP | OpenCLI uses only an existing user-controlled Chrome session; MCP/legacy tools use a manual Cookie-Editor export |
 | 📘 **Facebook** | Search · Profiles · Feed · Groups list | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 📷 **Instagram** | User search · Profiles · Recent posts · Explore | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 💼 **LinkedIn** | Jina Reader (public pages) | Full profiles, companies, job search | Tell your Agent "help me set up LinkedIn" |
@@ -156,7 +156,7 @@ No configuration needed — just tell your Agent:
 - "Read this link" → `curl https://r.jina.ai/URL` for any web page
 - "What's this GitHub repo about?" → `gh repo view owner/repo`
 - "What does this video cover?" → `yt-dlp --dump-json URL` for subtitles
-- "Read this tweet" → `twitter tweet URL`
+- "Read this tweet" → set `TWITTER_AUTH_TOKEN` / `TWITTER_CT0`, then run `twitter tweet URL`
 - "Subscribe to this RSS" → `feedparser` to parse feeds
 - "Search GitHub for LLM frameworks" → `gh search repos "LLM framework"`
 
@@ -176,7 +176,17 @@ Don't use it? Don't configure it. Every step is optional.
 
 ### 🍪 Cookies — Free, 2 minutes
 
-Tell your Agent "help me configure Twitter cookies" — it'll guide you through exporting from your browser. Local computers can auto-import.
+Tell your Agent "help me configure Twitter cookies" — it'll guide you through a
+manual Cookie-Editor export. Agent Reach saves the values for `doctor` to check
+whether credentials are present; `doctor` does not run `twitter status`.
+Direct `twitter` commands still require `TWITTER_AUTH_TOKEN` and `TWITTER_CT0`
+in their process environment.
+
+For XiaoHongShu, Agent Reach never logs the user in or reads browser cookies.
+OpenCLI may use only an existing Chrome session explicitly controlled by the
+user. If none exists, do not automate login; use a manual Cookie-Editor export
+with xiaohongshu-mcp or a legacy tool. `agent-reach configure xhs-cookies`
+does not inject cookies into OpenCLI or Chrome.
 
 ### 🌐 Proxy — $1/month, restricted networks only
 
@@ -196,7 +206,6 @@ $ agent-reach doctor
 
 ✅ Ready to use:
   ✅ GitHub repos and code — public repos readable and searchable
-  ✅ Twitter/X tweets — readable. Cookie unlocks search and posting
   ✅ YouTube video subtitles — yt-dlp
   ✅ Bilibili search & video detail — bili-cli (subtitles via OpenCLI)
   ✅ RSS/Atom feeds — feedparser
@@ -206,8 +215,9 @@ $ agent-reach doctor
   ⬜ Web semantic search — sign up at exa.ai for free key
 
 🔧 Configurable:
+  ⚠️  Twitter/X — doctor checks only that explicit credentials exist; direct CLI still needs its environment variables
   ⬜ Reddit posts and comments — needs login: rdt-cli after `rdt login`, or OpenCLI browser session
-  ⬜ XiaoHongShu notes — desktop: OpenCLI (browser session); server: xiaohongshu-mcp (QR)
+  ⬜ XiaoHongShu notes — OpenCLI needs an existing user-controlled session; otherwise use Cookie-Editor with MCP/legacy tools
   ⬜ Facebook / Instagram — desktop: OpenCLI browser session
 
 Status: 6/9 channels available
@@ -260,7 +270,7 @@ Each channel file **actually probes** its candidate backends in order (not just 
 | Search the web | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI semantic search, MCP integration, no API key |
 | GitHub | [gh CLI](https://cli.github.com) | — | Official tool, full API after auth |
 | Read RSS | [feedparser](https://github.com/kurtmckee/feedparser) | — | Python ecosystem standard |
-| XiaoHongShu | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) (server) ▸ xhs-cli | The xhs-cli author moved to OpenCLI (24K stars); browser sessions mean zero friction |
+| XiaoHongShu | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) (server) ▸ xhs-cli | OpenCLI uses only an existing user-controlled session; other backends use a manual Cookie-Editor export |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | Jina Reader | MCP server, browser automation |
 | Xiaoyuzhou Podcast | `transcribe.sh` | — | `bash ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh <URL>` |
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -63,7 +63,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 |-----------------|------|:----------:|------|
 | 🌐 **Web** | 閲覧 | 設定不要 | 任意のURL → クリーンなMarkdown（[Jina Reader](https://github.com/jina-ai/reader) ⭐9.8K） |
 | 🐦 **Twitter/X** | 閲覧・検索 | 設定不要 / Cookie | 単一ツイートはすぐに閲覧可能。Cookieで検索、タイムライン、投稿が解放（[twitter-cli](https://github.com/public-clis/twitter-cli)） |
-| 📕 **小紅書** | 閲覧・検索・**投稿・コメント・いいね** | Cookie | `pipx install xiaohongshu-cli` + `xhs login`（[xhs-cli](https://github.com/jackwener/xiaohongshu-cli)） |
+| 📕 **小紅書** | 閲覧・検索・コメント | OpenCLI / Cookie | OpenCLI はユーザー管理の既存 Chrome セッションだけを使用。MCP/旧ツールは Cookie-Editor を使用 |
 | 🎵 **抖音** | 動画解析・ウォーターマークなしダウンロード | mcporter | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server)、ログイン不要 |
 | 💼 **LinkedIn** | Jina Reader（公開ページ） | プロフィール、企業、求人検索 | エージェントに「LinkedInの設定を手伝って」と伝えてください |
 | 💬 **WeChat記事** | 検索 + 閲覧 | 設定不要 | WeChat公式アカウント記事の検索+閲覧（完全Markdown）（[Exa](https://exa.ai) + [Camoufox](https://github.com/daijro/camoufox)（オプション）） |
@@ -74,7 +74,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 | 🔍 **Web検索** | 検索 | 自動設定 | インストール時に自動設定、無料、APIキー不要（[Exa](https://exa.ai)、[mcporter](https://github.com/nicepkg/mcporter)経由） |
 | 📦 **GitHub** | 閲覧・検索 | 設定不要 | [gh CLI](https://cli.github.com) 搭載。公開リポジトリはすぐ使える。`gh auth login`でFork、Issue、PRが解放 |
 | 📺 **YouTube** | 閲覧・**検索** | 設定不要 | 字幕 + 1800以上の動画サイトでの検索（[yt-dlp](https://github.com/yt-dlp/yt-dlp) ⭐148K） |
-| 📺 **Bilibili** | 閲覧・**検索** | 設定不要 / プロキシ | 動画情報 + 字幕 + 検索。ローカルはそのまま動作、サーバーはプロキシが必要（[yt-dlp](https://github.com/yt-dlp/yt-dlp)） |
+| 📺 **Bilibili** | 閲覧・**検索** | 設定不要 | [bili-cli](https://github.com/public-clis/bilibili-cli) で検索・動画情報（ログイン不要）、字幕は OpenCLI。yt-dlp は Bilibili の 412 制限により使用しません |
 | 📡 **RSS** | 閲覧 | 設定不要 | 任意のRSS/Atomフィード（[feedparser](https://github.com/kurtmckee/feedparser) ⭐2.3K） |
 | 📖 **Reddit** | 検索・閲覧 | Cookie | 2024年以降認証が必要 — インストール後 `rdt login` を実行（[rdt-cli](https://github.com/public-clis/rdt-cli)） |
 
@@ -127,7 +127,7 @@ Skillインストール後、エージェントは`agent-reach` CLIが利用可�
 - 「このリンクを読んで」→ `curl https://r.jina.ai/URL` で任意のWebページ
 - 「このGitHubリポジトリは何？」→ `gh repo view owner/repo`
 - 「この動画の内容は？」→ `yt-dlp --dump-json URL` で字幕取得
-- 「このツイートを読んで」→ `twitter tweet URL`
+- 「このツイートを読んで」→ `TWITTER_AUTH_TOKEN` / `TWITTER_CT0` を設定してから `twitter tweet URL`
 - 「このRSSを購読して」→ `feedparser` でフィード解析
 - 「GitHubでLLMフレームワークを検索して」→ `gh search repos "LLM framework"`
 
@@ -141,11 +141,15 @@ Skillインストール後、エージェントは`agent-reach` CLIが利用可�
 
 ### 🍪 Cookie — 無料、2分
 
-エージェントに「Twitterのクッキーの設定を手伝って」と伝えてください — ブラウザからのエクスポート手順を案内してくれます。ローカルPCなら自動インポートも可能です。
+エージェントに「Twitterのクッキーの設定を手伝って」と伝えてください —
+Cookie-Editor による手動エクスポートを案内します。保存した値は
+`agent-reach doctor` が設定の有無を確認するためだけに使われ、doctor は
+`twitter status` を実行しません。上流の `twitter` コマンドには
+`TWITTER_AUTH_TOKEN` と `TWITTER_CT0` を明示的に設定してください。
 
 ### 🌐 プロキシ — 月額$1、サーバーのみ
 
-RedditとBilibiliはサーバーIPをブロックします。プロキシを取得し（[Webshare](https://webshare.io) 推奨、月額$1）、アドレスをエージェントに伝えてください。
+通常はプロキシ不要です。ネットワーク上で Reddit/Twitter が遮断されている場合のみ、プロキシを設定してください。Bilibili は bili-cli を使用します。
 
 > ローカルPCではプロキシは不要です。Reddit検索はプロキシなしでもrdt-cliで無料で動作します。
 
@@ -161,9 +165,8 @@ $ agent-reach doctor
 
 ✅ 利用可能:
   ✅ GitHubリポジトリとコード — 公開リポジトリの閲覧・検索可能
-  ✅ Twitter/Xツイート — 閲覧可能。Cookieで検索・投稿が解放
   ✅ YouTube動画字幕 — yt-dlp
-  ⚠️  Bilibili動画情報 — サーバーIPがブロックされる可能性あり、プロキシを設定してください
+  ✅ Bilibili検索・動画情報 — bili-cli（字幕は OpenCLI）
   ✅ RSS/Atomフィード — feedparser
   ✅ Webページ（任意のURL） — Jina Reader API
 
@@ -171,8 +174,9 @@ $ agent-reach doctor
   ⬜ Webセマンティック検索 — exa.aiで無料キーを取得
 
 🔧 設定可能:
+  ⚠️  Twitter/X — doctor は明示的な認証情報の有無だけを確認。上流CLIには環境変数が必要
   ✅ Reddit投稿とコメント — rdt-cliで検索+閲覧（無料、プロキシ不要）
-  ⬜ 小紅書ノート — Cookieが必要。ブラウザからエクスポート
+  ⬜ 小紅書ノート — OpenCLI は既存セッションのみ。それ以外は Cookie-Editor で MCP/旧ツールを設定
 
 ステータス: 9チャンネル中6チャンネルが利用可能
 ```
@@ -199,9 +203,9 @@ channels/
 ├── twitter.py      → twitter-cli      ← 公式APIなどに差し替え可能…
 ├── youtube.py      → yt-dlp          ← YouTube API、Whisperなどに差し替え可能…
 ├── github.py       → gh CLI          ← REST API、PyGithubなどに差し替え可能…
-├── bilibili.py     → yt-dlp          ← bilibili-apiなどに差し替え可能…
-├── reddit.py       → rdt-cli          ← 検索+閲覧、Cookie認証が必要
-├── xiaohongshu.py  → xhs-cli          ← 他のXHSツールに差し替え可能…
+├── bilibili.py     → bili-cli ▸ OpenCLI ▸ 検索 API（yt-dlp は 412 制限により退役）
+├── reddit.py       → OpenCLI ▸ rdt-cli（ログイン状態が必要）
+├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── douyin.py       → mcporter MCP    ← 他の抖音ツールに差し替え可能…
 ├── linkedin.py     → linkedin-mcp    ← LinkedIn APIに差し替え可能…
 ├── rss.py          → feedparser      ← atomaなどに差し替え可能…
@@ -217,11 +221,12 @@ channels/
 |----------|--------|------|
 | Webページ閲覧 | [Jina Reader](https://github.com/jina-ai/reader) | ⭐9.8K、無料、APIキー不要 |
 | ツイート閲覧 | [twitter-cli](https://github.com/public-clis/twitter-cli) | 2.1K Star、Cookie認証、検索/閲覧/タイムライン/長文 |
-| 動画字幕 + 検索 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | ⭐148K、YouTube + Bilibili + 1800サイト |
+| YouTube 字幕 + 検索 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | YouTube と対応動画サイト向け（Bilibili には使用しません） |
+| Bilibili | [bili-cli](https://github.com/public-clis/bilibili-cli) ▸ OpenCLI ▸ 検索 API | yt-dlp は 412 制限で退役。bili-cli はログイン不要で検索・閲覧可能 |
 | Web検索 | [Exa](https://exa.ai)（[mcporter](https://github.com/nicepkg/mcporter)経由） | AIセマンティック検索、MCP統合、APIキー不要 |
 | GitHub | [gh CLI](https://cli.github.com) | 公式ツール、認証後フルAPI |
 | RSS閲覧 | [feedparser](https://github.com/kurtmckee/feedparser) | Pythonエコシステムの標準、⭐2.3K |
-| 小紅書 | [xhs-cli](https://github.com/jackwener/xiaohongshu-cli) | 1.5K Star、pipxインストール、検索/閲覧/コメント/投稿 |
+| 小紅書 | [OpenCLI](https://github.com/jackwener/opencli)（デスクトップ）▸ [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp)（サーバー）▸ xhs-cli | OpenCLI は既存のユーザー管理セッションのみ使用。その他は Cookie-Editor で手動設定 |
 | 抖音 | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) | MCPサーバー、ログイン不要、動画解析 + ウォーターマークなしダウンロード |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | ⭐900+、MCPサーバー、ブラウザ自動化 |
 | WeChat記事 | [Exa](https://exa.ai)（検索+閲覧）+ [Camoufox](https://github.com/daijro/camoufox)（オプション） | ゼロ設定で検索+全文閲覧、Camoufoxでオプション強化 |
@@ -249,7 +254,7 @@ channels/
 <details>
 <summary><strong>Twitter/X APIに課金せずにAIエージェントで検索するには？</strong></summary>
 
-Agent Reach は [twitter-cli](https://github.com/public-clis/twitter-cli) をCookie認証で使用します — 完全無料、Twitter APIのサブスクリプションは不要です。`pipx install twitter-cli` でインストール後、Cookie-Editor Chrome拡張機能でTwitterのCookieをエクスポートし、`agent-reach configure twitter-cookies "your_cookies"` を実行すれば、`twitter search "query" -n 10` でエージェントが検索できるようになります。
+Agent Reach は [twitter-cli](https://github.com/public-clis/twitter-cli) をCookie認証で使用します。Cookie-Editor で手動エクスポートし、`agent-reach configure twitter-cookies "your_cookies"` で Agent Reach に保存します。これは doctor の設定確認用であり、doctor は上流の認証をリアルタイム検証しません。`twitter search "query" -n 10` を直接実行するプロセスには `TWITTER_AUTH_TOKEN` と `TWITTER_CT0` を明示的に渡してください。
 </details>
 
 <details>
@@ -273,7 +278,7 @@ Agent Reach は [rdt-cli](https://github.com/public-clis/rdt-cli) でRedditに�
 <details>
 <summary><strong>Agent Reach は無料？APIのコストは？</strong></summary>
 
-100%無料でオープンソース。すべてのバックエンド（twitter-cli、rdt-cli、xhs-cli、yt-dlp、Jina Reader、Exa）は有料APIキーが不要な無料ツールです。唯一のオプションコストは、サーバーからBilibiliにアクセスする場合のレジデンシャルプロキシ（月額約$1）です。
+100%無料でオープンソース。すべてのバックエンド（twitter-cli、rdt-cli、OpenCLI、bili-cli、yt-dlp、Jina Reader、Exa）は有料APIキーが不要な無料ツールです。ネットワーク上で特定サイトが遮断されている場合のみ、プロキシ費用が発生することがあります。
 </details>
 
 <details>
@@ -285,7 +290,7 @@ Agent Reach はtwitter-cliを使用し、Cookie認証でTwitterにアクセス�
 <details>
 <summary><strong>小紅書のコンテンツをプログラムで読むには？</strong></summary>
 
-`pipx install xiaohongshu-cli` でインストール後、`xhs login`（ブラウザからCookieを自動抽出）。エージェントは `xhs search "query"` でノートを検索、`xhs read NOTE_ID` で詳細を閲覧、`xhs comments NOTE_ID` でコメントを表示できます。Dockerは不要です。
+Agent Reach は小紅書へのログインを代行せず、ブラウザ Cookie も読み取りません。OpenCLI はユーザーが既に所有・管理している Chrome セッションだけを使用します。既存セッションがない場合は自動ログインせず、Cookie-Editor で手動エクスポートして xiaohongshu-mcp または旧ツールを設定してください。`agent-reach configure xhs-cookies` は OpenCLI / Chrome に Cookie を注入しません。
 </details>
 
 <details>

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -63,7 +63,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 |----------|-------------|:-----:|-------|
 | 🌐 **Web** | 읽기 | 없음 | 모든 URL → 깨끗한 Markdown ([Jina Reader](https://github.com/jina-ai/reader) ⭐9.8K) |
 | 🐦 **Twitter/X** | 읽기 · 검색 | Cookie | Cookie로 검색, 타임라인, 트윗 읽기, 아티클 읽기 가능 ([twitter-cli](https://github.com/public-clis/twitter-cli)) |
-| 📕 **XiaoHongShu** | 읽기 · 검색 · **게시글 작성 · 댓글 · 좋아요** | Cookie | `pipx install xiaohongshu-cli` + `xhs login` ([xhs-cli](https://github.com/jackwener/xiaohongshu-cli)) |
+| 📕 **XiaoHongShu** | 읽기 · 검색 · 댓글 | OpenCLI / Cookie | OpenCLI는 사용자가 관리하는 기존 Chrome 세션만 사용하며, MCP/기존 도구는 Cookie-Editor 사용 |
 | 🎵 **Douyin** | 비디오 파싱 · 워터마크 없는 다운로드 | mcporter | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) 통해, 로그인 불필요 |
 | 💼 **LinkedIn** | Jina Reader (공개 페이지) | Cookie | 전체 프로필, 회사, 채용 공고 검색 가능. 에이전트에 "LinkedIn 설정 도와줘"라고 말하세요 |
 | 💬 **WeChat Articles** | 검색 + 읽기 | 없음 | Exa를 통한 WeChat 공식 계정 게시글 검색 + 읽기 (설정 없음) + 선택적 [Camoufox](https://github.com/daijro/camoufox) |
@@ -74,7 +74,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 | 🔍 **Web Search** | 검색 | 자동 설정 | 설치 시 자동 설정, 무료, API key 불필요 ([Exa](https://exa.ai) via [mcporter](https://github.com/nicepkg/mcporter)) |
 | 📦 **GitHub** | 읽기 · 검색 | 없음 | [gh CLI](https://cli.github.com) 기반. 공개 저장소는 즉시 사용 가능. `gh auth login`으로 Fork, Issue, PR 기능 활성화 |
 | 📺 **YouTube** | 읽기 · **검색** | 없음 | 자막 + 1800+ 비디오 사이트 검색 ([yt-dlp](https://github.com/yt-dlp/yt-dlp) ⭐148K) |
-| 📺 **Bilibili** | 읽기 · **검색** | 없음 / 프록시 | 비디오 정보 + 자막 + 검색. 로컬은 바로 작동, 서버는 프록시 필요 ([yt-dlp](https://github.com/yt-dlp/yt-dlp)) |
+| 📺 **Bilibili** | 읽기 · **검색** | 설정 없음 | [bili-cli](https://github.com/public-clis/bilibili-cli)로 검색·비디오 정보(로그인 불필요), 자막은 OpenCLI. yt-dlp는 Bilibili의 412 차단으로 사용하지 않음 |
 | 📡 **RSS** | 읽기 | 없음 | 모든 RSS/Atom 피드 ([feedparser](https://github.com/kurtmckee/feedparser) ⭐2.3K) |
 | 📖 **Reddit** | 검색 · 읽기 | Cookie | 2024년부터 인증 필요 — 설치 후 `rdt login` 실행 ([rdt-cli](https://github.com/public-clis/rdt-cli)) |
 
@@ -127,7 +127,7 @@ Skill이 설치된 후, 에이전트는 `agent-reach` CLI 사용 가능 여부�
 - "이 링크 읽어줘" → 모든 웹 페이지에 대해 `curl https://r.jina.ai/URL`
 - "이 GitHub 저장소는 무엇인가요?" → `gh repo view owner/repo`
 - "이 비디오는 무엇을 다루나요?" → 자막을 위해 `yt-dlp --dump-json URL`
-- "이 트윗 읽어줘" → `twitter tweet URL`
+- "이 트윗 읽어줘" → `TWITTER_AUTH_TOKEN` / `TWITTER_CT0` 설정 후 `twitter tweet URL`
 - "이 RSS 구독해줘" → 피드 파싱을 위해 `feedparser`
 - "GitHub에서 LLM 프레임워크 검색" → `gh search repos "LLM framework"`
 
@@ -141,11 +141,15 @@ Skill이 설치된 후, 에이전트는 `agent-reach` CLI 사용 가능 여부�
 
 ### 🍪 Cookies — 무료, 2분
 
-에이전트에 "Twitter 쿠키 설정 도와줘"라고 말하세요 — 브라우저에서 내보내는 과정을 안내해 줍니다. 로컬 컴퓨터는 자동으로 가져올 수 있습니다.
+에이전트에 "Twitter 쿠키 설정 도와줘"라고 말하세요. Cookie-Editor 수동
+내보내기 절차를 안내합니다. 저장한 값은 `agent-reach doctor`가 명시적
+자격 증명의 존재 여부를 확인할 때만 사용하며, doctor는 `twitter status`를
+실행하지 않습니다. 직접 실행하는 `twitter` 프로세스에는
+`TWITTER_AUTH_TOKEN`과 `TWITTER_CT0`를 명시적으로 전달해야 합니다.
 
 ### 🌐 Proxy — 월 $1, 서버 전용
 
-Bilibili은 서버 IP를 차단합니다. 프록시를 가져오세요([Webshare](https://webshare.io) 추천, 월 $1)하고 주소를 에이전트에 보내세요.
+대부분의 사용자는 프록시가 필요 없습니다. 네트워크에서 Reddit/Twitter가 차단된 경우에만 프록시를 설정하세요. Bilibili는 bili-cli를 사용합니다.
 
 > Reddit은 이제 프록시 없이 rdt-cli를 통해 무료로 작동합니다. 로컬 컴퓨터는 Bilibili에도 프록시가 필요 없습니다.
 
@@ -161,9 +165,8 @@ $ agent-reach doctor
 
 ✅ 사용 가능:
   ✅ GitHub 저장소 및 코드 — 공개 저장소 읽기 및 검색 가능
-  ✅ Twitter/X 트윗 — 읽기 가능. Cookie로 검색 및 게시 가능
   ✅ YouTube 비디오 자막 — yt-dlp
-  ⚠️  Bilibili 비디오 정보 — 서버 IP가 차단될 수 있음, 프록시 설정
+  ✅ Bilibili 검색 및 비디오 정보 — bili-cli (자막은 OpenCLI)
   ✅ RSS/Atom 피드 — feedparser
   ✅ 웹 페이지 (모든 URL) — Jina Reader API
 
@@ -171,8 +174,9 @@ $ agent-reach doctor
   ⬜ 웹 시맨틱 검색 — exa.ai에서 무료 key 발급
 
 🔧 설정 가능:
+  ⚠️  Twitter/X — doctor는 명시적 자격 증명의 존재만 확인하며, 업스트림 CLI에는 환경 변수가 필요
   ✅ Reddit 글 및 댓글 — rdt-cli를 통한 검색 및 읽기 (무료, 프록시 없음)
-  ⬜ XiaoHongShu 노트 — 쿠키 필요. 브라우저에서 내보내기
+  ⬜ XiaoHongShu 노트 — OpenCLI는 기존 세션만 사용하며, 그 외에는 Cookie-Editor로 MCP/기존 도구 설정
 
 상태: 6/9 채널 사용 가능
 ```
@@ -199,9 +203,9 @@ channels/
 ├── twitter.py      → twitter-cli      ← 공식 API로 교체...
 ├── youtube.py      → yt-dlp          ← YouTube API, Whisper로 교체...
 ├── github.py       → gh CLI          → REST API, PyGithub로 교체...
-├── bilibili.py     → yt-dlp          → bilibili-api로 교체...
-├── reddit.py       → rdt-cli          → 검색 + 읽기, cookie 인증 필요
-├── xiaohongshu.py  → mcporter MCP    ← 다른 XHS 도구로 교체...
+├── bilibili.py     → bili-cli ▸ OpenCLI ▸ 검색 API (yt-dlp는 412 차단으로 폐기)
+├── reddit.py       → OpenCLI ▸ rdt-cli (로그인 상태 필요)
+├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── douyin.py       → mcporter MCP    ← 다른 Douyin 도구로 교체...
 ├── linkedin.py     → linkedin-mcp    ← LinkedIn API로 교체...
 ├── rss.py          → feedparser      ← atoma로 교체...
@@ -218,12 +222,12 @@ channels/
 | 웹 페이지 읽기 | [Jina Reader](https://github.com/jina-ai/reader) | 9.8K stars, 무료, API key 불필요 |
 | 트윗 읽기 | [twitter-cli](https://github.com/public-clis/twitter-cli) | 2.1K stars, cookie 인증, 검색/읽기/타임라인/글 |
 | Reddit | [rdt-cli](https://github.com/public-clis/rdt-cli) | 304 stars, cookie 인증, 검색 + 전체 글 + 댓글 |
-| 비디오 자막 + 검색 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | 154K stars, YouTube + Bilibili + 1800 사이트 |
-| Bilibili 향상 | [bili-cli](https://github.com/public-clis/bilibili-cli) | 590 stars, 인기/순위/검색/피드 |
+| YouTube 자막 + 검색 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | YouTube 및 지원 비디오 사이트용(Bilibili에는 사용하지 않음) |
+| Bilibili | [bili-cli](https://github.com/public-clis/bilibili-cli) ▸ OpenCLI ▸ 검색 API | yt-dlp는 412 차단으로 폐기. bili-cli는 로그인 없이 검색·읽기 가능 |
 | 웹 검색 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | AI 시맨틱 검색, MCP 통합, API key 불필요 |
 | GitHub | [gh CLI](https://cli.github.com) | 공식 도구, 인증 후 전체 API |
 | RSS 읽기 | [feedparser](https://github.com/kurtmckee/feedparser) | Python 생태계 표준, 2.3K stars |
-| XiaoHongShu | [xhs-cli](https://github.com/jackwener/xiaohongshu-cli) | 1.5K stars, pipx 설치, 검색/읽기/댓글/게시 |
+| XiaoHongShu | [OpenCLI](https://github.com/jackwener/opencli) (데스크톱) ▸ [xiaohongshu-mcp](https://github.com/xpzouying/xiaohongshu-mcp) (서버) ▸ xhs-cli | OpenCLI는 사용자가 관리하는 기존 세션만 사용하며, 그 외에는 Cookie-Editor로 수동 설정 |
 | Douyin | [douyin-mcp-server](https://github.com/yzfly/douyin-mcp-server) | MCP 서버, 로그인 불필요, 비디오 파싱 + 워터마크 없는 다운로드 |
 | LinkedIn | [linkedin-scraper-mcp](https://github.com/stickerdaniel/linkedin-mcp-server) | 1.2K stars, MCP 서버, 브라우저 자동화 |
 | WeChat Articles | [Exa](https://exa.ai) (검색 + 읽기) + [Camoufox](https://github.com/daijro/camoufox) (선택) | 설정 없이 검색 + 전체 글 읽기 |
@@ -251,7 +255,7 @@ channels/
 <details>
 <summary><strong>AI 에이전트로 Twitter/X를 API 비용 없이 검색하는 방법?</strong></summary>
 
-Agent Reach는 cookie 기반 인증을 사용하는 [twitter-cli](https://github.com/public-clis/twitter-cli)를 사용합니다 — 완전 무료, Twitter API 구독 불필요. `pipx install twitter-cli`로 설치하고, 브라우저에서 x.com에 로그인되어 있는지 확인하세요. 에이전트가 `twitter search "query" -n 10`으로 검색할 수 있습니다.
+Agent Reach는 cookie 기반 인증을 사용하는 [twitter-cli](https://github.com/public-clis/twitter-cli)를 사용합니다. Cookie-Editor로 수동 내보낸 뒤 `agent-reach configure twitter-cookies "..."`로 저장합니다. 이 값은 doctor의 설정 확인용이며 실시간 인증 성공을 뜻하지 않습니다. `twitter search "query" -n 10`을 직접 실행하는 프로세스에는 `TWITTER_AUTH_TOKEN`과 `TWITTER_CT0`를 명시적으로 전달해야 합니다.
 </details>
 
 <details>
@@ -275,7 +279,7 @@ Agent Reach는 Reddit을 위해 [rdt-cli](https://github.com/public-clis/rdt-cli
 <details>
 <summary><strong>Agent Reach는 무료인가요? API 비용이 있나요?</strong></summary>
 
-100% 무료 오픈 소스입니다. 모든 백엔드(twitter-cli, rdt-cli, xhs-cli, yt-dlp, Jina Reader, Exa)는 유료 API key가 필요 없는 무료 도구입니다. 유일한 선택적 비용은 서버에서 Bilibili 접근이 필요한 경우 주거용 프록시(월 ~$1)입니다. Reddit은 프록시 없이 rdt-cli를 통해 무료로 작동합니다.
+100% 무료 오픈 소스입니다. 모든 백엔드(twitter-cli, rdt-cli, OpenCLI, bili-cli, yt-dlp, Jina Reader, Exa)는 유료 API key가 필요 없는 무료 도구입니다. 네트워크에서 특정 사이트가 차단된 경우에만 선택적으로 프록시 비용이 발생할 수 있습니다.
 </details>
 
 <details>
@@ -287,7 +291,7 @@ Agent Reach는 cookie 인증을 통해 Twitter에 접근하는 twitter-cli를 �
 <details>
 <summary><strong>XiaoHongShu / 小红书 콘텐츠를 프로그래밍 방식으로 읽는 방법?</strong></summary>
 
-`pipx install xiaohongshu-cli`를 설치한 다음 `xhs login`(브라우저에서 cookie 자동 추출)을 실행하세요. 에이전트가 `xhs search "query"`로 노트를 검색하고, `xhs read NOTE_ID`로 상세 정보를 읽고, `xhs comments NOTE_ID`로 댓글을 볼 수 있습니다. Docker 불필요.
+Agent Reach는 XiaoHongShu 로그인을 대신 수행하거나 브라우저 cookie를 읽지 않습니다. OpenCLI는 사용자가 이미 보유하고 명시적으로 관리하는 Chrome 세션만 사용합니다. 기존 세션이 없다면 자동 로그인하지 말고 Cookie-Editor로 수동 내보내 xiaohongshu-mcp 또는 기존 도구를 설정하세요. `agent-reach configure xhs-cookies`는 OpenCLI/Chrome에 cookie를 주입하지 않습니다.
 </details>
 
 <details>

--- a/docs/cookie-export.md
+++ b/docs/cookie-export.md
@@ -19,7 +19,19 @@ Here's how to export cookies from your local computer — **fastest method first
 That's it! Your Agent will run:
 ```bash
 agent-reach configure twitter-cookies <your_pasted_string>
+agent-reach configure xhs-cookies <your_pasted_string>
 ```
+
+Twitter values saved by Agent Reach are used by `agent-reach doctor` only to
+check whether explicit credentials are present. Doctor does not run
+`twitter status`. Direct `twitter` commands still require
+`TWITTER_AUTH_TOKEN` and `TWITTER_CT0` in their process environment.
+
+This XiaoHongShu export is for xiaohongshu-mcp or a legacy tool.
+`agent-reach configure xhs-cookies` does not inject cookies into OpenCLI or
+Chrome. OpenCLI may use only an existing Chrome session explicitly controlled
+by the user. Agent Reach never logs the user in or reads XiaoHongShu browser
+cookies.
 
 ### Sites to export:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -143,7 +143,7 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 > 3. 点击插件 → Export → Header String
 > 4. 把导出的字符串发给 Agent
 >
-> **本地电脑用户**也可以用 `agent-reach configure --from-browser chrome` 一键自动提取（支持 Twitter + 小红书 + 雪球）。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
+> Twitter 与小红书只接受用户通过 Cookie-Editor 明确导出的内容，不会自动读取浏览器 Cookie。雪球、Bilibili 可按平台显式导入，例如 `agent-reach configure --from-browser chrome --platform xueqiu`；命令不会扫描或保存其他平台。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
 
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
@@ -195,7 +195,7 @@ agent-reach install --channels opencli
 > 1. 从 https://github.com/xpzouying/xiaohongshu-mcp/releases 下载对应平台 binary 到 `~/.agent-reach/tools/`
 > 2. 启动服务（首次运行会自动下载约 150MB 无头浏览器，耐心等完成）
 > 3. 让用户扫码登录（agent 调 `get_login_qrcode` 工具取二维码）
-> 4. 接入：`mcporter config add xiaohongshu http://localhost:18060/mcp`
+> 4. 接入：`mcporter config add xiaohongshu http://localhost:18060/mcp --scope home`
 > 5. 调用时务必带 `--timeout 120000`
 >
 > **存量用户（xhs-cli）：** 已装好的 xhs-cli 继续作为备选后端工作（上游 2026-03 起停更，不推荐新装）。`xhs login` 自动提取浏览器 Cookie；失败时用 Cookie-Editor 导出后：
@@ -229,10 +229,10 @@ agent-reach install --channels facebook,instagram
 > "雪球需要登录后的 Cookie。请先在 Chrome 里登录 xueqiu.com，然后运行："
 
 ```bash
-agent-reach configure --from-browser chrome
+agent-reach configure --from-browser chrome --platform xueqiu
 ```
 
-> Cookie 会随其他平台一起自动提取。
+> 只会读取并保存雪球需要的最小 Cookie；不会顺带读取其他平台。
 
 **小宇宙播客 / Xiaoyuzhou Podcast (Groq Whisper):**
 > "小宇宙播客转文字已默认安装，只需要一个免费的 Groq API Key。"
@@ -297,7 +297,7 @@ pip install linkedin-scraper-mcp
 > **登录后启动 MCP 服务：**
 > ```bash
 > linkedin-scraper-mcp --transport streamable-http --port 8001
-> mcporter config add linkedin http://localhost:8001/mcp
+> mcporter config add linkedin http://localhost:8001/mcp --scope home
 > ```
 >
 > 详见 https://github.com/stickerdaniel/linkedin-mcp-server

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,11 +96,11 @@ After installing the basics, **ask the user** which additional channels they nee
 >
 > 还有这些可选渠道，你需要哪些？
 >
-> - 🌟 **OpenCLI**（桌面推荐）— 一次安装，小红书/Reddit/Facebook/Instagram/B站字幕/Twitter 备选全解锁（复用浏览器登录态，零配置；只需在 Chrome 商店点一次"添加扩展"）
+> - 🌟 **OpenCLI**（桌面推荐）— 一次安装即可提供 Reddit/Facebook/Instagram/B站字幕/Twitter 备选，并作为小红书桌面后端；小红书只使用用户已有且明确控制的 Chrome 会话
 > - 🐦 **Twitter/X** — 搜推文、看时间线（需要登录 Cookie）
 > - 📈 **雪球** — 股票行情、热门帖子（需要登录 Cookie）
 > - 🎙️ **小宇宙播客** — 音频转文字（需要免费 Groq Key）
-> - 📕 **小红书** — 搜索、阅读、评论（桌面走 OpenCLI；服务器用 xiaohongshu-mcp 扫码）
+> - 📕 **小红书** — 搜索、阅读、评论（OpenCLI 用已有会话；MCP/存量工具用 Cookie-Editor）
 > - 📖 **Reddit** — 搜索和阅读帖子（必须登录态：桌面 OpenCLI 或 rdt-cli + Cookie）
 > - 📘 **Facebook** — 搜索、主页、Feed、群组列表（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📷 **Instagram** — 用户搜索、Profile、用户最近帖子、Explore（桌面走 OpenCLI，复用 Chrome 登录态）
@@ -143,13 +143,23 @@ Some channels need credentials only the user can provide. Based on the doctor ou
 > 3. 点击插件 → Export → Header String
 > 4. 把导出的字符串发给 Agent
 >
-> Twitter 与小红书只接受用户通过 Cookie-Editor 明确导出的内容，不会自动读取浏览器 Cookie。雪球、Bilibili 可按平台显式导入，例如 `agent-reach configure --from-browser chrome --platform xueqiu`；命令不会扫描或保存其他平台。OpenCLI 平台（Reddit、小红书桌面后端、Facebook、Instagram）优先复用 Chrome 登录态，不需要把 Cookie 发给 Agent。
+> Twitter 只接受用户通过 Cookie-Editor 明确导出的内容。Agent Reach 不替用户执行小红书登录，也不读取小红书浏览器 Cookie；小红书 OpenCLI 只使用用户已有且明确控制的 Chrome 会话。没有现成会话时，改用 Cookie-Editor 导出后配置 xiaohongshu-mcp / 存量工具。雪球、Bilibili 可按平台显式导入，例如 `agent-reach configure --from-browser chrome --platform xueqiu`；命令不会扫描或保存其他平台。
 
 **Twitter search & posting:**
 > "To unlock Twitter search, I need your Twitter cookies. Install the Cookie-Editor Chrome extension, go to x.com/twitter.com, click the extension → Export → Header String, and paste it to me."
 
 ```bash
 agent-reach configure twitter-cookies "PASTED_STRING"
+```
+
+这会把 `twitter_auth_token` 和 `twitter_ct0` 保存给 Agent Reach 自己的
+`doctor` 配置检查。`doctor` 不会实时执行上游 `twitter status`，也不会修改
+当前 Shell。直接运行 `twitter search/read/...` 前，必须在该进程环境中显式设置：
+
+```bash
+export TWITTER_AUTH_TOKEN="..."
+export TWITTER_CT0="..."
+twitter search "query" -n 10
 ```
 
 > **代理说明（中国大陆等需要翻墙的网络环境）：**
@@ -179,8 +189,20 @@ rdt login   # 自动提取浏览器 Cookie；服务器无浏览器时按 doctor 
 
 **XiaoHongShu / 小红书（多后端，按环境选）:**
 
+> **认证边界：** Agent Reach 不替用户执行小红书登录，也不读取浏览器
+> Cookie。OpenCLI 只使用用户已经存在且明确控制的 Chrome 会话；
+> `agent-reach configure xhs-cookies` 不会把 Cookie 注入 OpenCLI 或 Chrome。
+> 如果没有现成会话，不要自动登录；改用 Cookie-Editor 手工导出后配置
+> xiaohongshu-mcp 或存量工具：
+>
+> ```bash
+> agent-reach configure xhs-cookies "key1=val1; key2=val2; ..."
+> ```
+>
+> 该显式命令会保存/导入用户提供的 xiaohongshu.com 同域 Cookie 集；请先确认
+> Cookie 名称和范围。非 xiaohongshu.com 域 Cookie 会被忽略。
+>
 > **桌面电脑（推荐 OpenCLI）：**
-> "小红书走 OpenCLI——复用你浏览器里的登录态，平时刷过小红书就直接能用，零配置。"
 
 ```bash
 agent-reach install --channels opencli
@@ -191,17 +213,19 @@ agent-reach install --channels opencli
 > 2. 点「添加至 Chrome」
 > 3. 运行 `opencli doctor` 验证（显示 Extension: connected 即成功）
 >
+> AUTH_REQUIRED 且用户没有现成会话时，不要替用户自动登录；改走下面的
+> xiaohongshu-mcp / 存量工具 Cookie-Editor 路线。
+>
 > **服务器 / 无桌面环境（xiaohongshu-mcp）：**
 > 1. 从 https://github.com/xpzouying/xiaohongshu-mcp/releases 下载对应平台 binary 到 `~/.agent-reach/tools/`
 > 2. 启动服务（首次运行会自动下载约 150MB 无头浏览器，耐心等完成）
-> 3. 让用户扫码登录（agent 调 `get_login_qrcode` 工具取二维码）
+> 3. 按上面的 Cookie-Editor 流程手工导入 Cookie
 > 4. 接入：`mcporter config add xiaohongshu http://localhost:18060/mcp --scope home`
 > 5. 调用时务必带 `--timeout 120000`
 >
-> **存量用户（xhs-cli）：** 已装好的 xhs-cli 继续作为备选后端工作（上游 2026-03 起停更，不推荐新装）。`xhs login` 自动提取浏览器 Cookie；失败时用 Cookie-Editor 导出后：
-> ```bash
-> agent-reach configure xhs-cookies "key1=val1; key2=val2; ..."
-> ```
+> **存量用户（xhs-cli）：** 已装好的 xhs-cli 继续作为备选后端工作
+> （上游 2026-03 起停更，不推荐新装）；认证仍使用上面的 Cookie-Editor
+> 手工导出流程。
 
 **Facebook / Instagram（桌面 OpenCLI）:**
 > 这两个平台走 OpenCLI：复用用户自己的 Chrome 登录态，不保存账号密码，不走 Meta Graph API 审批流。服务器/无桌面环境不推荐支持。
@@ -337,7 +361,7 @@ If the user wants a different agent to handle it, let them choose.
 | `agent-reach doctor` | Show channel status |
 | `agent-reach watch` | Quick health + update check (for scheduled tasks) |
 | `agent-reach check-update` | Check for new versions |
-| `agent-reach configure twitter-cookies "..."` | Unlock Twitter search + posting |
+| `agent-reach configure twitter-cookies "..."` | 保存 Twitter Cookie 供 doctor 检查；直接调用仍需显式环境变量 |
 | `agent-reach configure proxy URL` | 保存代理地址（Agent 访问 Reddit/Twitter 等受限网络时读取它设置 HTTP_PROXY/HTTPS_PROXY，不是自动解锁开关） |
 | `agent-reach configure groq-key gsk_xxx` | Unlock Xiaoyuzhou podcast transcription |
 
@@ -345,7 +369,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 
 | Platform | Upstream Tool | Example |
 |----------|--------------|---------|
-| Twitter/X | `twitter`（备选 `opencli`） | `twitter search "query" -n 10` |
+| Twitter/X | `twitter`（备选 `opencli`） | 设置 `TWITTER_AUTH_TOKEN` / `TWITTER_CT0` 后运行 `twitter search "query" -n 10` |
 | YouTube | `yt-dlp` | `yt-dlp --dump-json URL` |
 | Bilibili | `bili`（字幕走 `opencli`） | `bili search "query" --type video` / `opencli bilibili subtitle BVxxx` |
 | Reddit | `opencli`（备选 `rdt`） | `opencli reddit search "query" -f yaml` / `rdt read POST_ID` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,13 +20,18 @@ agent-reach configure --from-browser chrome --platform xueqiu
 
 **症状：** `twitter search` 或其他命令返回错误
 
-**原因：** twitter-cli 需要 AUTH_TOKEN 和 CT0 环境变量才能访问 Twitter API。如果你的网络环境需要代理才能访问 x.com，需要配置代理。
+**原因：** twitter-cli 需要 `TWITTER_AUTH_TOKEN` 和 `TWITTER_CT0`
+环境变量才能访问 Twitter API。`agent-reach configure twitter-cookies`
+保存的值只供 doctor 检查配置是否齐全；doctor 不执行上游认证，也不会设置当前
+Shell。如果你的网络环境需要代理才能访问 x.com，还需要配置代理。
 
 **解决方案：**
 
 ### 方案 1：设置环境变量代理
 
 ```bash
+export TWITTER_AUTH_TOKEN="..."
+export TWITTER_CT0="..."
 export HTTP_PROXY="http://user:pass@host:port"
 export HTTPS_PROXY="http://user:pass@host:port"
 twitter search "test" -n 1
@@ -56,6 +61,7 @@ mcporter call 'exa.web_search_exa(query: "site:x.com 搜索词", numResults: 5)'
 twitter check
 ```
 
-> 如果返回 "Missing credentials"，需要设置 AUTH_TOKEN 和 CT0 环境变量。
+> 如果返回 "Missing credentials"，需要在运行该命令的进程环境中设置
+> `TWITTER_AUTH_TOKEN` 和 `TWITTER_CT0`。
 >
 > **Fallback：** 如果你已经安装了 bird CLI（`npm install -g @steipete/bird`），它也能正常工作。Agent Reach 会自动检测已安装的工具。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@
 **解决方案：** 在 Chrome 里登录 xueqiu.com，然后运行：
 
 ```bash
-agent-reach configure --from-browser chrome
+agent-reach configure --from-browser chrome --platform xueqiu
 ```
 
 再次运行 `agent-reach doctor` 确认恢复 ✅。Cookie 过期后重新运行即可。

--- a/docs/update.md
+++ b/docs/update.md
@@ -56,7 +56,7 @@ exception: OpenCLI on desktop, see below).
 which twitter >/dev/null 2>&1 && { pipx upgrade twitter-cli 2>/dev/null || uv tool upgrade twitter-cli 2>/dev/null; }
 which bili    >/dev/null 2>&1 && { pipx upgrade bilibili-cli 2>/dev/null || uv tool upgrade bilibili-cli 2>/dev/null; }
 which xhs     >/dev/null 2>&1 && { pipx upgrade xiaohongshu-cli 2>/dev/null || uv tool upgrade xiaohongshu-cli 2>/dev/null; }
-which yt-dlp  >/dev/null 2>&1 && { pipx upgrade yt-dlp 2>/dev/null || uv tool upgrade yt-dlp 2>/dev/null || pip install -U yt-dlp 2>/dev/null; }
+which yt-dlp  >/dev/null 2>&1 && { pipx install --force 'yt-dlp[default]' 2>/dev/null || uv tool install --force 'yt-dlp[default]' 2>/dev/null || python -m pip install -U 'yt-dlp[default]' 2>/dev/null; }
 
 # rdt-cli is pinned to a git source (PyPI lags upstream) — same pin as the code's _RDT_GIT_SOURCE
 which rdt >/dev/null 2>&1 && pipx install --force 'git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66' 2>/dev/null
@@ -67,10 +67,13 @@ which opencli  >/dev/null 2>&1 && npm update -g @jackwener/opencli 2>/dev/null
 ```
 
 **Desktop users without OpenCLI**: since v1.5.0 OpenCLI is the preferred
-backend for 小红书/Reddit (and adds B站 subtitles) by riding the user's
-browser session. Offer it once:
+backend for 小红书/Reddit (and adds B站 subtitles). Offer it once. For
+小红书, OpenCLI may use only an existing Chrome session explicitly controlled
+by the user. The update must never log the user in or read browser cookies:
 
-> "这次更新引入了 OpenCLI 后端（复用你的浏览器登录态，小红书/Reddit 零配置）。要装吗？装完只需你在 Chrome 商店点一次『添加扩展』。"
+> "这次更新引入了 OpenCLI 后端。要装吗？装完只需你在 Chrome 商店点一次
+> 『添加扩展』。小红书 OpenCLI 只使用你已有的 Chrome 会话；如果没有现成
+> 会话，我不会自动登录，会改用 Cookie-Editor 配置 MCP / 存量工具。"
 
 If yes: `agent-reach install --channels opencli` and guide them through the
 extension click. If no, everything keeps working on existing backends.
@@ -110,8 +113,8 @@ Tell the user:
 1. What version they're on now (`agent-reach version`)
 2. How many channels are available, and which backend each multi-backend
    platform is using (from doctor)
-3. Anything that needs their action (e.g. Chrome extension click, `xhs login`,
-   QR scan for xiaohongshu-mcp on servers)
+3. Anything that needs their action (e.g. a Chrome extension click, or a
+   manual Cookie-Editor export when XiaoHongShu uses MCP / a legacy tool)
 4. What changed in this update (release notes shown by `check-update`)
 
 Done.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "loguru>=0.7",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "yt-dlp>=2024.0",
+    "yt-dlp[default]>=2026.07.04",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Suite-wide containment for tests that exercise user-facing installers."""
+
+import pytest
+
+from agent_reach.config import Config
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect every common home/config root before each test runs."""
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home / ".config"))
+    monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
+    monkeypatch.setenv("LOCALAPPDATA", str(home / "AppData" / "Local"))
+    monkeypatch.delenv("OPENCLAW_HOME", raising=False)
+
+    config_dir = home / ".agent-reach"
+    monkeypatch.setattr(Config, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(Config, "CONFIG_FILE", config_dir / "config.yaml")
+    return home

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,14 @@ def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Config, "CONFIG_DIR", config_dir)
     monkeypatch.setattr(Config, "CONFIG_FILE", config_dir / "config.yaml")
     return home
+
+
+@pytest.fixture(autouse=True)
+def isolated_xueqiu_cookie_jar(monkeypatch):
+    """Prevent the module-level Xueqiu session from leaking between tests."""
+    from agent_reach.channels import xueqiu
+
+    xueqiu._cookie_jar.clear()
+    monkeypatch.setattr(xueqiu, "_cookies_initialized", False)
+    yield
+    xueqiu._cookie_jar.clear()

--- a/tests/test_auth_guidance_policy.py
+++ b/tests/test_auth_guidance_policy.py
@@ -1,0 +1,141 @@
+"""Documentation must preserve the project's explicit auth boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _policy_documents() -> list[Path]:
+    documents = list(ROOT.glob("README*.md"))
+    for directory in (
+        ROOT / "docs",
+        ROOT / "agent_reach" / "guides",
+        ROOT / "agent_reach" / "skill",
+    ):
+        documents.extend(directory.rglob("*.md"))
+    return sorted(set(documents))
+
+
+def test_xiaohongshu_guidance_never_starts_implicit_login():
+    """Do not reintroduce QR or automatic browser-cookie login guidance."""
+    xhs_markers = ("xiaohongshu", "小红书", "小紅書", "xhs")
+    legacy_auth_markers = (
+        "扫码",
+        "二维码",
+        "qr login",
+        "qr scan",
+        "qrcode",
+        "ブラウザからcookieを自動抽出",
+        "브라우저에서 cookie 자동 추출",
+    )
+    forbidden_commands = (
+        "xhs " + "login",
+        "get_login_" + "qrcode",
+    )
+
+    violations = []
+    for path in _policy_documents():
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        for command in forbidden_commands:
+            if command in lowered:
+                violations.append(f"{path.relative_to(ROOT)}: {command}")
+        for line_number, line in enumerate(lowered.splitlines(), 1):
+            if not any(marker in line for marker in xhs_markers):
+                continue
+            if any(marker in line for marker in legacy_auth_markers):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}"
+                )
+
+    assert not violations, "\n".join(violations)
+
+
+def test_xiaohongshu_opencli_and_export_boundaries_are_truthful():
+    """Cookie import is for MCP/legacy tools, never OpenCLI or Chrome."""
+    boundary_docs = (
+        ROOT / "docs" / "install.md",
+        ROOT / "agent_reach" / "guides" / "setup-xiaohongshu.md",
+        ROOT / "agent_reach" / "skill" / "references" / "social.md",
+    )
+    for path in boundary_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "已经存在且明确控制" in text, path.relative_to(ROOT)
+        assert "不会把 Cookie 注入 OpenCLI" in text, path.relative_to(ROOT)
+
+    xhs_guide = boundary_docs[1].read_text(encoding="utf-8")
+    assert "xiaohongshu.com 同域 Cookie 集" in xhs_guide
+    assert "非 xiaohongshu.com 域 Cookie" in xhs_guide
+
+
+def test_twitter_operational_docs_explain_the_environment_boundary():
+    """Saved cookies help doctor only; direct twitter commands need env vars."""
+    operational_docs = (
+        ROOT / "README.md",
+        ROOT / "docs" / "README_en.md",
+        ROOT / "docs" / "README_ja.md",
+        ROOT / "docs" / "README_ko.md",
+        ROOT / "docs" / "cookie-export.md",
+        ROOT / "docs" / "install.md",
+        ROOT / "docs" / "troubleshooting.md",
+        ROOT / "agent_reach" / "guides" / "setup-twitter.md",
+        ROOT / "agent_reach" / "skill" / "SKILL.md",
+        ROOT / "agent_reach" / "skill" / "SKILL_en.md",
+        ROOT / "agent_reach" / "skill" / "references" / "social.md",
+    )
+
+    for path in operational_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "TWITTER_AUTH_TOKEN" in text, path.relative_to(ROOT)
+        assert "TWITTER_CT0" in text, path.relative_to(ROOT)
+
+    twitter_guide = (
+        ROOT / "agent_reach" / "guides" / "setup-twitter.md"
+    ).read_text(encoding="utf-8")
+    assert "不会执行 `twitter status`" in twitter_guide
+    assert "不会修改当前 Shell" in twitter_guide
+    assert "Export → Header String" in twitter_guide
+    assert "cookie JSON" not in twitter_guide
+    assert "复制全部" not in twitter_guide
+
+    for expected in (
+        "--sync-legacy-twitter",
+        "~/.agent-reach/config.yaml",
+        "~/.config/xfetch/session.json",
+        "~/.config/bird/credentials.env",
+    ):
+        assert expected in twitter_guide
+    assert "默认只写" in twitter_guide
+    assert "不会自动删除" in twitter_guide
+
+    rendered_as_verified = (
+        "✅ Twitter/X tweets",
+        "✅ Twitter/Xツイート",
+        "✅ Twitter/X 트윗",
+    )
+    all_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in _policy_documents()
+    )
+    assert not any(claim in all_text for claim in rendered_as_verified)
+
+
+def test_localized_readmes_keep_current_bilibili_and_xhs_routes():
+    """Translations must not revive retired yt-dlp/Bilibili or XHS defaults."""
+    readmes = (
+        ROOT / "README.md",
+        ROOT / "docs" / "README_en.md",
+        ROOT / "docs" / "README_ja.md",
+        ROOT / "docs" / "README_ko.md",
+    )
+
+    for path in readmes:
+        text = path.read_text(encoding="utf-8")
+        assert "bilibili.py     → yt-dlp" not in text, path.relative_to(ROOT)
+        assert "YouTube + Bilibili" not in text, path.relative_to(ROOT)
+        assert "bili-cli" in text, path.relative_to(ROOT)
+        assert (
+            "xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli"
+            in text
+        ), path.relative_to(ROOT)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -6,8 +6,11 @@ import shutil
 import subprocess
 from urllib.error import URLError
 
+import pytest
+
 from agent_reach.backends import OpenCLIStatus
 from agent_reach.channels import get_all_channels, get_channel
+from agent_reach.channels.bilibili import BilibiliChannel
 from agent_reach.channels.facebook import FacebookChannel
 from agent_reach.channels.instagram import InstagramChannel
 from agent_reach.channels.v2ex import V2EXChannel
@@ -51,7 +54,9 @@ class TestOpenCLISiteChannels:
         assert ch.can_handle("https://instagr.am/p/abc123/")
         assert not ch.can_handle("https://facebook.com/openai")
 
-    def test_opencli_ready_reports_ok(self, monkeypatch):
+    def test_opencli_bridge_ready_is_unverified_for_login_platform(
+        self, monkeypatch
+    ):
         monkeypatch.setattr(
             "agent_reach.backends.opencli_status",
             lambda: OpenCLIStatus(
@@ -62,10 +67,18 @@ class TestOpenCLISiteChannels:
         )
         ch = FacebookChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "OpenCLI"
-        assert "opencli facebook search/profile/feed/groups -f yaml" in msg
+        assert status == "warn"
+        assert ch.active_backend is None
+        assert "桥接已连接" in msg
+        assert "登录态和实际命令未实时验证" in msg
         assert "facebook.com" in msg
+
+        instagram = InstagramChannel()
+        status, msg = instagram.check()
+        assert status == "warn"
+        assert instagram.active_backend is None
+        assert "桥接已连接" in msg
+        assert "instagram.com" in msg
 
     def test_opencli_missing_reports_off(self, monkeypatch):
         monkeypatch.setattr(
@@ -90,7 +103,7 @@ class TestOpenCLISiteChannels:
         ch = InstagramChannel()
         status, msg = ch.check()
         assert status == "warn"
-        assert ch.active_backend == "OpenCLI"
+        assert ch.active_backend is None
         assert "Chrome 扩展" in msg
 
 
@@ -136,6 +149,46 @@ class TestV2EXChannel:
         status, msg = V2EXChannel().check()
         assert status == "warn"
         assert "失败" in msg
+
+    def test_check_passes_its_read_only_config_to_cookie_loading(self, monkeypatch):
+        """Doctor's config object must flow through instead of reopening config."""
+        import agent_reach.channels.xueqiu as xueqiu_mod
+
+        supplied_config = object()
+        observed = []
+        monkeypatch.setattr(xueqiu_mod, "_cookies_initialized", False)
+
+        def fake_load(config=None):
+            observed.append(config)
+            return False
+
+        fake_response_data = {
+            "data": {"quote": {"symbol": "SH601138", "current": 52.0}}
+        }
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+            def read(self):
+                return json.dumps(fake_response_data).encode()
+
+        monkeypatch.setattr(
+            xueqiu_mod, "_load_cookies_from_config", fake_load
+        )
+        monkeypatch.setattr(
+            xueqiu_mod._opener,
+            "open",
+            lambda req, timeout=None: FakeResponse(),
+        )
+
+        status, _ = XueqiuChannel().check(supplied_config)
+
+        assert status == "ok"
+        assert observed == [supplied_config]
 
     # ------------------------------------------------------------------ #
     # get_hot_topics
@@ -670,7 +723,12 @@ class TestXueqiuChannel:
         monkeypatch.setattr(
             xq_mod,
             "_load_cookies_from_config",
-            lambda: (xq_mod._inject_cookie_string("xq_a_token=TESTTOKEN; xq_is_login=1") or True),
+            lambda config=None: (
+                xq_mod._inject_cookie_string(
+                    "xq_a_token=TESTTOKEN; xq_is_login=1"
+                )
+                or True
+            ),
         )
 
         # Patch opener so no real HTTP call is made
@@ -690,7 +748,11 @@ class TestXueqiuChannel:
         import agent_reach.channels.xueqiu as xueqiu_mod
 
         monkeypatch.setattr(xueqiu_mod, "_cookies_initialized", False)
-        monkeypatch.setattr(xueqiu_mod, "_load_cookies_from_config", lambda: False)
+        monkeypatch.setattr(
+            xueqiu_mod,
+            "_load_cookies_from_config",
+            lambda config=None: False,
+        )
         requested = []
 
         class FakeResponse:
@@ -701,8 +763,6 @@ class TestXueqiuChannel:
             "open",
             lambda req, timeout=None: requested.append(req.full_url) or FakeResponse(),
         )
-        assert {cookie.name for cookie in xueqiu_mod._cookie_jar} == {"xq_a_token"}
-
         xueqiu_mod._ensure_cookies()
 
         assert requested == ["https://xueqiu.com"]
@@ -762,98 +822,47 @@ class TestRedditChannel:
         assert status == "ok"
         assert ch.active_backend == "OpenCLI"
 
-    def test_reports_ok_when_authenticated(self, monkeypatch):
+    def test_saved_rdt_cookie_is_unverified_not_active(
+        self, monkeypatch, isolated_home
+    ):
         self._isolate(monkeypatch)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-        fake_output = json.dumps({
-            "ok": True,
-            "schema_version": "1",
-            "data": {"authenticated": True, "username": "testuser", "cookie_count": 1},
-        })
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, fake_output, "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        from agent_reach.channels.reddit import RedditChannel
-        ch = RedditChannel()
-        status, msg = ch.check()
-        assert status == "ok"
-        assert "testuser" in msg
-        assert ch.active_backend == "rdt-cli"
-
-    def test_reports_warn_when_not_authenticated(self, monkeypatch):
-        self._isolate(monkeypatch)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-        fake_output = json.dumps({
-            "ok": True,
-            "schema_version": "1",
-            "data": {"authenticated": False, "username": None, "cookie_count": 0},
-        })
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, fake_output, "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        credential_path = (
+            isolated_home / ".config" / "rdt-cli" / "credential.json"
+        )
+        credential_path.parent.mkdir(parents=True)
+        credential_path.write_text(
+            json.dumps(
+                {
+                    "cookies": {"reddit_session": "explicit"},
+                    "saved_at": __import__("time").time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute rdt status"
+            ),
+        )
         from agent_reach.channels.reddit import RedditChannel
         ch = RedditChannel()
         status, msg = ch.check()
         assert status == "warn"
-        assert "403" in msg
-        assert "rdt login" in msg
+        assert "未实时验证" in msg
+        assert ch.active_backend is None
+
+    def test_reports_warn_when_cookie_is_missing(self, monkeypatch):
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
+        from agent_reach.channels.reddit import RedditChannel
+        ch = RedditChannel()
+        status, msg = ch.check()
+        assert status == "warn"
         assert "Cookie-Editor" in msg
         assert "chromewebstore.google.com" in msg
-        # 未登录是业务态：进程活着，后端仍然算可用
-        assert ch.active_backend == "rdt-cli"
-
-    def test_reports_error_when_status_check_fails(self, monkeypatch):
-        """rdt 非零退出且输出不可解析 → 工具异常（error），不再算 warn。"""
-        self._isolate(monkeypatch)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "not valid json{{{", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        from agent_reach.channels.reddit import RedditChannel
-        ch = RedditChannel()
-        status, msg = ch.check()
-        assert status == "error"
-        assert "rdt 异常退出" in msg
-        assert ch.active_backend is None
-
-    def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
-        self._isolate(monkeypatch)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-
-        def fake_run(cmd, **kwargs):
-            raise FileNotFoundError("/usr/local/bin/rdt")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        from agent_reach.channels.reddit import RedditChannel
-        ch = RedditChannel()
-        status, msg = ch.check()
-        assert status == "error"
-        assert "无法执行" in msg
-        assert "pipx install --force" in msg  # rdt 专用 git 源重装处方
-        assert "git+https://github.com/public-clis/rdt-cli.git" in msg
-        assert ch.active_backend is None
-
-    def test_reports_error_with_reinstall_hint_on_exit_127(self, monkeypatch):
-        """退出码 127（找到但跑不动）同样按断链处理。"""
-        self._isolate(monkeypatch)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/rdt")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 127, "", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        from agent_reach.channels.reddit import RedditChannel
-        ch = RedditChannel()
-        status, msg = ch.check()
-        assert status == "error"
-        assert "pipx install --force" in msg
         assert ch.active_backend is None
 
     def test_can_handle_reddit_urls(self):
@@ -883,20 +892,69 @@ class TestXiaoHongShuChannel:
             xhs_mod, "_mcp_service_reachable", lambda timeout=3: mcp_reachable
         )
 
-    def test_reports_ok_when_cli_authenticated(self, monkeypatch):
+    def test_opencli_bridge_ready_is_unverified(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent_reach.backends.opencli_status",
+            lambda: OpenCLIStatus(
+                installed=True,
+                extension_connected=True,
+                version="1.8.6",
+            ),
+        )
+
+        status, message = XiaoHongShuChannel()._check_opencli()
+
+        assert status == "warn"
+        assert "桥接已连接" in message
+        assert "登录态和实际命令未实时验证" in message
+
+    def test_saved_cli_cookie_is_unverified_not_active(
+        self, monkeypatch, isolated_home
+    ):
         self._isolate(monkeypatch)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "ok: true\nusername: testuser\n", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        cookie_path = isolated_home / ".xiaohongshu-cli" / "cookies.json"
+        cookie_path.parent.mkdir()
+        cookie_path.write_text(
+            json.dumps(
+                {"a1": "explicit", "saved_at": __import__("time").time()}
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute xhs status"
+            ),
+        )
 
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert "xhs-cli 可用" in msg
-        assert ch.active_backend == "xhs-cli (xiaohongshu-cli)"
+        assert status == "warn"
+        assert "未实时验证" in msg
+        assert ch.active_backend is None
+
+    def test_saved_cli_cookie_refuses_ancestor_symlink(
+        self, monkeypatch, isolated_home
+    ):
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
+        victim_dir = isolated_home / "victim-xhs"
+        victim_dir.mkdir()
+        (victim_dir / "cookies.json").write_text(
+            json.dumps({"a1": "do-not-read"}),
+            encoding="utf-8",
+        )
+        (isolated_home / ".xiaohongshu-cli").symlink_to(
+            victim_dir,
+            target_is_directory=True,
+        )
+
+        status, message = XiaoHongShuChannel()._check_xhs_cli()
+
+        assert status == "warn"
+        assert "符号链接" in message
 
     def test_reports_warn_when_not_authenticated(self, monkeypatch):
         self._isolate(monkeypatch)
@@ -910,9 +968,9 @@ class TestXiaoHongShuChannel:
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
         assert status == "warn"
-        assert "xhs login" in msg
-        # 未登录是业务态：工具进程活着，后端仍可用
-        assert ch.active_backend == "xhs-cli (xiaohongshu-cli)"
+        assert "Cookie-Editor" in msg
+        assert "configure xhs-cookies" in msg
+        assert ch.active_backend is None
 
     def test_reports_off_when_nothing_installed(self, monkeypatch):
         self._isolate(monkeypatch)
@@ -923,24 +981,6 @@ class TestXiaoHongShuChannel:
         # off 指引推荐当代后端，而非停更的 xhs-cli
         assert "opencli" in msg
         assert "xiaohongshu-mcp" in msg
-        assert ch.active_backend is None
-
-    def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
-        self._isolate(monkeypatch)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
-
-        def fake_run(cmd, **kwargs):
-            raise FileNotFoundError("/usr/local/bin/xhs")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-
-        ch = XiaoHongShuChannel()
-        status, msg = ch.check()
-        assert status == "error"
-        assert "无法执行" in msg
-        assert "uv tool install --force xiaohongshu-cli" in msg
-        assert "pipx reinstall xiaohongshu-cli" in msg
         assert ch.active_backend is None
 
     def test_opencli_ready_wins_over_cli(self, monkeypatch):
@@ -958,8 +998,9 @@ class TestXiaoHongShuChannel:
         assert status == "ok"
         assert ch.active_backend == "OpenCLI"
 
-    def test_opencli_warn_loses_to_usable_cli(self, monkeypatch):
-        """OpenCLI 装了但扩展未连（warn）时，完整可用的 xhs-cli 获胜。"""
+    def test_opencli_warn_remains_first_when_cli_is_only_unverified(
+        self, monkeypatch
+    ):
         self._isolate(monkeypatch, opencli=("warn", "扩展未连接"))
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
@@ -970,50 +1011,150 @@ class TestXiaoHongShuChannel:
 
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "xhs-cli (xiaohongshu-cli)"
+        assert status == "warn"
+        assert msg == "扩展未连接"
+        assert ch.active_backend is None
 
-    def test_mcp_service_wins_when_opencli_absent(self, monkeypatch):
+    def test_mcp_service_wins_when_opencli_absent(
+        self, monkeypatch, tmp_path
+    ):
         """服务器场景：OpenCLI 未装、mcp 服务可达且 mcporter 已接入 → mcp 获胜。"""
         self._isolate(monkeypatch, mcp_reachable=True)
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"xiaohongshu": {"baseUrl": "http://local"}},
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
 
         def fake_which(name):
             return "/usr/local/bin/mcporter" if name == "mcporter" else None
 
         monkeypatch.setattr(shutil, "which", fake_which)
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa\nxiaohongshu\n", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
 
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "xiaohongshu-mcp"
-        assert "search_feeds" in msg
+        assert status == "warn"
+        assert ch.active_backend is None
+        assert "未验证登录态" in msg
 
-    def test_mcp_reachable_but_mcporter_unconfigured_warns(self, monkeypatch):
+    def test_mcp_reachable_but_mcporter_unconfigured_warns(
+        self, monkeypatch, tmp_path
+    ):
         self._isolate(monkeypatch, mcp_reachable=True)
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"exa": {"baseUrl": "https://example.test"}},
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
 
         def fake_which(name):
             return "/usr/local/bin/mcporter" if name == "mcporter" else None
 
         monkeypatch.setattr(shutil, "which", fake_which)
 
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa\n", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
 
         ch = XiaoHongShuChannel()
         status, msg = ch.check()
         assert status == "warn"
         assert "mcporter config add xiaohongshu" in msg
-        assert ch.active_backend == "xiaohongshu-mcp"
+        assert ch.active_backend is None
 
-    def test_backend_override_prefers_cli(self, monkeypatch):
-        """config xiaohongshu_backend=xhs-cli 时，即使 OpenCLI ready 也用 xhs-cli。"""
+    def test_mcp_metadata_containing_xiaohongshu_is_not_configured(
+        self, monkeypatch, tmp_path
+    ):
+        """Paths and URLs are not valid server-name health signals."""
+        self._isolate(monkeypatch, mcp_reachable=True)
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "unrelated": {
+                            "baseUrl": "http://xiaohongshu-project.test/mcp"
+                        }
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            shutil,
+            "which",
+            lambda name: "/usr/local/bin/mcporter"
+            if name == "mcporter"
+            else None,
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
+
+        ch = XiaoHongShuChannel()
+        status, message = ch.check()
+
+        assert status == "warn"
+        assert "未接入" in message
+        assert ch.active_backend is None
+
+    def test_all_xhs_auth_hints_exclude_qr_and_automatic_cookie_read(
+        self, monkeypatch
+    ):
+        """XHS remediation must remain on the explicit Cookie-Editor path."""
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 1, "", "not_authenticated"
+            ),
+        )
+
+        status, message = XiaoHongShuChannel().check()
+
+        assert status == "warn"
+        assert "Cookie-Editor" in message
+        assert "configure xhs-cookies" in message
+        assert "扫码" not in message
+        assert "自动从浏览器" not in message
+
+    def test_unverified_cli_override_cannot_hide_working_opencli(
+        self, monkeypatch
+    ):
         self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用"))
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/xhs")
 
@@ -1029,7 +1170,7 @@ class TestXiaoHongShuChannel:
         ch = XiaoHongShuChannel()
         status, _ = ch.check(_Cfg())
         assert status == "ok"
-        assert ch.active_backend == "xhs-cli (xiaohongshu-cli)"
+        assert ch.active_backend == "OpenCLI"
 
 
 class TestBilibiliChannel:
@@ -1060,6 +1201,22 @@ class TestBilibiliChannel:
         assert status == "ok"
         assert "bili-cli 可用" in msg
         assert ch.active_backend == "bili-cli"
+
+    def test_opencli_bridge_ready_is_unverified(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent_reach.backends.opencli_status",
+            lambda: OpenCLIStatus(
+                installed=True,
+                extension_connected=True,
+                version="1.8.6",
+            ),
+        )
+
+        status, message = BilibiliChannel()._check_opencli()
+
+        assert status == "warn"
+        assert "桥接已连接" in message
+        assert "实际命令未实时验证" in message
 
     def test_bili_broken_falls_back_to_api_with_hint_kept(self, monkeypatch):
         """bili 断链 → API 兜底获胜，但重装处方必须保留在消息里。"""
@@ -1099,14 +1256,32 @@ class TestBilibiliChannel:
         assert "uv tool install --force bilibili-cli" in msg
         assert ch.active_backend is None
 
-    def test_opencli_serves_when_bili_missing(self, monkeypatch):
-        self._isolate(monkeypatch, opencli=("ok", "OpenCLI 可用（字幕）"), api_ok=True)
+    def test_unverified_opencli_falls_back_to_verified_api(self, monkeypatch):
+        self._isolate(
+            monkeypatch,
+            opencli=("warn", "OpenCLI 桥接已连接但未验证"),
+            api_ok=True,
+        )
         monkeypatch.setattr(shutil, "which", lambda _: None)
         from agent_reach.channels.bilibili import BilibiliChannel
         ch = BilibiliChannel()
         status, msg = ch.check()
         assert status == "ok"
-        assert ch.active_backend == "OpenCLI"
+        assert ch.active_backend == "B站搜索 API"
+
+    def test_unverified_opencli_alone_has_no_active_backend(self, monkeypatch):
+        self._isolate(
+            monkeypatch,
+            opencli=("warn", "OpenCLI 桥接已连接但未验证"),
+            api_ok=False,
+        )
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+
+        ch = BilibiliChannel()
+        status, _ = ch.check()
+
+        assert status == "warn"
+        assert ch.active_backend is None
 
     def test_api_only_still_ok_with_install_nudge(self, monkeypatch):
         self._isolate(monkeypatch, api_ok=True)
@@ -1148,10 +1323,11 @@ class TestYouTubeChannel:
 
 class TestGitHubChannel:
     def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """gh which 命中但 exec 失败 → error + brew 重装处方（gh 不是 pip 包）。"""
+        """gh --version 断链时给出二进制重装处方。"""
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
 
         def fake_run(cmd, **kwargs):
+            assert cmd[-1:] == ["--version"]
             raise FileNotFoundError(cmd[0])
 
         monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1163,25 +1339,40 @@ class TestGitHubChannel:
         assert "brew reinstall gh" in msg
         assert ch.active_backend is None
 
-    def test_active_backend_set_when_authenticated(self, monkeypatch):
+    def test_explicit_auth_is_unverified_and_never_marked_active(
+        self, monkeypatch
+    ):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
+        monkeypatch.setenv("GH_TOKEN", "configured-secret")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "Logged in to github.com", "")
+            assert cmd[-1:] == ["--version"]
+            assert "auth" not in cmd
+            assert kwargs["env"]["GH_TELEMETRY"] == "false"
+            assert kwargs["env"]["DO_NOT_TRACK"] == "true"
+            return subprocess.CompletedProcess(cmd, 0, "gh version 2.92.0", "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.github import GitHubChannel
         ch = GitHubChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "gh CLI"
+        assert status == "warn"
+        assert "显式认证配置" in msg
+        assert "configured-secret" not in msg
+        assert ch.active_backend is None
 
-    def test_active_backend_set_when_unauthenticated(self, monkeypatch):
-        """gh auth status 非零退出是正常业务态（未登录）：warn 但后端可用。"""
+    def test_no_auth_metadata_remains_warn_and_inactive(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 1, "", "You are not logged in")
+            assert cmd[-1:] == ["--version"]
+            assert "auth" not in cmd
+            return subprocess.CompletedProcess(cmd, 0, "gh version 2.92.0", "")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.github import GitHubChannel
@@ -1189,61 +1380,146 @@ class TestGitHubChannel:
         status, msg = ch.check()
         assert status == "warn"
         assert "gh auth login" in msg
-        assert ch.active_backend == "gh CLI"
+        assert ch.active_backend is None
+
+    def test_hosts_metadata_is_read_without_exposing_token(
+        self, monkeypatch, isolated_home
+    ):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        hosts = isolated_home / ".config" / "gh" / "hosts.yml"
+        hosts.parent.mkdir(parents=True)
+        hosts.write_text(
+            "github.com:\n"
+            "  user: alice\n"
+            "  oauth_token: super-secret-token\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 0, "gh version 2.92.0", ""
+            ),
+        )
+
+        from agent_reach.channels.github import GitHubChannel
+
+        status, message = GitHubChannel().check()
+
+        assert status == "warn"
+        assert "显式认证配置" in message
+        assert "alice" not in message
+        assert "super-secret-token" not in message
+
+    def test_hosts_metadata_refuses_ancestor_symlink(
+        self, monkeypatch, isolated_home
+    ):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/gh")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        real_config = isolated_home / "real-config"
+        hosts = real_config / "gh" / "hosts.yml"
+        hosts.parent.mkdir(parents=True)
+        hosts.write_text(
+            "github.com:\n  oauth_token: do-not-read\n",
+            encoding="utf-8",
+        )
+        (isolated_home / ".config").symlink_to(
+            real_config,
+            target_is_directory=True,
+        )
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 0, "gh version 2.92.0", ""
+            ),
+        )
+
+        from agent_reach.channels.github import GitHubChannel
+
+        channel = GitHubChannel()
+        status, message = channel.check()
+
+        assert status == "warn"
+        assert "无法安全确认" in message
+        assert "do-not-read" not in message
+        assert channel.active_backend is None
 
 
 class TestLinkedInChannel:
-    def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """mcporter which 命中但 exec 失败 → error + npm 重装处方。"""
+    def test_mcporter_is_never_executed(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            raise FileNotFoundError(cmd[0])
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
         from agent_reach.channels.linkedin import LinkedInChannel
         ch = LinkedInChannel()
         status, msg = ch.check()
-        assert status == "error"
-        assert "npm install -g mcporter" in msg
+        assert status == "off"
         assert ch.active_backend is None
 
-    def test_active_backend_set_when_linkedin_configured(self, monkeypatch):
+    def test_configured_linkedin_is_not_false_positive_active(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "linkedin-scraper": {"command": "linkedin-mcp"}
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            assert cmd[-3:] == ["config", "list", "--json"]
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                json.dumps({"servers": [{"name": "linkedin-scraper"}]}),
-                "",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
         from agent_reach.channels.linkedin import LinkedInChannel
         ch = LinkedInChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "linkedin-scraper-mcp"
+        assert status == "warn"
+        assert "未启动" in msg
+        assert ch.active_backend is None
 
-    def test_config_path_containing_linkedin_is_not_a_backend(self, monkeypatch):
+    def test_config_metadata_containing_linkedin_is_not_a_backend(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "unrelated": {
+                            "baseUrl": "http://linkedin-project.test/mcp"
+                        }
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            payload = {
-                "servers": [
-                    {
-                        "name": "unrelated",
-                        "source": {
-                            "path": "/tmp/linkedin-project/config/mcporter.json",
-                        },
-                    }
-                ]
-            }
-            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
 
         ch = LinkedInChannel()
@@ -1251,18 +1527,22 @@ class TestLinkedInChannel:
         assert status == "off"
         assert ch.active_backend is None
 
-    def test_off_without_backend_when_linkedin_not_configured(self, monkeypatch):
+    def test_off_without_backend_when_linkedin_not_configured(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {"exa": {"baseUrl": "https://example.test"}},
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                json.dumps({"servers": [{"name": "exa"}]}),
-                "",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
         ch = LinkedInChannel()
         status, msg = ch.check()
@@ -1271,57 +1551,67 @@ class TestLinkedInChannel:
 
 
 class TestExaSearchChannel:
-    def test_reports_error_with_reinstall_hint_when_broken(self, monkeypatch):
-        """mcporter which 命中但 exec 失败 → error + npm 重装处方。"""
+    def test_mcporter_is_never_executed(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            raise FileNotFoundError(cmd[0])
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
+            ),
+        )
         from agent_reach.channels.exa_search import ExaSearchChannel
         ch = ExaSearchChannel()
         status, msg = ch.check()
-        assert status == "error"
-        assert "npm install -g mcporter" in msg
+        assert status == "off"
         assert ch.active_backend is None
 
-    def test_active_backend_set_when_exa_configured(self, monkeypatch):
+    def test_configured_exa_is_not_false_positive_active(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "exa": {"baseUrl": "https://mcp.example.test"}
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            assert cmd[-3:] == ["config", "list", "--json"]
-            return subprocess.CompletedProcess(
-                cmd,
-                0,
-                json.dumps({"servers": [{"name": "exa"}]}),
-                "",
-            )
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.exa_search import ExaSearchChannel
         ch = ExaSearchChannel()
         status, msg = ch.check()
-        assert status == "ok"
-        assert ch.active_backend == "Exa via mcporter"
+        assert status == "warn"
+        assert "未启动" in msg
+        assert ch.active_backend is None
 
-    def test_config_path_containing_exa_is_not_a_backend(self, monkeypatch):
+    def test_config_metadata_containing_exa_is_not_a_backend(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "unrelated": {
+                            "baseUrl": "https://example.test/exa-project"
+                        }
+                    },
+                    "imports": [],
+                }
+            ),
+            encoding="utf-8",
+        )
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
-
-        def fake_run(cmd, **kwargs):
-            payload = {
-                "servers": [
-                    {
-                        "name": "unrelated",
-                        "source": {
-                            "path": "/tmp/example-project/config/mcporter.json",
-                        },
-                    }
-                ]
-            }
-            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.exa_search import ExaSearchChannel
 
         ch = ExaSearchChannel()
@@ -1330,17 +1620,18 @@ class TestExaSearchChannel:
         assert ch.active_backend is None
 
     def test_invalid_mcporter_json_is_reported_as_error_not_unconfigured(
-        self, monkeypatch
+        self, monkeypatch, tmp_path
     ):
+        monkeypatch.chdir(tmp_path)
+        config_path = tmp_path / "config" / "mcporter.json"
+        config_path.parent.mkdir()
+        config_path.write_text("not-json", encoding="utf-8")
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
         monkeypatch.setattr(
             subprocess,
             "run",
-            lambda cmd, **kwargs: subprocess.CompletedProcess(
-                cmd,
-                0,
-                "Project config: /tmp/example/config/mcporter.json",
-                "",
+            lambda *_args, **_kwargs: pytest.fail(
+                "Doctor must not execute mcporter"
             ),
         )
         from agent_reach.channels.exa_search import ExaSearchChannel

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -701,6 +701,7 @@ class TestXueqiuChannel:
             "open",
             lambda req, timeout=None: requested.append(req.full_url) or FakeResponse(),
         )
+        assert {cookie.name for cookie in xueqiu_mod._cookie_jar} == {"xq_a_token"}
 
         xueqiu_mod._ensure_cookies()
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1211,7 +1211,13 @@ class TestLinkedInChannel:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "linkedin  http://localhost:3000/mcp", "")
+            assert cmd[-3:] == ["config", "list", "--json"]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                json.dumps({"servers": [{"name": "linkedin-scraper"}]}),
+                "",
+            )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
@@ -1220,11 +1226,40 @@ class TestLinkedInChannel:
         assert status == "ok"
         assert ch.active_backend == "linkedin-scraper-mcp"
 
+    def test_config_path_containing_linkedin_is_not_a_backend(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            payload = {
+                "servers": [
+                    {
+                        "name": "unrelated",
+                        "source": {
+                            "path": "/tmp/linkedin-project/config/mcporter.json",
+                        },
+                    }
+                ]
+            }
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.linkedin import LinkedInChannel
+
+        ch = LinkedInChannel()
+        status, _ = ch.check()
+        assert status == "off"
+        assert ch.active_backend is None
+
     def test_off_without_backend_when_linkedin_not_configured(self, monkeypatch):
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa  https://mcp.exa.ai/mcp", "")
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                json.dumps({"servers": [{"name": "exa"}]}),
+                "",
+            )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.linkedin import LinkedInChannel
@@ -1254,7 +1289,13 @@ class TestExaSearchChannel:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
 
         def fake_run(cmd, **kwargs):
-            return subprocess.CompletedProcess(cmd, 0, "exa  https://mcp.exa.ai/mcp", "")
+            assert cmd[-3:] == ["config", "list", "--json"]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                json.dumps({"servers": [{"name": "exa"}]}),
+                "",
+            )
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         from agent_reach.channels.exa_search import ExaSearchChannel
@@ -1262,6 +1303,52 @@ class TestExaSearchChannel:
         status, msg = ch.check()
         assert status == "ok"
         assert ch.active_backend == "Exa via mcporter"
+
+    def test_config_path_containing_exa_is_not_a_backend(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+
+        def fake_run(cmd, **kwargs):
+            payload = {
+                "servers": [
+                    {
+                        "name": "unrelated",
+                        "source": {
+                            "path": "/tmp/example-project/config/mcporter.json",
+                        },
+                    }
+                ]
+            }
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        from agent_reach.channels.exa_search import ExaSearchChannel
+
+        ch = ExaSearchChannel()
+        status, _ = ch.check()
+        assert status == "off"
+        assert ch.active_backend is None
+
+    def test_invalid_mcporter_json_is_reported_as_error_not_unconfigured(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(shutil, "which", lambda _: "/usr/local/bin/mcporter")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd,
+                0,
+                "Project config: /tmp/example/config/mcporter.json",
+                "",
+            ),
+        )
+        from agent_reach.channels.exa_search import ExaSearchChannel
+
+        ch = ExaSearchChannel()
+        status, message = ch.check()
+        assert status == "error"
+        assert "JSON" in message
+        assert ch.active_backend is None
 
 
 class TestXiaoyuzhouChannel:

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -406,9 +406,12 @@ class TestXueqiuChannel:
 
         fake_response_data = {
             "data": {
-                "items": [
-                    {"quote": {"symbol": "SH000001", "name": "上证指数", "current": 3200.0}}
-                ]
+                "quote": {
+                    "symbol": "SH601138",
+                    "name": "工业富联",
+                    "current": 52.0,
+                    "pe_ttm": 38.1,
+                }
             }
         }
 
@@ -451,27 +454,26 @@ class TestXueqiuChannel:
 
         fake_data = {
             "data": {
-                "items": [
-                    {
-                        "quote": {
-                            "symbol": "SH600519",
-                            "name": "贵州茅台",
-                            "current": 1800.0,
-                            "percent": 1.5,
-                            "chg": 26.6,
-                            "high": 1810.0,
-                            "low": 1770.0,
-                            "open": 1775.0,
-                            "last_close": 1773.4,
-                            "volume": 12345678,
-                            "amount": 22000000000,
-                            "market_capital": 2260000000000,
-                            "turnover_rate": 0.098,
-                            "pe_ttm": 30.5,
-                            "timestamp": 1700000000000,
-                        }
-                    }
-                ]
+                "quote": {
+                    "symbol": "SH600519",
+                    "name": "贵州茅台",
+                    "current": 1800.0,
+                    "percent": 1.5,
+                    "chg": 26.6,
+                    "high": 1810.0,
+                    "low": 1770.0,
+                    "open": 1775.0,
+                    "last_close": 1773.4,
+                    "volume": 12345678,
+                    "amount": 22000000000,
+                    "market_capital": 2260000000000,
+                    "turnover_rate": 0.098,
+                    "pe_ttm": 30.5,
+                    "pe_forecast": 25.2,
+                    "pb": 8.5,
+                    "eps": 59.0,
+                    "timestamp": 1700000000000,
+                }
             }
         }
 
@@ -670,7 +672,6 @@ class TestXueqiuChannel:
             "_load_cookies_from_config",
             lambda: (xq_mod._inject_cookie_string("xq_a_token=TESTTOKEN; xq_is_login=1") or True),
         )
-        monkeypatch.setattr(xq_mod, "_load_cookies_from_browser", lambda: False)
 
         # Patch opener so no real HTTP call is made
         class FakeResp:
@@ -685,34 +686,26 @@ class TestXueqiuChannel:
         cookie_names = {c.name for c in xq_mod._cookie_jar}
         assert "xq_a_token" in cookie_names
 
-    def test_load_cookies_from_browser_rookiepy_path(self, monkeypatch):
-        import sys
-        import types
-
+    def test_ensure_cookies_uses_public_homepage_fallback(self, monkeypatch):
         import agent_reach.channels.xueqiu as xueqiu_mod
 
-        xueqiu_mod._cookie_jar.clear()
-        fake_rookiepy = types.SimpleNamespace(
-            chrome=lambda domains=None: [
-                {
-                    "name": "xq_a_token",
-                    "value": "TOKEN_FROM_BROWSER",
-                    "domain": ".xueqiu.com",
-                },
-                {
-                    "name": "xq_is_login",
-                    "value": "1",
-                    "domain": ".xueqiu.com",
-                },
-            ]
-        )
-        monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+        monkeypatch.setattr(xueqiu_mod, "_cookies_initialized", False)
+        monkeypatch.setattr(xueqiu_mod, "_load_cookies_from_config", lambda: False)
+        requested = []
 
-        assert xueqiu_mod._load_cookies_from_browser() is True
-        assert any(
-            cookie.name == "xq_a_token" and cookie.value == "TOKEN_FROM_BROWSER"
-            for cookie in xueqiu_mod._cookie_jar
+        class FakeResponse:
+            pass
+
+        monkeypatch.setattr(
+            xueqiu_mod._opener,
+            "open",
+            lambda req, timeout=None: requested.append(req.full_url) or FakeResponse(),
         )
+
+        xueqiu_mod._ensure_cookies()
+
+        assert requested == ["https://xueqiu.com"]
+        assert xueqiu_mod._cookies_initialized is True
 
     def test_get_json_sends_referer_and_browser_ua(self, monkeypatch):
         """_get_json() must send Referer and a browser-like User-Agent."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ class TestCLI:
         assert "Agent Reach" in captured.out
         assert "✅" in captured.out
 
-    def test_doctor_preserves_existing_skill_install(self, monkeypatch, tmp_path, capsys):
+    def test_doctor_never_touches_existing_skill_install(self, monkeypatch, tmp_path, capsys):
         skill_dir = tmp_path / ".agents" / "skills" / "agent-reach"
         skill_dir.mkdir(parents=True)
         skill_file = skill_dir / "SKILL.md"
@@ -58,8 +58,9 @@ class TestCLI:
 
         assert skill_file.read_text(encoding="utf-8") == custom_content
         out = capsys.readouterr().out
-        assert "preserving existing files" in out
-        assert f"Skill installed for Agent: {skill_dir}" not in out
+        assert "report" in out
+        assert "Skill installed" not in out
+        assert "preserving existing files" not in out
 
     def test_transcribe_command_prints_text(self, capsys):
         with patch("agent_reach.transcribe.transcribe", return_value="hello transcript"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,34 +115,34 @@ class TestCLI:
         assert auth_token == "token123"
         assert ct0 == "ct0abc"
 
-    def test_twitter_config_verification_preserves_existing_env_priority(
+    def test_twitter_config_does_not_run_unsafe_verification_or_mutate_env(
         self, monkeypatch, capsys
     ):
         monkeypatch.setenv("TWITTER_AUTH_TOKEN", "shell-auth")
         monkeypatch.setenv("TWITTER_CT0", "shell-ct0")
         monkeypatch.setattr(shutil, "which", lambda name: "/bin/twitter")
-        calls = []
-
-        def fake_run(cmd, **kwargs):
-            calls.append((cmd, kwargs))
-            return subprocess.CompletedProcess(cmd, 0, "ok: true\n", "")
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "configure must not execute twitter status"
+            ),
+        )
 
         cli._cmd_configure(
             Namespace(
                 from_browser=None,
                 key="twitter-cookies",
                 value=["saved-auth", "saved-ct0"],
+                sync_legacy_twitter=False,
             )
         )
 
-        child_env = calls[0][1]["env"]
-        assert child_env["TWITTER_AUTH_TOKEN"] == "shell-auth"
-        assert child_env["TWITTER_CT0"] == "shell-ct0"
+        output = capsys.readouterr().out
+        assert "未实时验证" in output
+        assert "不会执行 `twitter status`" in output
         assert cli.os.environ["TWITTER_AUTH_TOKEN"] == "shell-auth"
         assert cli.os.environ["TWITTER_CT0"] == "shell-ct0"
-        assert "Twitter access works" in capsys.readouterr().out
 
     def test_install_rdt_cli_prefers_github_source(self, monkeypatch, capsys):
         state = {"rdt_installed": False}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,13 +30,30 @@ class TestCLI:
         assert exc_info.value.code == 0
 
     def test_doctor_runs(self, capsys):
-        with patch("sys.argv", ["agent-reach", "doctor"]):
+        with patch(
+            "agent_reach.doctor.check_all",
+            return_value={
+                "web": {
+                    "status": "ok",
+                    "name": "网页",
+                    "message": "可用",
+                    "tier": 0,
+                    "backends": ["Jina Reader"],
+                    "active_backend": "Jina Reader",
+                }
+            },
+        ), patch(
+            "agent_reach.doctor.format_report",
+            return_value="Agent Reach\n✅ 网页可用",
+        ), patch("sys.argv", ["agent-reach", "doctor"]):
             main()
         captured = capsys.readouterr()
         assert "Agent Reach" in captured.out
         assert "✅" in captured.out
 
-    def test_doctor_never_touches_existing_skill_install(self, monkeypatch, tmp_path, capsys):
+    def test_doctor_is_read_only_and_never_installs_skill(
+        self, monkeypatch, tmp_path, capsys
+    ):
         skill_dir = tmp_path / ".agents" / "skills" / "agent-reach"
         skill_dir.mkdir(parents=True)
         skill_file = skill_dir / "SKILL.md"
@@ -53,14 +70,23 @@ class TestCLI:
         monkeypatch.setattr(Config, "CONFIG_FILE", config_dir / "config.yaml")
         monkeypatch.setattr("agent_reach.doctor.check_all", lambda config: {})
         monkeypatch.setattr("agent_reach.doctor.format_report", lambda results: "report")
+        install_calls = []
+        monkeypatch.setattr(
+            cli,
+            "_install_skill",
+            lambda *args, **kwargs: install_calls.append((args, kwargs)),
+        )
 
         cli._cmd_doctor(Namespace(json=False))
 
         assert skill_file.read_text(encoding="utf-8") == custom_content
+        assert install_calls == []
+        assert not config_dir.exists()
         out = capsys.readouterr().out
         assert "report" in out
         assert "Skill installed" not in out
         assert "preserving existing files" not in out
+        assert f"Skill installed for Agent: {skill_dir}" not in out
 
     def test_transcribe_command_prints_text(self, capsys):
         with patch("agent_reach.transcribe.transcribe", return_value="hello transcript"):
@@ -88,6 +114,35 @@ class TestCLI:
         )
         assert auth_token == "token123"
         assert ct0 == "ct0abc"
+
+    def test_twitter_config_verification_preserves_existing_env_priority(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("TWITTER_AUTH_TOKEN", "shell-auth")
+        monkeypatch.setenv("TWITTER_CT0", "shell-ct0")
+        monkeypatch.setattr(shutil, "which", lambda name: "/bin/twitter")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "ok: true\n", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        cli._cmd_configure(
+            Namespace(
+                from_browser=None,
+                key="twitter-cookies",
+                value=["saved-auth", "saved-ct0"],
+            )
+        )
+
+        child_env = calls[0][1]["env"]
+        assert child_env["TWITTER_AUTH_TOKEN"] == "shell-auth"
+        assert child_env["TWITTER_CT0"] == "shell-ct0"
+        assert cli.os.environ["TWITTER_AUTH_TOKEN"] == "shell-auth"
+        assert cli.os.environ["TWITTER_CT0"] == "shell-ct0"
+        assert "Twitter access works" in capsys.readouterr().out
 
     def test_install_rdt_cli_prefers_github_source(self, monkeypatch, capsys):
         state = {"rdt_installed": False}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,6 +187,39 @@ class TestConfig:
             Config(config_path=linked_dir / "config.yaml")
         assert list(real_dir.iterdir()) == []
 
+    def test_config_ancestor_symlink_is_rejected(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        linked_root = tmp_path / "linked-root"
+        try:
+            linked_root.symlink_to(real_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        with pytest.raises(ConfigSecurityError, match="符号链接"):
+            Config(config_path=linked_root / "nested" / "config.yaml")
+
+    def test_config_load_refuses_non_regular_file(self, tmp_path):
+        import os
+
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFOs are not supported on this platform")
+        config_file = tmp_path / "config.yaml"
+        os.mkfifo(config_file)
+
+        with pytest.raises(ConfigSecurityError, match="常规文件"):
+            Config(config_path=config_file)
+
+    def test_config_load_is_bounded(self, tmp_path, monkeypatch):
+        import agent_reach.config as config_module
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("secret: too-long\n", encoding="utf-8")
+        monkeypatch.setattr(config_module, "_MAX_CONFIG_BYTES", 4)
+
+        with pytest.raises(ConfigSecurityError, match="大小上限"):
+            Config(config_path=config_file)
+
     def test_save_preserves_previous_file_on_serialization_failure(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from agent_reach.config import Config
+from agent_reach.config import Config, ConfigReadOnlyError, ConfigSecurityError
 
 
 @pytest.fixture
@@ -14,10 +14,20 @@ def tmp_config(tmp_path):
 
 
 class TestConfig:
-    def test_init_creates_dir(self, tmp_path):
+    def test_init_is_read_only_on_disk_until_first_save(self, tmp_path):
         config_file = tmp_path / "subdir" / "config.yaml"
         Config(config_path=config_file)
-        assert config_file.parent.exists()
+        assert not config_file.parent.exists()
+
+    def test_read_only_config_never_creates_or_changes_files(self, tmp_path):
+        config_file = tmp_path / "subdir" / "config.yaml"
+        config = Config(config_path=config_file, read_only=True)
+
+        assert config.get("missing") is None
+        assert not config_file.parent.exists()
+        with pytest.raises(ConfigReadOnlyError):
+            config.set("secret", "value")
+        assert not config_file.parent.exists()
 
     def test_set_and_get(self, tmp_config):
         tmp_config.set("test_key", "test_value")
@@ -125,7 +135,8 @@ class TestConfig:
         import sys
 
         config_file = tmp_path / "private" / "config.yaml"
-        Config(config_path=config_file)
+        config = Config(config_path=config_file)
+        config.set("key", "value")
 
         if sys.platform != "win32":
             mode = config_file.parent.stat().st_mode
@@ -133,3 +144,84 @@ class TestConfig:
             assert not (mode & stat.S_IXGRP), "group execute should not be set"
             assert not (mode & stat.S_IROTH), "other read should not be set"
             assert not (mode & stat.S_IXOTH), "other execute should not be set"
+
+    def test_load_refuses_symlink_config_path(self, tmp_path):
+        victim = tmp_path / "victim.yaml"
+        victim.write_text("secret: victim-data\n", encoding="utf-8")
+        config_file = tmp_path / "config.yaml"
+        try:
+            config_file.symlink_to(victim)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        with pytest.raises(ConfigSecurityError, match="符号链接"):
+            Config(config_path=config_file)
+        assert victim.read_text(encoding="utf-8") == "secret: victim-data\n"
+
+    def test_save_refuses_symlink_inserted_after_load(self, tmp_path):
+        victim = tmp_path / "victim.yaml"
+        victim.write_text("secret: victim-data\n", encoding="utf-8")
+        config_file = tmp_path / "config.yaml"
+        config = Config(config_path=config_file)
+        try:
+            config_file.symlink_to(victim)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        with pytest.raises(ConfigSecurityError, match="符号链接"):
+            config.set("secret", "new-data")
+
+        assert config_file.is_symlink()
+        assert victim.read_text(encoding="utf-8") == "secret: victim-data\n"
+
+    def test_config_directory_symlink_is_rejected(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        linked_dir = tmp_path / "linked"
+        try:
+            linked_dir.symlink_to(real_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        with pytest.raises(ConfigSecurityError, match="配置目录"):
+            Config(config_path=linked_dir / "config.yaml")
+        assert list(real_dir.iterdir()) == []
+
+    def test_save_preserves_previous_file_on_serialization_failure(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.yaml"
+        config = Config(config_path=config_file)
+        config.set("keep_key", "keep_value")
+        previous = config_file.read_bytes()
+
+        def fail_dump(*args, **kwargs):
+            raise RuntimeError("simulated write failure")
+
+        monkeypatch.setattr("agent_reach.config.yaml.safe_dump", fail_dump)
+        with pytest.raises(RuntimeError, match="simulated"):
+            config.set("new_key", "new_value")
+
+        assert config_file.read_bytes() == previous
+        assert config.get("new_key") is None
+        assert list(tmp_path.glob(".config.yaml.*.tmp")) == []
+
+    def test_atomic_temp_file_is_created_next_to_custom_config_path(
+        self, tmp_path, monkeypatch
+    ):
+        import tempfile
+
+        config_file = tmp_path / "custom" / "nested" / "settings.yaml"
+        config = Config(config_path=config_file)
+        observed = {}
+        real_mkstemp = tempfile.mkstemp
+
+        def spy_mkstemp(*args, **kwargs):
+            observed["dir"] = kwargs.get("dir")
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr("agent_reach.config.tempfile.mkstemp", spy_mkstemp)
+        config.set("key", "value")
+
+        assert observed["dir"] == str(config_file.parent)
+        assert config_file.read_text(encoding="utf-8") == "key: value\n"

--- a/tests/test_cookie_security.py
+++ b/tests/test_cookie_security.py
@@ -1,0 +1,222 @@
+"""Least-privilege browser-cookie extraction and URL routing regressions."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agent_reach import cookie_extract
+
+
+class RecordingConfig:
+    def __init__(self):
+        self.values = {}
+
+    def set(self, key, value):
+        self.values[key] = value
+
+
+def test_browser_extraction_requires_an_explicit_platform():
+    with pytest.raises(ValueError, match="platform"):
+        cookie_extract.extract_all("chrome")
+
+
+def test_rookiepy_is_limited_at_source_to_the_requested_platform(monkeypatch):
+    calls = []
+
+    def chrome(domains):
+        calls.append(domains)
+        return [
+            {"name": "SESSDATA", "value": "session", "domain": ".bilibili.com"},
+            {"name": "bili_jct", "value": "csrf", "domain": ".bilibili.com"},
+        ]
+
+    fake_rookiepy = SimpleNamespace(
+        chrome=chrome,
+        firefox=lambda domains: [],
+        edge=lambda domains: [],
+        brave=lambda domains: [],
+        opera=lambda domains: [],
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+
+    extracted = cookie_extract.extract_all("chrome", platform="bilibili")
+
+    assert calls == [[".bilibili.com"]]
+    assert extracted == {
+        "bilibili": {"SESSDATA": "session", "bili_jct": "csrf"}
+    }
+
+
+def test_xueqiu_collects_only_xq_a_token(monkeypatch):
+    def chrome(domains):
+        assert domains == [".xueqiu.com"]
+        return [
+            {"name": "xq_a_token", "value": "needed", "domain": ".xueqiu.com"},
+            {"name": "device_id", "value": "unrelated", "domain": ".xueqiu.com"},
+            {"name": "remember", "value": "private", "domain": ".xueqiu.com"},
+        ]
+
+    fake_rookiepy = SimpleNamespace(
+        chrome=chrome,
+        firefox=lambda domains: [],
+        edge=lambda domains: [],
+        brave=lambda domains: [],
+        opera=lambda domains: [],
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+
+    extracted = cookie_extract.extract_all("chrome", platform="xueqiu")
+
+    assert extracted == {"xueqiu": {"xq_a_token": "needed"}}
+
+
+def test_cookie_backend_cannot_smuggle_a_lookalike_domain(monkeypatch):
+    def chrome(domains):
+        assert domains == [".xueqiu.com"]
+        return [
+            {"name": "xq_a_token", "value": "valid", "domain": ".xueqiu.com"},
+            {
+                "name": "xq_a_token",
+                "value": "lookalike",
+                "domain": ".notxueqiu.com",
+            },
+        ]
+
+    fake_rookiepy = SimpleNamespace(
+        chrome=chrome,
+        firefox=lambda domains: [],
+        edge=lambda domains: [],
+        brave=lambda domains: [],
+        opera=lambda domains: [],
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+
+    extracted = cookie_extract.extract_all("chrome", platform="xueqiu")
+
+    assert extracted == {"xueqiu": {"xq_a_token": "valid"}}
+
+
+@pytest.mark.parametrize(
+    ("platform", "manual_key"),
+    [
+        ("twitter", "twitter-cookies"),
+        ("xhs", "xhs-cookies"),
+    ],
+)
+def test_browser_extraction_rejects_cookie_editor_platforms(platform, manual_key):
+    with pytest.raises(ValueError, match=rf"Cookie-Editor.*{manual_key}"):
+        cookie_extract.extract_all("chrome", platform=platform)
+
+
+def test_explicit_profile_uses_only_that_cookie_database(tmp_path, monkeypatch):
+    cookie_db = tmp_path / "Profile 1" / "Network" / "Cookies"
+    cookie_db.parent.mkdir(parents=True)
+    cookie_db.write_bytes(b"test database placeholder")
+    monkeypatch.setattr(
+        cookie_extract, "_chromium_user_data_dir", lambda browser: tmp_path
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", None)
+
+    calls = []
+
+    def chrome(*, cookie_file=None, domain_name=""):
+        calls.append((cookie_file, domain_name))
+        return []
+
+    fake_browser_cookie3 = SimpleNamespace(
+        chrome=chrome,
+        firefox=lambda **kwargs: [],
+        edge=lambda **kwargs: [],
+        brave=lambda **kwargs: [],
+        opera=lambda **kwargs: [],
+    )
+    monkeypatch.setitem(sys.modules, "browser_cookie3", fake_browser_cookie3)
+
+    cookie_extract.extract_all(
+        "chrome", platform="xueqiu", profile="Profile 1"
+    )
+
+    assert calls == [
+        (str(cookie_db), ".xueqiu.com"),
+    ]
+
+
+def test_missing_explicit_profile_fails_instead_of_falling_back(tmp_path, monkeypatch):
+    default_db = tmp_path / "Default" / "Network" / "Cookies"
+    default_db.parent.mkdir(parents=True)
+    default_db.write_bytes(b"default profile")
+    monkeypatch.setattr(
+        cookie_extract, "_chromium_user_data_dir", lambda browser: tmp_path
+    )
+
+    with pytest.raises(ValueError, match="Profile 7.*not found"):
+        cookie_extract.extract_all(
+            "chrome", platform="xueqiu", profile="Profile 7"
+        )
+
+
+def test_configure_requires_platform_before_reading_browser():
+    with pytest.raises(ValueError, match="platform"):
+        cookie_extract.configure_from_browser("chrome", RecordingConfig())
+
+
+def test_invalid_platform_error_does_not_echo_url_secrets():
+    with pytest.raises(ValueError) as error:
+        cookie_extract.extract_all(
+            "chrome",
+            platform="https://user:pass@example.test/?access_token=secret",
+        )
+
+    message = str(error.value)
+    assert "user:pass" not in message
+    assert "secret" not in message
+    assert "***" in message
+
+
+@pytest.mark.parametrize("platform", ["twitter", "xhs"])
+def test_configure_from_browser_rejects_cookie_editor_platforms(platform):
+    with pytest.raises(ValueError, match="Cookie-Editor"):
+        cookie_extract.configure_from_browser(
+            "chrome", RecordingConfig(), platform=platform
+        )
+
+
+def test_xueqiu_config_persists_only_xq_a_token(monkeypatch):
+    monkeypatch.setattr(
+        cookie_extract,
+        "extract_all",
+        lambda browser, **kwargs: {"xueqiu": {"xq_a_token": "needed"}},
+    )
+    config = RecordingConfig()
+
+    result = cookie_extract.configure_from_browser(
+        "chrome", config, platform="xueqiu"
+    )
+
+    assert config.values == {"xueqiu_cookie": "xq_a_token=needed"}
+    assert result[0].targets == ("xueqiu_cookie",)
+
+
+def test_bilibili_config_reports_each_written_key(monkeypatch):
+    monkeypatch.setattr(
+        cookie_extract,
+        "extract_all",
+        lambda browser, **kwargs: {
+            "bilibili": {"SESSDATA": "session", "bili_jct": "csrf"}
+        },
+    )
+    config = RecordingConfig()
+
+    result = cookie_extract.configure_from_browser(
+        "chrome", config, platform="bilibili"
+    )
+
+    assert config.values == {
+        "bilibili_sessdata": "session",
+        "bilibili_csrf": "csrf",
+    }
+    assert result[0].targets == ("bilibili_sessdata", "bilibili_csrf")
+    assert tuple(result[0]) == ("Bilibili", True, "SESSDATA + bili_jct")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 """Tests for doctor module."""
 
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
 import pytest
 
 import agent_reach.doctor as doctor
@@ -124,3 +132,194 @@ def test_stale_active_backend_does_not_leak_into_errored_result(monkeypatch):
     results = doctor.check_all(config=None)
     assert results["boom"]["status"] == "error"
     assert results["boom"]["active_backend"] is None
+
+
+def test_channel_exception_credentials_are_scrubbed(monkeypatch):
+    """Doctor is the final trust boundary for unexpected channel errors."""
+
+    class _ExplodingChannel:
+        name = "secret"
+        description = "敏感渠道"
+        tier = 0
+        backends = ["secret-backend"]
+        active_backend = None
+
+        def check(self, config=None):
+            raise RuntimeError(
+                "request https://alice:password@example.test/data"
+                "?access_token=top-secret failed"
+            )
+
+    monkeypatch.setattr(doctor, "get_all_channels", lambda: [_ExplodingChannel()])
+
+    message = doctor.check_all(config=None)["secret"]["message"]
+
+    assert "alice" not in message
+    assert "password" not in message
+    assert "top-secret" not in message
+    assert "https://***@example.test/data?access_token=***" in message
+
+
+def test_channel_success_message_credentials_are_scrubbed(monkeypatch):
+    """Expected channel messages must pass through the same trust boundary."""
+    channel = _StubChannel(
+        "configured",
+        "已配置渠道",
+        0,
+        "warn",
+        (
+            "upstream returned https://alice:password@example.test/data"
+            "?api_key=top-secret"
+        ),
+        ["upstream"],
+    )
+    monkeypatch.setattr(doctor, "get_all_channels", lambda: [channel])
+
+    message = doctor.check_all(config=None)["configured"]["message"]
+
+    assert "alice" not in message
+    assert "password" not in message
+    assert "top-secret" not in message
+    assert "https://***@example.test/data?api_key=***" in message
+
+
+def _snapshot_user_roots() -> tuple:
+    entries = []
+    seen = set()
+    for variable in (
+        "HOME",
+        "USERPROFILE",
+        "XDG_CONFIG_HOME",
+        "APPDATA",
+        "LOCALAPPDATA",
+    ):
+        root = Path(os.environ[variable])
+        if root in seen:
+            continue
+        seen.add(root)
+        if not root.exists():
+            entries.append((variable, ".", "missing"))
+            continue
+        for path in sorted(root.rglob("*")):
+            relative = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                detail = ("symlink", os.readlink(path))
+            elif path.is_dir():
+                detail = ("directory", path.stat().st_mode & 0o777)
+            elif path.is_file():
+                detail = (
+                    "file",
+                    path.stat().st_mode & 0o777,
+                    hashlib.sha256(path.read_bytes()).hexdigest(),
+                )
+            else:
+                detail = ("other",)
+            entries.append((variable, relative, detail))
+    return tuple(entries)
+
+
+def test_real_doctor_path_is_zero_write_and_never_runs_risky_status_commands(
+    monkeypatch, tmp_path, capsys
+):
+    """Run the real Doctor collector with deterministic external probes."""
+    import agent_reach.backends.opencli as opencli
+    import agent_reach.channels.bilibili as bilibili
+    import agent_reach.channels.v2ex as v2ex
+    import agent_reach.channels.xiaohongshu as xiaohongshu
+    import agent_reach.channels.xueqiu as xueqiu
+    from agent_reach import cli
+
+    workdir = tmp_path / "empty-workdir"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    monkeypatch.delenv("MCPORTER_CONFIG", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    available = {
+        "gh",
+        "opencli",
+        "yt-dlp",
+        "bili",
+        "ffmpeg",
+        "mcporter",
+        "twitter",
+        "rdt",
+        "xhs",
+        "deno",
+        "node",
+    }
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: f"/audit-bin/{name}" if name in available else None,
+    )
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        argv = [str(item) for item in command]
+        calls.append(argv)
+        name = Path(argv[0]).name
+        assert name != "mcporter"
+        assert argv[1:] not in (
+            ["auth", "status"],
+            ["status"],
+            ["daemon", "status"],
+        )
+        if name == "gh":
+            assert argv[1:] == ["--version"]
+            assert kwargs["env"]["GH_TELEMETRY"] == "false"
+            assert kwargs["env"]["DO_NOT_TRACK"] == "true"
+            output = "gh version 2.92.0"
+        elif name == "opencli":
+            assert argv[1:] == ["--version"]
+            output = "1.8.6"
+        elif name == "yt-dlp":
+            output = "2026.01.01"
+        elif name == "bili":
+            output = "0.3.0"
+        elif name == "ffmpeg":
+            output = "ffmpeg version 7.0"
+        else:
+            pytest.fail(f"unexpected Doctor subprocess: {argv}")
+        return subprocess.CompletedProcess(argv, 0, output, "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(opencli, "_fetch_daemon_status", lambda timeout=2: None)
+    monkeypatch.setattr(opencli, "_extension_installed_on_disk", lambda: False)
+    monkeypatch.setattr(
+        opencli, "_unpacked_extension_files_present", lambda: False
+    )
+    monkeypatch.setattr(bilibili, "_search_api_ok", lambda: False)
+    monkeypatch.setattr(
+        xiaohongshu, "_mcp_service_reachable", lambda timeout=3: False
+    )
+    monkeypatch.setattr(v2ex, "_get_json", lambda _url: [])
+    monkeypatch.setattr(
+        xueqiu,
+        "_get_json",
+        lambda _url, _config=None: {
+            "data": {"quote": {"symbol": "SH601138"}}
+        },
+    )
+
+    before = _snapshot_user_roots()
+    cli._cmd_doctor(Namespace(json=True))
+    after = _snapshot_user_roots()
+
+    assert after == before
+    assert calls
+    assert all(Path(call[0]).name != "mcporter" for call in calls)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["github"]["status"] == "warn"
+    assert payload["github"]["active_backend"] is None
+    for channel_name in (
+        "twitter",
+        "reddit",
+        "facebook",
+        "instagram",
+        "xiaohongshu",
+    ):
+        assert payload[channel_name]["status"] == "warn"
+        assert payload[channel_name]["active_backend"] is None

--- a/tests/test_doctor_credential_boundaries.py
+++ b/tests/test_doctor_credential_boundaries.py
@@ -1,0 +1,172 @@
+"""Doctor must not trigger upstream browser-cookie refresh or persistence."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+
+from agent_reach.channels.reddit import RedditChannel
+from agent_reach.channels.twitter import TwitterChannel
+from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
+
+
+def _forbid_subprocess(*_args, **_kwargs):
+    raise AssertionError("credential-backed health checks must not execute upstream CLIs")
+
+
+def test_twitter_doctor_does_not_start_cli_without_explicit_credentials(
+    monkeypatch,
+):
+    monkeypatch.delenv("TWITTER_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TWITTER_CT0", raising=False)
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+
+    channel = TwitterChannel()
+    status, message = channel.check()
+
+    assert status == "warn"
+    assert channel.active_backend is None
+    assert "Cookie-Editor" in message
+    assert "浏览器" not in message or "不会" in message
+
+
+def test_twitter_doctor_still_avoids_upstream_fallback_with_saved_credentials(
+    monkeypatch,
+):
+    class Config:
+        def get(self, key, default=None):
+            return {
+                "twitter_auth_token": "explicit-auth",
+                "twitter_ct0": "explicit-ct0",
+            }.get(key, default)
+
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+
+    status, message = TwitterChannel().check(Config())
+
+    assert status == "warn"
+    assert "已配置" in message
+    assert "不会执行" in message
+
+
+def test_reddit_doctor_does_not_create_or_refresh_missing_credentials(
+    isolated_home, monkeypatch
+):
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/rdt" if name == "rdt" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+
+    channel = RedditChannel()
+    status, message = channel.check()
+
+    assert status == "warn"
+    assert channel.active_backend is None
+    assert "Cookie-Editor" in message
+    assert not (isolated_home / ".config" / "rdt-cli").exists()
+
+
+def test_reddit_doctor_reports_stale_saved_credential_without_refresh(
+    isolated_home, monkeypatch
+):
+    credential_path = (
+        isolated_home / ".config" / "rdt-cli" / "credential.json"
+    )
+    credential_path.parent.mkdir(parents=True)
+    credential_path.write_text(
+        json.dumps(
+            {
+                "cookies": {"reddit_session": "explicit-cookie"},
+                "saved_at": time.time() - 8 * 86400,
+            }
+        ),
+        encoding="utf-8",
+    )
+    original = credential_path.read_bytes()
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/rdt" if name == "rdt" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+
+    status, message = RedditChannel().check()
+
+    assert status == "warn"
+    assert "超过 7 天" in message
+    assert credential_path.read_bytes() == original
+
+
+def test_xhs_doctor_does_not_create_or_extract_missing_cookies(
+    isolated_home, monkeypatch
+):
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/xhs" if name == "xhs" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+    monkeypatch.setattr(
+        XiaoHongShuChannel,
+        "_check_opencli",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        XiaoHongShuChannel,
+        "_check_mcp",
+        lambda self: None,
+    )
+
+    channel = XiaoHongShuChannel()
+    status, message = channel.check()
+
+    assert status == "warn"
+    assert channel.active_backend is None
+    assert "Cookie-Editor" in message
+    assert not (isolated_home / ".xiaohongshu-cli").exists()
+
+
+def test_xhs_doctor_reports_stale_cookie_without_refresh(
+    isolated_home, monkeypatch
+):
+    cookie_path = isolated_home / ".xiaohongshu-cli" / "cookies.json"
+    cookie_path.parent.mkdir(parents=True)
+    cookie_path.write_text(
+        json.dumps(
+            {
+                "a1": "explicit-cookie",
+                "saved_at": time.time() - 8 * 86400,
+            }
+        ),
+        encoding="utf-8",
+    )
+    original = cookie_path.read_bytes()
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/xhs" if name == "xhs" else None,
+    )
+    monkeypatch.setattr(subprocess, "run", _forbid_subprocess)
+    monkeypatch.setattr(
+        XiaoHongShuChannel,
+        "_check_opencli",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        XiaoHongShuChannel,
+        "_check_mcp",
+        lambda self: None,
+    )
+
+    status, message = XiaoHongShuChannel().check()
+
+    assert status == "warn"
+    assert "超过 7 天" in message
+    assert cookie_path.read_bytes() == original

--- a/tests/test_home_isolation.py
+++ b/tests/test_home_isolation.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Regression guards for test-suite and Doctor filesystem isolation."""
+
+import os
+from argparse import Namespace
+from pathlib import Path
+
+import agent_reach.cli as cli
+from agent_reach.config import Config
+
+
+def test_runtime_home_and_config_are_inside_test_sandbox(isolated_home):
+    assert Path.home() == isolated_home
+    assert Path(os.path.expanduser("~")) == isolated_home
+    assert Config.CONFIG_DIR.is_relative_to(isolated_home)
+    assert Config.CONFIG_FILE.is_relative_to(isolated_home)
+
+
+def test_doctor_leaves_sandbox_home_unchanged(
+    isolated_home, monkeypatch, capsys
+):
+    """If Doctor is truly read-only, even the sandbox remains empty."""
+    monkeypatch.setattr("agent_reach.doctor.check_all", lambda config: {})
+    monkeypatch.setattr("agent_reach.doctor.format_report", lambda results: "report")
+    monkeypatch.setattr(
+        cli,
+        "_install_skill",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("doctor must not install skills")
+        ),
+    )
+
+    cli._cmd_doctor(Namespace(json=False))
+
+    assert capsys.readouterr().out.strip() == "report"
+    assert list(isolated_home.iterdir()) == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,101 @@
+"""Security boundaries for the optional Agent Reach MCP server."""
+
+import asyncio
+from types import SimpleNamespace
+
+import agent_reach.integrations.mcp_server as mcp_server
+
+
+class _FakeServer:
+    def __init__(self, name):
+        self.name = name
+        self.list_tools_handler = None
+        self.call_tool_handler = None
+
+    def list_tools(self):
+        def register(handler):
+            self.list_tools_handler = handler
+            return handler
+
+        return register
+
+    def call_tool(self):
+        def register(handler):
+            self.call_tool_handler = handler
+            return handler
+
+        return register
+
+
+def _install_fake_mcp(monkeypatch):
+    monkeypatch.setattr(mcp_server, "HAS_MCP", True)
+    monkeypatch.setattr(mcp_server, "Server", _FakeServer, raising=False)
+    monkeypatch.setattr(
+        mcp_server,
+        "Tool",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mcp_server,
+        "TextContent",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+        raising=False,
+    )
+
+
+def test_mcp_status_uses_read_only_config(monkeypatch):
+    _install_fake_mcp(monkeypatch)
+    created_configs = []
+
+    class _RecordingConfig:
+        def __init__(self, *, read_only=False):
+            self.read_only = read_only
+            created_configs.append(self)
+
+    class _AgentReach:
+        def __init__(self, config):
+            self.config = config
+
+        def doctor_report(self):
+            return "ok"
+
+    monkeypatch.setattr(mcp_server, "Config", _RecordingConfig)
+    monkeypatch.setattr(mcp_server, "AgentReach", _AgentReach)
+
+    server = mcp_server.create_server()
+    result = asyncio.run(server.call_tool_handler("get_status", {}))
+
+    assert len(created_configs) == 1
+    assert created_configs[0].read_only is True
+    assert result[0].text == "ok"
+
+
+def test_mcp_status_exception_credentials_are_scrubbed(monkeypatch):
+    _install_fake_mcp(monkeypatch)
+
+    class _Config:
+        def __init__(self, *, read_only=False):
+            self.read_only = read_only
+
+    class _ExplodingAgentReach:
+        def __init__(self, config):
+            self.config = config
+
+        def doctor_report(self):
+            raise RuntimeError(
+                "request https://alice:password@example.test/data"
+                "?token=top-secret failed"
+            )
+
+    monkeypatch.setattr(mcp_server, "Config", _Config)
+    monkeypatch.setattr(mcp_server, "AgentReach", _ExplodingAgentReach)
+
+    server = mcp_server.create_server()
+    result = asyncio.run(server.call_tool_handler("get_status", {}))
+    text = result[0].text
+
+    assert "alice" not in text
+    assert "password" not in text
+    assert "top-secret" not in text
+    assert "https://***@example.test/data?token=***" in text

--- a/tests/test_mcporter_config.py
+++ b/tests/test_mcporter_config.py
@@ -1,0 +1,158 @@
+"""Read-only mcporter configuration inspection tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_reach.channels.mcporter import (
+    McporterConfigError,
+    configured_server_names,
+    inspect_mcporter_config,
+)
+
+
+def _write_config(path, servers, *, imports=()):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"mcpServers": servers, "imports": list(imports)}),
+        encoding="utf-8",
+    )
+
+
+def test_home_and_project_layers_are_merged(
+    monkeypatch, tmp_path, isolated_home
+):
+    monkeypatch.chdir(tmp_path)
+    _write_config(
+        isolated_home / ".mcporter" / "mcporter.json",
+        {
+            "home-only": {"baseUrl": "https://home.example.test"},
+            "shared": {"baseUrl": "https://home-shared.example.test"},
+        },
+    )
+    _write_config(
+        tmp_path / "config" / "mcporter.json",
+        {
+            "project-only": {"command": "project-mcp"},
+            "shared": {"baseUrl": "https://project-shared.example.test"},
+        },
+    )
+
+    inspection = inspect_mcporter_config()
+
+    assert inspection.server_names == {
+        "home-only",
+        "project-only",
+        "shared",
+    }
+    assert inspection.source == "home+project"
+    assert inspection.imports_unchecked is False
+
+
+def test_explicit_config_is_the_only_layer(
+    monkeypatch, tmp_path, isolated_home
+):
+    monkeypatch.chdir(tmp_path)
+    _write_config(
+        isolated_home / ".mcporter" / "mcporter.json",
+        {"home-only": {"command": "home"}},
+    )
+    _write_config(
+        tmp_path / "config" / "mcporter.json",
+        {"project-only": {"command": "project"}},
+    )
+    _write_config(
+        tmp_path / "explicit.json",
+        {"explicit-only": {"command": "explicit"}},
+    )
+    monkeypatch.setenv("MCPORTER_CONFIG", "explicit.json")
+
+    inspection = inspect_mcporter_config()
+
+    assert inspection.server_names == {"explicit-only"}
+    assert inspection.source == "explicit"
+
+
+def test_missing_explicit_config_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MCPORTER_CONFIG", "missing.json")
+
+    with pytest.raises(McporterConfigError, match="不存在"):
+        inspect_mcporter_config()
+
+
+def test_symlink_config_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "real.json"
+    _write_config(target, {"exa": {"baseUrl": "https://example.test"}})
+    config_path = tmp_path / "config" / "mcporter.json"
+    config_path.parent.mkdir()
+    try:
+        config_path.symlink_to(target)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(McporterConfigError, match="符号链接"):
+        inspect_mcporter_config()
+
+
+def test_ancestor_symlink_config_is_rejected(monkeypatch, tmp_path):
+    real_root = tmp_path / "real-root"
+    _write_config(
+        real_root / "config" / "mcporter.json",
+        {"exa": {"baseUrl": "https://example.test"}},
+    )
+    linked_root = tmp_path / "linked-root"
+    try:
+        linked_root.symlink_to(real_root, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+    monkeypatch.setenv(
+        "MCPORTER_CONFIG",
+        str(linked_root / "config" / "mcporter.json"),
+    )
+
+    with pytest.raises(McporterConfigError, match="安全读取"):
+        inspect_mcporter_config()
+
+
+def test_invalid_json_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config" / "mcporter.json"
+    config_path.parent.mkdir()
+    config_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(McporterConfigError, match="UTF-8 JSON"):
+        inspect_mcporter_config()
+
+
+def test_omitted_imports_are_reported_but_not_expanded(
+    monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    config_path = tmp_path / "config" / "mcporter.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps({"mcpServers": {"exa": {"command": "exa"}}}),
+        encoding="utf-8",
+    )
+
+    inspection = inspect_mcporter_config()
+
+    assert inspection.server_names == {"exa"}
+    assert inspection.imports_unchecked is True
+
+
+def test_machine_output_parser_remains_available_for_install_flows():
+    output = json.dumps(
+        {
+            "servers": [
+                {"name": "Exa", "baseUrl": "https://example.test"},
+                {"name": "linkedin-scraper"},
+            ]
+        }
+    )
+
+    assert configured_server_names(output) == {"exa", "linkedin-scraper"}

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -14,20 +14,22 @@ from agent_reach.probe import ProbeResult
 
 def _status_with(
     version_probe,
-    daemon_probe=None,
+    daemon_status=None,
     ext_on_disk=False,
     unpacked_files=False,
 ):
-    """Run opencli_status with probe_command and disk check patched."""
+    """Run opencli_status with the CLI version and HTTP status patched."""
     calls = []
 
     def fake_probe(cmd, args=("--version",), **kwargs):
         calls.append(list(args))
-        if list(args) == ["--version"]:
-            return version_probe
-        return daemon_probe or ProbeResult("missing")
+        return version_probe
 
     with patch("agent_reach.backends.opencli.probe_command", side_effect=fake_probe), \
+         patch(
+             "agent_reach.backends.opencli._fetch_daemon_status",
+             return_value=daemon_status,
+         ), \
          patch(
              "agent_reach.backends.opencli._extension_installed_on_disk",
              return_value=ext_on_disk,
@@ -54,10 +56,14 @@ def test_broken_node_env_gives_npm_hint():
 
 
 def test_daemon_running_extension_connected_is_ready():
-    daemon_out = "Daemon: running (PID 37389)\nVersion: v1.8.3\nExtension: connected\n"
+    daemon_status = {
+        "ok": True,
+        "pid": 37389,
+        "extensionConnected": True,
+    }
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output=daemon_out),
+        daemon_status,
     )
     assert st.installed and st.daemon_running and st.extension_connected
     assert st.ready
@@ -65,10 +71,10 @@ def test_daemon_running_extension_connected_is_ready():
 
 
 def test_extension_never_installed_not_ready_with_store_guide():
-    daemon_out = "Daemon: running (PID 1)\nExtension: disconnected\n"
+    daemon_status = {"ok": True, "pid": 1, "extensionConnected": False}
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output=daemon_out),
+        daemon_status,
         ext_on_disk=False,
     )
     assert st.daemon_running and not st.extension_connected
@@ -78,10 +84,10 @@ def test_extension_never_installed_not_ready_with_store_guide():
 
 def test_extension_files_on_disk_are_not_reported_as_loaded_or_ready():
     """A disabled/stale extension leaves files behind, so disk != loaded."""
-    daemon_out = "Daemon: running (PID 1)\nExtension: disconnected\n"
+    daemon_status = {"ok": True, "pid": 1, "extensionConnected": False}
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output=daemon_out),
+        daemon_status,
         ext_on_disk=True,
     )
     assert not st.extension_connected
@@ -92,10 +98,10 @@ def test_extension_files_on_disk_are_not_reported_as_loaded_or_ready():
 
 
 def test_unpacked_source_files_are_not_reported_as_loaded_or_ready():
-    daemon_out = "Daemon: running (PID 1)\nExtension: disconnected\n"
+    daemon_status = {"ok": True, "pid": 1, "extensionConnected": False}
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output=daemon_out),
+        daemon_status,
         unpacked_files=True,
     )
     assert st.unpacked_extension_files
@@ -108,7 +114,7 @@ def test_unpacked_source_files_are_not_reported_as_loaded_or_ready():
 def test_daemon_not_running_parsed_correctly():
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output="Daemon: not running\n"),
+        None,
     )
     assert st.installed
     assert not st.daemon_running
@@ -116,15 +122,13 @@ def test_daemon_not_running_parsed_correctly():
     assert "自动启动" in opencli_summary(st)
 
 
-def test_probe_uses_daemon_status_not_doctor():
-    """`opencli doctor` auto-starts the daemon (side effect) — health checks
-    must only ever call `daemon status`."""
+def test_probe_never_executes_any_daemon_or_doctor_command():
+    """Even `daemon status` mutates ~/.opencli in current upstream releases."""
     _, calls = _status_with(
         ProbeResult("ok", output="1.8.3"),
-        ProbeResult("ok", output="Daemon: not running\n"),
+        None,
     )
-    assert ["daemon", "status"] in calls
-    assert ["doctor"] not in calls
+    assert calls == [["--version"]]
 
 
 def test_opencli_probes_strip_deprecated_app_env_only_from_children(monkeypatch):
@@ -143,11 +147,12 @@ def test_opencli_probes_strip_deprecated_app_env_only_from_children(monkeypatch)
                 "error",
                 output="OPENCLI_DAEMON_PORT is no longer supported",
             )
-        if list(args) == ["--version"]:
-            return ProbeResult("ok", output="1.8.6")
-        return ProbeResult("ok", output="Daemon: not running\n")
+        return ProbeResult("ok", output="1.8.6")
 
     with patch("agent_reach.backends.opencli.probe_command", side_effect=fake_probe), patch(
+        "agent_reach.backends.opencli._fetch_daemon_status",
+        return_value=None,
+    ), patch(
         "agent_reach.backends.opencli._extension_installed_on_disk",
         return_value=False,
     ):
@@ -156,7 +161,6 @@ def test_opencli_probes_strip_deprecated_app_env_only_from_children(monkeypatch)
     assert status.installed and not status.broken
     assert calls == [
         (["--version"], ("OPENCLI_DAEMON_PORT",)),
-        (["daemon", "status"], ("OPENCLI_DAEMON_PORT",)),
     ]
     assert "OPENCLI_DAEMON_PORT" in __import__("os").environ
 

--- a/tests/test_opencli_backend.py
+++ b/tests/test_opencli_backend.py
@@ -4,10 +4,20 @@
 from unittest.mock import patch
 
 from agent_reach.backends import opencli_status, opencli_summary
+from agent_reach.backends.opencli import (
+    OPENCLI_EXTENSION_ID,
+    _extension_installed_on_disk,
+    _unpacked_extension_files_present,
+)
 from agent_reach.probe import ProbeResult
 
 
-def _status_with(version_probe, daemon_probe=None, ext_on_disk=False):
+def _status_with(
+    version_probe,
+    daemon_probe=None,
+    ext_on_disk=False,
+    unpacked_files=False,
+):
     """Run opencli_status with probe_command and disk check patched."""
     calls = []
 
@@ -21,6 +31,10 @@ def _status_with(version_probe, daemon_probe=None, ext_on_disk=False):
          patch(
              "agent_reach.backends.opencli._extension_installed_on_disk",
              return_value=ext_on_disk,
+         ), \
+         patch(
+             "agent_reach.backends.opencli._unpacked_extension_files_present",
+             return_value=unpacked_files,
          ):
         return opencli_status(), calls
 
@@ -62,9 +76,8 @@ def test_extension_never_installed_not_ready_with_store_guide():
     assert "chromewebstore.google.com" in st.hint
 
 
-def test_sleeping_extension_counts_as_ready():
-    """实测:扩展 service worker 睡眠时 daemon status 报 disconnected,
-    但任何真实命令会唤醒它——装在磁盘上即视为可用。"""
+def test_extension_files_on_disk_are_not_reported_as_loaded_or_ready():
+    """A disabled/stale extension leaves files behind, so disk != loaded."""
     daemon_out = "Daemon: running (PID 1)\nExtension: disconnected\n"
     st, _ = _status_with(
         ProbeResult("ok", output="1.8.3"),
@@ -73,9 +86,23 @@ def test_sleeping_extension_counts_as_ready():
     )
     assert not st.extension_connected
     assert st.extension_installed
-    assert st.ready
-    assert "唤醒" in opencli_summary(st)
-    assert st.hint == ""
+    assert not st.ready
+    assert "可用" not in opencli_summary(st)
+    assert "无法确认" in st.hint
+
+
+def test_unpacked_source_files_are_not_reported_as_loaded_or_ready():
+    daemon_out = "Daemon: running (PID 1)\nExtension: disconnected\n"
+    st, _ = _status_with(
+        ProbeResult("ok", output="1.8.3"),
+        ProbeResult("ok", output=daemon_out),
+        unpacked_files=True,
+    )
+    assert st.unpacked_extension_files
+    assert not st.extension_connected
+    assert not st.ready
+    assert "不代表" in st.hint
+    assert "可用" not in opencli_summary(st)
 
 
 def test_daemon_not_running_parsed_correctly():
@@ -98,3 +125,71 @@ def test_probe_uses_daemon_status_not_doctor():
     )
     assert ["daemon", "status"] in calls
     assert ["doctor"] not in calls
+
+
+def test_opencli_probes_strip_deprecated_app_env_only_from_children(monkeypatch):
+    """OpenCLIApp can inject a variable that makes every CLI command exit 78.
+
+    Agent Reach must remove it from both read-only child probes without
+    mutating the desktop app's parent environment.
+    """
+    monkeypatch.setenv("OPENCLI_DAEMON_PORT", "19825")
+    calls = []
+
+    def fake_probe(cmd, args=("--version",), **kwargs):
+        calls.append((list(args), tuple(kwargs.get("remove_env", ()))))
+        if "OPENCLI_DAEMON_PORT" not in kwargs.get("remove_env", ()):
+            return ProbeResult(
+                "error",
+                output="OPENCLI_DAEMON_PORT is no longer supported",
+            )
+        if list(args) == ["--version"]:
+            return ProbeResult("ok", output="1.8.6")
+        return ProbeResult("ok", output="Daemon: not running\n")
+
+    with patch("agent_reach.backends.opencli.probe_command", side_effect=fake_probe), patch(
+        "agent_reach.backends.opencli._extension_installed_on_disk",
+        return_value=False,
+    ):
+        status = opencli_status()
+
+    assert status.installed and not status.broken
+    assert calls == [
+        (["--version"], ("OPENCLI_DAEMON_PORT",)),
+        (["daemon", "status"], ("OPENCLI_DAEMON_PORT",)),
+    ]
+    assert "OPENCLI_DAEMON_PORT" in __import__("os").environ
+
+
+def test_store_install_scan_includes_edge_profiles(tmp_path, monkeypatch):
+    edge_root = tmp_path / "Microsoft Edge"
+    (
+        edge_root
+        / "Default"
+        / "Extensions"
+        / OPENCLI_EXTENSION_ID
+        / "1.0.0"
+    ).mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "agent_reach.backends.opencli._CHROME_PROFILE_ROOTS",
+        (str(edge_root),),
+    )
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+
+    assert _extension_installed_on_disk()
+
+
+def test_unpacked_scan_requires_manifest_but_does_not_claim_browser_load(
+    tmp_path, monkeypatch
+):
+    unpacked = tmp_path / ".opencli" / "extension"
+    unpacked.mkdir(parents=True)
+    monkeypatch.setattr(
+        "agent_reach.backends.opencli._OPENCLI_UNPACKED_EXTENSION",
+        str(unpacked),
+    )
+
+    assert not _unpacked_extension_files_present()
+    (unpacked / "manifest.json").write_text('{"name": "OpenCLI"}', encoding="utf-8")
+    assert _unpacked_extension_files_present()

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for P0 CLI safety and configuration failures."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+import agent_reach.cli as cli
+
+
+class _MemoryConfig:
+    def __init__(self):
+        self.data = {}
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+
+def test_browser_cookie_import_requires_explicit_platform(monkeypatch):
+    """A bare --from-browser must fail before any browser credential access."""
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: pytest.fail("browser cookie reader must not run"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-reach", "configure", "--from-browser", "chrome"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+
+
+def test_browser_cookie_import_passes_explicit_platform_and_profile(
+    monkeypatch, capsys
+):
+    """The CLI forwards an allowed minimal-cookie platform and exact profile."""
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    captured = {}
+
+    def fake_configure(browser, config, **kwargs):
+        captured.update(browser=browser, config=config, **kwargs)
+        return [("Twitter/X", True, "saved to config.yaml")]
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(cookie_extract, "configure_from_browser", fake_configure)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-reach",
+            "configure",
+            "--from-browser",
+            "chrome",
+            "--platform",
+            "xueqiu",
+            "--profile",
+            "Profile 2",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["browser"] == "chrome"
+    assert captured["platform"] == "xueqiu"
+    assert captured["profile"] == "Profile 2"
+    assert "Cookies configured" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("platform", "manual_key"),
+    [("twitter", "twitter-cookies"), ("xiaohongshu", "xhs-cookies")],
+)
+def test_browser_cookie_import_rejects_cookie_editor_only_platforms(
+    monkeypatch, capsys, platform, manual_key
+):
+    """Twitter/XHS browser stores are never opened by the automatic importer."""
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: pytest.fail("browser cookie reader must not run"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-reach",
+            "configure",
+            "--from-browser",
+            "chrome",
+            "--platform",
+            platform,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+    assert manual_key in capsys.readouterr().err
+
+
+def test_install_does_not_implicitly_read_browser_cookies(monkeypatch, tmp_path, capsys):
+    """Installing a cookie-backed channel prints an explicit command instead."""
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(
+        cli.os.path,
+        "expanduser",
+        lambda value: value.replace("~", str(tmp_path)),
+    )
+    monkeypatch.setattr(cli, "_install_system_deps", lambda: None)
+    monkeypatch.setattr(cli, "_install_mcporter", lambda: None)
+    monkeypatch.setattr(cli, "_install_twitter_deps", lambda: None)
+    monkeypatch.setattr(cli, "_install_skill", lambda: None)
+    monkeypatch.setattr(
+        "agent_reach.doctor.check_all",
+        lambda _config: {},
+    )
+    monkeypatch.setattr(
+        "agent_reach.doctor.format_report",
+        lambda _results: "report",
+    )
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: pytest.fail("install must not read browser cookies"),
+    )
+
+    cli._cmd_install(
+        Namespace(
+            env="local",
+            proxy="",
+            safe=False,
+            dry_run=False,
+            channels="twitter",
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "configure twitter-cookies" in output
+    assert "Importing cookies from browser" not in output
+
+
+@pytest.mark.parametrize("sync_legacy", [False, True])
+def test_manual_twitter_cookie_legacy_copies_are_opt_in(
+    monkeypatch, capsys, sync_legacy
+):
+    """The source-of-truth config is always written; legacy copies are optional."""
+    import shutil
+
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    calls = []
+    config = _MemoryConfig()
+    monkeypatch.setattr(config_module, "Config", lambda: config)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "_sync_xfetch_session",
+        lambda auth, ct0: calls.append(("xfetch", auth, ct0)),
+    )
+    monkeypatch.setattr(
+        cookie_extract,
+        "_sync_bird_env",
+        lambda auth, ct0: calls.append(("bird", auth, ct0)),
+    )
+
+    cli._cmd_configure(
+        Namespace(
+            from_browser=None,
+            key="twitter-cookies",
+            value=["auth-value", "ct0-value"],
+            sync_legacy_twitter=sync_legacy,
+        )
+    )
+
+    assert config.get("twitter_auth_token") == "auth-value"
+    assert config.get("twitter_ct0") == "ct0-value"
+    assert bool(calls) is sync_legacy
+    output = capsys.readouterr().out
+    assert ("Legacy copies written" in output) is sync_legacy
+
+
+def test_doctor_never_installs_or_updates_skill(monkeypatch, capsys):
+    """A diagnostic command is read-only and must not mutate agent instructions."""
+    import agent_reach.config as config_module
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr("agent_reach.doctor.check_all", lambda _config: {})
+    monkeypatch.setattr("agent_reach.doctor.format_report", lambda _results: "report")
+    monkeypatch.setattr(
+        cli,
+        "_install_skill",
+        lambda *_args, **_kwargs: pytest.fail("doctor must not install skill"),
+    )
+
+    cli._cmd_doctor(Namespace(json=False))
+
+    assert "report" in capsys.readouterr().out
+
+
+def _docker_result(args, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+def test_xhs_docker_cookie_copy_succeeds_without_local_os_binding_error(
+    monkeypatch, capsys
+):
+    """The Docker branch must be able to unlink its temporary file."""
+    calls = []
+
+    def fake_which(name):
+        if name == "docker":
+            return "/usr/bin/docker"
+        return None
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        if args[1] == "ps":
+            return _docker_result(args, stdout="xiaohongshu-mcp\n")
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return _docker_result(args, stdout="/app/data/cookies.json\n")
+        return _docker_result(args)
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._configure_xhs_cookies("web_session=xhs_secret")
+
+    output = capsys.readouterr().out
+    assert "Cookies written to xiaohongshu-mcp:/app/data/cookies.json" in output
+    assert "cannot access local variable 'os'" not in output
+    assert any(call[1] == "cp" for call in calls)
+
+
+def test_xhs_docker_cookie_copy_always_removes_temporary_file(monkeypatch, capsys):
+    """Failed docker cp must not leave a plaintext cookie file behind."""
+    copied_from = []
+
+    def fake_which(name):
+        if name == "docker":
+            return "/usr/bin/docker"
+        return None
+
+    def fake_run(args, **_kwargs):
+        if args[1] == "ps":
+            return _docker_result(args, stdout="xiaohongshu-mcp\n")
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return _docker_result(args, stdout="/app/data/cookies.json\n")
+        if args[1] == "cp":
+            copied_from.append(args[2])
+            return _docker_result(args, returncode=1, stderr="copy failed")
+        return _docker_result(args)
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._configure_xhs_cookies("web_session=xhs_secret")
+
+    assert copied_from
+    assert not Path(copied_from[0]).exists()
+    assert "Failed to copy cookies: copy failed" in capsys.readouterr().out
+
+
+def test_system_install_uses_platform_specific_ytdlp_config(
+    monkeypatch, tmp_path
+):
+    """macOS installation writes the same config path that doctor reads."""
+    import shutil
+
+    import agent_reach.utils.paths as paths
+
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(
+        cli.os.path,
+        "expanduser",
+        lambda value: str(tmp_path / ".legacy-config")
+        if value == "~/.config/yt-dlp"
+        else value.replace("~", str(tmp_path)),
+    )
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}" if name in {"gh", "node", "npm"} else None,
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda args, **_kwargs: _docker_result(
+            args,
+            stdout="/tmp/npm-root\n" if args[1:3] == ["root", "-g"] else "",
+        ),
+    )
+
+    cli._install_system_deps()
+
+    config_path = (
+        tmp_path / "Library" / "Application Support" / "yt-dlp" / "config"
+    )
+    assert config_path.read_text(encoding="utf-8") == "--js-runtimes node\n"
+    assert not (tmp_path / ".legacy-config" / "config").exists()
+
+
+def test_mcporter_install_adds_exa_to_home_scope(monkeypatch):
+    """Installer config remains available across working directories."""
+    import shutil
+
+    calls = []
+
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: "/usr/bin/mcporter" if name == "mcporter" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        if args[:3] == ["mcporter", "config", "list"]:
+            return _docker_result(args, stdout='{"servers": []}')
+        return _docker_result(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._install_mcporter()
+
+    assert [
+        "mcporter",
+        "config",
+        "add",
+        "exa",
+        "https://mcp.exa.ai/mcp",
+        "--scope",
+        "home",
+    ] in calls

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from argparse import Namespace
@@ -14,8 +15,9 @@ import agent_reach.cli as cli
 
 
 class _MemoryConfig:
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         self.data = {}
+        self.read_only = kwargs.get("read_only", False)
 
     def get(self, key, default=None):
         return self.data.get(key, default)
@@ -85,6 +87,40 @@ def test_browser_cookie_import_passes_explicit_platform_and_profile(
     assert captured["platform"] == "xueqiu"
     assert captured["profile"] == "Profile 2"
     assert "Cookies configured" in capsys.readouterr().out
+
+
+def test_browser_cookie_import_without_cookie_exits_one(monkeypatch, capsys):
+    """An unsuccessful browser import is a CLI failure, not a silent success."""
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: [
+            ("Xueqiu", False, "No Xueqiu cookies found")
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-reach",
+            "configure",
+            "--from-browser",
+            "chrome",
+            "--platform",
+            "xueqiu",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 1
+    assert "No cookies found" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -167,6 +203,52 @@ def test_install_does_not_implicitly_read_browser_cookies(monkeypatch, tmp_path,
     assert "Importing cookies from browser" not in output
 
 
+def test_install_rejects_unknown_channel_before_side_effects(
+    monkeypatch, capsys
+):
+    """A typo in --channels fails before config or system installation starts."""
+    import agent_reach.config as config_module
+
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        config_module,
+        "Config",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Config must not be constructed for an invalid channel"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_install_system_deps",
+        lambda: pytest.fail("system dependencies must not be installed"),
+    )
+    monkeypatch.setattr(
+        cli.os,
+        "makedirs",
+        lambda *_args, **_kwargs: pytest.fail(
+            "install directories must not be created"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-reach",
+            "install",
+            "--env",
+            "local",
+            "--channels",
+            "twiter",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+    assert "twiter" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize("sync_legacy", [False, True])
 def test_manual_twitter_cookie_legacy_copies_are_opt_in(
     monkeypatch, capsys, sync_legacy
@@ -184,12 +266,12 @@ def test_manual_twitter_cookie_legacy_copies_are_opt_in(
     monkeypatch.setattr(
         cookie_extract,
         "_sync_xfetch_session",
-        lambda auth, ct0: calls.append(("xfetch", auth, ct0)),
+        lambda auth, ct0: calls.append(("xfetch", auth, ct0)) or True,
     )
     monkeypatch.setattr(
         cookie_extract,
         "_sync_bird_env",
-        lambda auth, ct0: calls.append(("bird", auth, ct0)),
+        lambda auth, ct0: calls.append(("bird", auth, ct0)) or True,
     )
 
     cli._cmd_configure(
@@ -208,6 +290,87 @@ def test_manual_twitter_cookie_legacy_copies_are_opt_in(
     assert ("Legacy copies written" in output) is sync_legacy
 
 
+@pytest.mark.parametrize(
+    ("xfetch_ok", "bird_ok", "written_count", "failed_count"),
+    [
+        (True, True, 2, 0),
+        (True, False, 1, 1),
+        (False, True, 1, 1),
+        (False, False, 0, 2),
+    ],
+)
+def test_legacy_twitter_sync_reports_only_confirmed_results(
+    monkeypatch,
+    capsys,
+    xfetch_ok,
+    bird_ok,
+    written_count,
+    failed_count,
+):
+    import shutil
+
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "_sync_xfetch_session",
+        lambda *_args: xfetch_ok,
+    )
+    monkeypatch.setattr(
+        cookie_extract,
+        "_sync_bird_env",
+        lambda *_args: bird_ok,
+    )
+
+    cli._cmd_configure(
+        Namespace(
+            from_browser=None,
+            key="twitter-cookies",
+            value=["auth-value", "ct0-value"],
+            sync_legacy_twitter=True,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert output.count("  written:") == written_count
+    assert output.count("  failed:") == failed_count
+
+
+def test_twitter_configure_never_runs_upstream_browser_fallback(
+    monkeypatch, capsys
+):
+    import shutil
+
+    import agent_reach.config as config_module
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/twitter")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail(
+            "configure must not execute twitter status"
+        ),
+    )
+
+    cli._cmd_configure(
+        Namespace(
+            from_browser=None,
+            key="twitter-cookies",
+            value=["auth-value", "ct0-value"],
+            sync_legacy_twitter=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "已保存" in output
+    assert "未实时验证" in output
+    assert "Twitter access works" not in output
+
+
 def test_doctor_never_installs_or_updates_skill(monkeypatch, capsys):
     """A diagnostic command is read-only and must not mutate agent instructions."""
     import agent_reach.config as config_module
@@ -224,6 +387,51 @@ def test_doctor_never_installs_or_updates_skill(monkeypatch, capsys):
     cli._cmd_doctor(Namespace(json=False))
 
     assert "report" in capsys.readouterr().out
+
+
+def test_watch_uses_read_only_config(monkeypatch, capsys):
+    """Scheduled diagnostics must enforce the same no-write boundary as doctor."""
+    import agent_reach.config as config_module
+
+    created = []
+
+    class RecordingConfig(_MemoryConfig):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    class _Release:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"tag_name": "v0.0.0", "body": ""}
+
+    monkeypatch.setattr(config_module, "Config", RecordingConfig)
+    monkeypatch.setattr(
+        "agent_reach.doctor.check_all",
+        lambda _config: {
+            "web": {
+                "status": "ok",
+                "name": "网页",
+                "message": "可用",
+                "tier": 0,
+                "backends": ["Jina Reader"],
+                "active_backend": "Jina Reader",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        cli,
+        "_github_get_with_retry",
+        lambda *_args, **_kwargs: (_Release(), None, 1),
+    )
+
+    cli._cmd_watch()
+
+    assert len(created) == 1
+    assert created[0].read_only is True
+    assert "全部正常" in capsys.readouterr().out
 
 
 def _docker_result(args, returncode=0, stdout="", stderr=""):
@@ -289,16 +497,17 @@ def test_xhs_docker_cookie_copy_always_removes_temporary_file(monkeypatch, capsy
     assert "Failed to copy cookies: copy failed" in capsys.readouterr().out
 
 
-def test_system_install_uses_platform_specific_ytdlp_config(
+def test_system_install_uses_ytdlp_first_user_config(
     monkeypatch, tmp_path
 ):
-    """macOS installation writes the same config path that doctor reads."""
+    """Installer writes the first config directory that real yt-dlp reads."""
     import shutil
 
     import agent_reach.utils.paths as paths
 
     monkeypatch.setattr(paths.sys, "platform", "darwin")
     monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME")
     monkeypatch.setattr(
         cli.os.path,
         "expanduser",
@@ -309,24 +518,83 @@ def test_system_install_uses_platform_specific_ytdlp_config(
     monkeypatch.setattr(
         shutil,
         "which",
-        lambda name: f"/usr/bin/{name}" if name in {"gh", "node", "npm"} else None,
+        lambda name: f"/usr/bin/{name}"
+        if name in {"gh", "node", "npm", "yt-dlp"}
+        else None,
     )
-    monkeypatch.setattr(
-        subprocess,
-        "run",
-        lambda args, **_kwargs: _docker_result(
+
+    def fake_run(args, **_kwargs):
+        if args[-1:] == ["--version"] and args[0].endswith("yt-dlp"):
+            return _docker_result(args, stdout="2026.07.04\n")
+        return _docker_result(
             args,
-            stdout="/tmp/npm-root\n" if args[1:3] == ["root", "-g"] else "",
-        ),
-    )
+            stdout="/tmp/npm-root\n"
+            if args[1:3] == ["root", "-g"]
+            else "",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
     cli._install_system_deps()
 
-    config_path = (
-        tmp_path / "Library" / "Application Support" / "yt-dlp" / "config"
-    )
+    config_path = tmp_path / ".config" / "yt-dlp" / "config"
     assert config_path.read_text(encoding="utf-8") == "--js-runtimes node\n"
     assert not (tmp_path / ".legacy-config" / "config").exists()
+
+
+@pytest.mark.parametrize(
+    "yt_dlp_version",
+    [None, "2025.10.22", "not-a-stable-version"],
+)
+def test_system_install_never_writes_unsupported_ytdlp_flag(
+    monkeypatch, tmp_path, yt_dlp_version
+):
+    """A missing, old, or unknown yt-dlp must not receive a fatal option."""
+    import shutil
+
+    import agent_reach.utils.paths as paths
+
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+
+    def fake_which(name):
+        if name in {"gh", "node", "npm"}:
+            return f"/usr/bin/{name}"
+        if name == "yt-dlp" and yt_dlp_version is not None:
+            return "/usr/bin/yt-dlp"
+        return None
+
+    def fake_run(args, **_kwargs):
+        if args[-1:] == ["--version"] and args[0].endswith("yt-dlp"):
+            return _docker_result(args, stdout=f"{yt_dlp_version}\n")
+        return _docker_result(
+            args,
+            stdout="/tmp/npm-root\n"
+            if args[1:3] == ["root", "-g"]
+            else "",
+        )
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._install_system_deps()
+
+    config_path = tmp_path / ".config" / "yt-dlp" / "config"
+    assert not config_path.exists()
+
+
+def test_update_guide_preserves_ytdlp_default_extra():
+    """Every documented upgrade path keeps yt-dlp's default/EJS dependencies."""
+    guide = (
+        Path(__file__).resolve().parents[1] / "docs" / "update.md"
+    ).read_text(encoding="utf-8")
+    update_line = next(
+        line for line in guide.splitlines() if line.startswith("which yt-dlp")
+    )
+
+    assert update_line.count("yt-dlp[default]") == 3
+    assert "pipx install --force 'yt-dlp[default]'" in update_line
 
 
 def test_mcporter_install_adds_exa_to_home_scope(monkeypatch):
@@ -343,7 +611,7 @@ def test_mcporter_install_adds_exa_to_home_scope(monkeypatch):
 
     def fake_run(args, **_kwargs):
         calls.append(args)
-        if args[:3] == ["mcporter", "config", "list"]:
+        if args == ["mcporter", "config", "list", "--json"]:
             return _docker_result(args, stdout='{"servers": []}')
         return _docker_result(args)
 
@@ -360,3 +628,276 @@ def test_mcporter_install_adds_exa_to_home_scope(monkeypatch):
         "--scope",
         "home",
     ] in calls
+    assert ["mcporter", "config", "list", "--json"] in calls
+
+
+def test_mcporter_install_does_not_treat_metadata_as_exa_server(
+    monkeypatch,
+):
+    """Only a server object's exact name may suppress Exa setup."""
+    import json
+    import shutil
+
+    calls = []
+    payload = {
+        "servers": [
+            {
+                "name": "unrelated",
+                "source": {"path": "/tmp/exa-project/mcporter.json"},
+                "url": "https://example.test/?note=exa",
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name: "/usr/bin/mcporter" if name == "mcporter" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        if args == ["mcporter", "config", "list", "--json"]:
+            return _docker_result(args, stdout=json.dumps(payload))
+        return _docker_result(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._install_mcporter()
+
+    assert [
+        "mcporter",
+        "config",
+        "add",
+        "exa",
+        "https://mcp.exa.ai/mcp",
+        "--scope",
+        "home",
+    ] in calls
+
+
+def test_server_xhs_install_never_recommends_qr_or_browser_extraction(
+    monkeypatch, capsys
+):
+    """Project policy requires an explicit Cookie-Editor export for XHS."""
+    monkeypatch.setattr(cli, "_detect_environment", lambda: "server")
+
+    cli._install_xhs_deps()
+
+    output = capsys.readouterr().out
+    assert "Cookie-Editor" in output
+    assert "configure xhs-cookies" in output
+    assert "扫码" not in output
+    assert "二维码" not in output
+
+
+def test_configure_usage_does_not_recommend_blocked_twitter_browser_import(
+    capsys,
+):
+    cli._cmd_configure(
+        Namespace(
+            from_browser=None,
+            key=None,
+            value=[],
+            sync_legacy_twitter=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "--platform xueqiu" in output
+    assert "--platform twitter" not in output
+
+
+def test_configure_missing_value_exits_one(monkeypatch, capsys):
+    """A selected config key without a value must fail at the CLI boundary."""
+    import agent_reach.config as config_module
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-reach", "configure", "github-token"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 1
+    assert "Missing value for github-token" in capsys.readouterr().out
+
+
+def test_twitter_cookie_parse_failure_exits_one(monkeypatch, capsys):
+    """Malformed Twitter cookie input must not produce a successful CLI status."""
+    import agent_reach.config as config_module
+
+    config = _MemoryConfig()
+    monkeypatch.setattr(config_module, "Config", lambda: config)
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent-reach", "configure", "twitter-cookies", "not-a-cookie"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 1
+    assert "Could not find auth_token and ct0" in capsys.readouterr().out
+    assert config.data == {}
+
+
+def test_profile_rejects_unsupported_browser_before_cookie_backend(
+    monkeypatch, capsys
+):
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: pytest.fail(
+            "unsupported profile must fail before browser access"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "agent-reach",
+            "configure",
+            "--from-browser",
+            "firefox",
+            "--platform",
+            "xueqiu",
+            "--profile",
+            "default-release",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 2
+    assert "Chrome/Edge/Brave" in capsys.readouterr().err
+
+
+def test_missing_profile_is_clean_cli_error_without_traceback(
+    monkeypatch, capsys
+):
+    import agent_reach.config as config_module
+    import agent_reach.cookie_extract as cookie_extract
+
+    monkeypatch.setattr(config_module, "Config", _MemoryConfig)
+    monkeypatch.setattr(
+        cookie_extract,
+        "configure_from_browser",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ValueError(
+                "Profile 'secret-profile' not found for chrome; "
+                "https://user:pass@example.test/?token=hidden"
+            )
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_configure(
+            Namespace(
+                from_browser="chrome",
+                platform="xueqiu",
+                profile="Missing",
+                key=None,
+                value=[],
+                sync_legacy_twitter=False,
+            )
+        )
+
+    error = capsys.readouterr().err
+    assert exc.value.code == 2
+    assert "Traceback" not in error
+    assert "user:pass" not in error
+    assert "hidden" not in error
+    assert "***" in error
+
+
+def test_install_dry_run_does_not_create_agent_reach_directory(
+    isolated_home, monkeypatch
+):
+    monkeypatch.setattr(cli, "_install_system_deps_dryrun", lambda: None)
+
+    cli._cmd_install(
+        Namespace(
+            env="local",
+            proxy="",
+            safe=False,
+            dry_run=True,
+            channels="",
+        )
+    )
+
+    assert not (isolated_home / ".agent-reach").exists()
+
+
+def test_uninstall_warns_about_opt_in_legacy_credential_copies(
+    isolated_home, capsys
+):
+    xfetch = isolated_home / ".config" / "xfetch" / "session.json"
+    bird = isolated_home / ".config" / "bird" / "credentials.env"
+    xfetch.parent.mkdir(parents=True)
+    bird.parent.mkdir(parents=True)
+    xfetch.write_text("{}", encoding="utf-8")
+    bird.write_text("AUTH_TOKEN=secret\n", encoding="utf-8")
+
+    cli._cmd_uninstall(Namespace(dry_run=True, keep_config=False))
+
+    output = capsys.readouterr().out
+    assert str(xfetch) in output
+    assert str(bird) in output
+    assert "不会自动删除" in output
+    assert xfetch.exists()
+    assert bird.exists()
+
+
+def test_uninstall_preserves_mcporter_entries_without_agent_reach_provenance(
+    isolated_home, monkeypatch, capsys
+):
+    """Names and endpoints alone do not prove Agent Reach owns an MCP entry."""
+    calls = []
+    payload = {
+        "servers": [
+            {
+                "name": "exa",
+                "source": {
+                    "kind": "local",
+                    "path": str(isolated_home / ".mcporter" / "mcporter.json"),
+                },
+                "baseUrl": "https://mcp.exa.ai/mcp",
+            },
+            {
+                "name": "xiaohongshu",
+                "source": {
+                    "kind": "local",
+                    "path": str(isolated_home / ".mcporter" / "mcporter.json"),
+                },
+                "baseUrl": "http://localhost:18060/mcp",
+            },
+        ]
+    }
+
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/bin/mcporter" if name == "mcporter" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _docker_result(args, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._cmd_uninstall(Namespace(dry_run=False, keep_config=True))
+
+    output = capsys.readouterr().out
+    assert not any("remove" in call for call in calls)
+    assert "来源无法证明" in output

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,6 +2,7 @@
 """Behavior tests for cross-platform path and remediation helpers."""
 
 import subprocess
+from pathlib import Path
 
 from agent_reach.utils import paths
 
@@ -11,6 +12,7 @@ def test_posix_ytdlp_fix_is_single_line_executable_and_idempotent(
 ):
     monkeypatch.setattr(paths.sys, "platform", "linux")
     monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME")
 
     command = paths.render_ytdlp_fix_command()
 
@@ -20,3 +22,16 @@ def test_posix_ytdlp_fix_is_single_line_executable_and_idempotent(
 
     config = tmp_path / ".config" / "yt-dlp" / "config"
     assert config.read_text(encoding="utf-8") == "--js-runtimes node\n"
+
+
+def test_ytdlp_config_dir_matches_upstream_first_user_location(
+    monkeypatch, tmp_path
+):
+    from yt_dlp.options import get_user_config_dirs
+
+    config_home = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+
+    expected = Path(next(get_user_config_dirs("yt-dlp")))
+
+    assert paths.get_ytdlp_config_dir() == expected

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Behavior tests for cross-platform path and remediation helpers."""
+
+import subprocess
+
+from agent_reach.utils import paths
+
+
+def test_posix_ytdlp_fix_is_single_line_executable_and_idempotent(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+
+    command = paths.render_ytdlp_fix_command()
+
+    assert "\n" not in command
+    subprocess.run(["/bin/sh", "-c", command], check=True)
+    subprocess.run(["/bin/sh", "-c", command], check=True)
+
+    config = tmp_path / ".config" / "yt-dlp" / "config"
+    assert config.read_text(encoding="utf-8") == "--js-runtimes node\n"

--- a/tests/test_private_file_writes.py
+++ b/tests/test_private_file_writes.py
@@ -1,0 +1,421 @@
+"""Security regressions for local credential and tool configuration writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from argparse import Namespace
+
+import pytest
+
+from agent_reach import cli
+from agent_reach.cookie_extract import _sync_bird_env, _sync_xfetch_session
+from agent_reach.utils import paths
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+def test_atomic_private_text_write_is_0600(tmp_path):
+    target = tmp_path / "private" / "secret.txt"
+
+    paths.atomic_write_private_text(target, "secret")
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+
+
+def test_atomic_private_text_write_preserves_old_file_on_replace_failure(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "private" / "secret.txt"
+    target.parent.mkdir()
+    target.write_text("keep-old", encoding="utf-8")
+
+    def fail_replace(*_args, **_kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(paths.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failure"):
+        paths.atomic_write_private_text(target, "new-secret")
+
+    assert target.read_text(encoding="utf-8") == "keep-old"
+    assert list(target.parent.glob(".secret.txt.*.tmp")) == []
+
+
+def test_legacy_xfetch_sync_refuses_target_symlink(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    session_path = tmp_path / ".config" / "xfetch" / "session.json"
+    session_path.parent.mkdir(parents=True)
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"keep": "unchanged"}', encoding="utf-8")
+    try:
+        session_path.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    assert _sync_xfetch_session("new-auth", "new-ct0") is False
+    assert victim.read_text(encoding="utf-8") == '{"keep": "unchanged"}'
+    assert session_path.is_symlink()
+
+
+def test_legacy_xfetch_sync_refuses_parent_symlink(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_dir = tmp_path / ".config"
+    config_dir.mkdir()
+    victim_dir = tmp_path / "victim-dir"
+    victim_dir.mkdir()
+    xfetch_dir = config_dir / "xfetch"
+    try:
+        xfetch_dir.symlink_to(victim_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    assert _sync_xfetch_session("new-auth", "new-ct0") is False
+    assert not (victim_dir / "session.json").exists()
+    assert xfetch_dir.is_symlink()
+
+
+def test_legacy_xfetch_sync_refuses_ancestor_symlink(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    victim_dir = tmp_path / "victim-config"
+    victim_dir.mkdir()
+    config_dir = tmp_path / ".config"
+    try:
+        config_dir.symlink_to(victim_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    assert _sync_xfetch_session("new-auth", "new-ct0") is False
+    assert list(victim_dir.iterdir()) == []
+    assert config_dir.is_symlink()
+
+
+def test_legacy_xfetch_sync_refuses_oversized_existing_session(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    session_path = tmp_path / ".config" / "xfetch" / "session.json"
+    session_path.parent.mkdir(parents=True)
+    previous = json.dumps({"untrusted": "x" * (1024 * 1024)})
+    session_path.write_text(previous, encoding="utf-8")
+
+    assert _sync_xfetch_session("new-auth", "new-ct0") is False
+    assert session_path.read_text(encoding="utf-8") == previous
+
+
+def test_legacy_bird_sync_refuses_target_symlink(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    env_path = tmp_path / ".config" / "bird" / "credentials.env"
+    env_path.parent.mkdir(parents=True)
+    victim = tmp_path / "victim.env"
+    victim.write_text("KEEP=unchanged\n", encoding="utf-8")
+    try:
+        env_path.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    assert _sync_bird_env("new-auth", "new-ct0") is False
+    assert victim.read_text(encoding="utf-8") == "KEEP=unchanged\n"
+    assert env_path.is_symlink()
+
+
+def test_xhs_cookie_editor_json_ignores_non_xhs_domains(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    exported = [
+        {
+            "name": "web_session",
+            "value": "valid-root",
+            "domain": ".xiaohongshu.com",
+            "path": "/",
+        },
+        {
+            "name": "a1",
+            "value": "valid-subdomain",
+            "domain": "www.xiaohongshu.com",
+            "path": "/",
+        },
+        {
+            "name": "foreign",
+            "value": "must-not-persist",
+            "domain": ".example.com",
+            "path": "/",
+        },
+        {
+            "name": "lookalike",
+            "value": "must-not-persist",
+            "domain": ".notxiaohongshu.com",
+            "path": "/",
+        },
+    ]
+
+    cli._configure_xhs_cookies(json.dumps(exported))
+
+    cookie_path = tmp_path / ".agent-reach" / "xhs-cookies.json"
+    saved = json.loads(cookie_path.read_text(encoding="utf-8"))
+    assert [cookie["name"] for cookie in saved] == ["web_session", "a1"]
+    output = capsys.readouterr().out
+    assert "忽略" in output
+    assert "2" in output
+
+
+def test_xhs_cookie_editor_json_fails_without_valid_xhs_cookie(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: pytest.fail("invalid cookies must fail before tool lookup"),
+    )
+    exported = [
+        {
+            "name": "session",
+            "value": "foreign",
+            "domain": ".example.com",
+        },
+        {
+            "name": "lookalike",
+            "value": "foreign",
+            "domain": ".xiaohongshu.com.evil.test",
+        },
+    ]
+
+    monkeypatch.setattr("agent_reach.config.Config", lambda: object())
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_configure(
+            Namespace(
+                from_browser=None,
+                key="xhs-cookies",
+                value=[json.dumps(exported)],
+                sync_legacy_twitter=False,
+            )
+        )
+
+    assert exc.value.code == 1
+    assert not (tmp_path / ".agent-reach" / "xhs-cookies.json").exists()
+    output = capsys.readouterr().out
+    assert "没有有效的 xiaohongshu.com" in output
+
+
+def test_xhs_local_fallback_refuses_target_symlink(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    cookie_path = tmp_path / ".agent-reach" / "xhs-cookies.json"
+    cookie_path.parent.mkdir()
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"keep": "unchanged"}', encoding="utf-8")
+    try:
+        cookie_path.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    result = cli._configure_xhs_cookies("web_session=xhs-secret")
+
+    assert result is False
+    assert victim.read_text(encoding="utf-8") == '{"keep": "unchanged"}'
+    assert cookie_path.is_symlink()
+    assert "Could not save cookies" in capsys.readouterr().out
+
+
+def test_xhs_docker_success_via_configure_command_does_not_exit(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr("agent_reach.config.Config", lambda: object())
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        if args[1] == "ps":
+            return subprocess.CompletedProcess(
+                args, 0, stdout="xiaohongshu-mcp\n", stderr=""
+            )
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="/app/data/cookies.json\n", stderr=""
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._cmd_configure(
+        Namespace(
+            from_browser=None,
+            key="xhs-cookies",
+            value=["web_session=xhs-secret"],
+            sync_legacy_twitter=False,
+        )
+    )
+
+    assert "Cookies written to" in capsys.readouterr().out
+
+
+def test_xhs_docker_failure_via_configure_command_exits_one(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr("agent_reach.config.Config", lambda: object())
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/bin/docker" if name == "docker" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        if args[1] == "ps":
+            return subprocess.CompletedProcess(
+                args, 0, stdout="xiaohongshu-mcp\n", stderr=""
+            )
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="/app/data/cookies.json\n", stderr=""
+            )
+        if args[1] == "cp":
+            return subprocess.CompletedProcess(
+                args, 1, stdout="", stderr="copy failed"
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_configure(
+            Namespace(
+                from_browser=None,
+                key="xhs-cookies",
+                value=["web_session=xhs-secret"],
+                sync_legacy_twitter=False,
+            )
+        )
+
+    assert exc.value.code == 1
+    assert "Failed to copy cookies" in capsys.readouterr().out
+
+
+def test_ytdlp_config_write_refuses_target_symlink(
+    tmp_path, monkeypatch, capsys
+):
+    import shutil
+
+    import agent_reach.utils.paths as paths
+
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        paths.Path,
+        "home",
+        classmethod(lambda cls: tmp_path),
+    )
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    config_path = tmp_path / ".config" / "yt-dlp" / "config"
+    config_path.parent.mkdir(parents=True)
+    victim = tmp_path / "victim.conf"
+    victim.write_text("# keep unchanged\n", encoding="utf-8")
+    try:
+        config_path.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    def fake_which(name):
+        if name in {"gh", "node", "npm", "yt-dlp"}:
+            return f"/usr/bin/{name}"
+        return None
+
+    def fake_run(args, **_kwargs):
+        if args[-1:] == ["--version"] and args[0].endswith("yt-dlp"):
+            return subprocess.CompletedProcess(
+                args, 0, stdout="2026.07.04\n", stderr=""
+            )
+        stdout = "/tmp/npm-root\n" if args[1:3] == ["root", "-g"] else ""
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._install_system_deps()
+
+    assert victim.read_text(encoding="utf-8") == "# keep unchanged\n"
+    assert config_path.is_symlink()
+    assert "Could not configure yt-dlp JS runtime" in capsys.readouterr().out
+
+
+def test_transcribe_cli_scrubs_credentials_from_errors(
+    monkeypatch, capsys
+):
+    import agent_reach.transcribe as transcribe_module
+
+    secret_url = (
+        "https://alice:super-secret@example.test/audio"
+        "?access_token=hidden-token"
+    )
+
+    def fail_transcribe(*_args, **_kwargs):
+        raise transcribe_module.TranscribeError(
+            f"yt-dlp failed for {secret_url}"
+        )
+
+    monkeypatch.setattr(transcribe_module, "transcribe", fail_transcribe)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_transcribe(
+            Namespace(
+                source=secret_url,
+                provider="auto",
+                output=None,
+            )
+        )
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "alice:super-secret" not in output
+    assert "hidden-token" not in output
+    assert "***" in output
+
+
+def test_safe_install_with_proxy_makes_no_persistent_writes(
+    isolated_home, monkeypatch, capsys
+):
+    observed_configs = []
+    skill_calls = []
+
+    monkeypatch.setattr(cli, "_install_system_deps_safe", lambda: None)
+    monkeypatch.setattr(cli, "_install_mcporter_safe", lambda: None)
+    monkeypatch.setattr(
+        "agent_reach.doctor.check_all",
+        lambda config: observed_configs.append(config) or {},
+    )
+    monkeypatch.setattr(
+        "agent_reach.doctor.format_report",
+        lambda _results: "report",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_install_skill",
+        lambda: skill_calls.append("installed"),
+    )
+
+    cli._cmd_install(
+        Namespace(
+            env="local",
+            proxy="http://user:pass@proxy.example:8080",
+            safe=True,
+            dry_run=False,
+            channels="twitter",
+        )
+    )
+
+    assert len(observed_configs) == 1
+    assert observed_configs[0].read_only is True
+    assert skill_calls == []
+    assert not (isolated_home / ".agent-reach").exists()
+    assert not (isolated_home / ".agent-reach" / "tools").exists()
+    assert not (isolated_home / ".openclaw" / "skills" / "agent-reach").exists()
+    assert not (isolated_home / ".claude" / "skills" / "agent-reach").exists()
+    assert not (isolated_home / ".agents" / "skills" / "agent-reach").exists()
+    output = capsys.readouterr().out
+    assert "SAFE MODE" in output
+    assert "Would save network proxy" in output

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from agent_reach.probe import ProbeResult, probe_command, reinstall_hint
+from agent_reach.probe import probe_command, reinstall_hint
 
 
 def _make_executable(path, content):
@@ -25,7 +25,7 @@ def test_missing_command():
 @pytest.mark.skipif(sys.platform == "win32", reason="shebang semantics are POSIX-only")
 def test_broken_shebang_detected_as_broken(tmp_path, monkeypatch):
     """A stale venv shim: which() finds it, exec raises FileNotFoundError."""
-    script = _make_executable(
+    _make_executable(
         tmp_path / "stale-tool", "#!/nonexistent/venv/bin/python\nprint('hi')\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -38,7 +38,7 @@ def test_broken_shebang_detected_as_broken(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
-    script = _make_executable(
+    _make_executable(
         tmp_path / "healthy-tool", "#!/bin/sh\necho 'healthy-tool 1.2.3'\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -49,8 +49,33 @@ def test_healthy_command_returns_ok_with_output(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
+def test_probe_child_env_can_add_and_remove_without_mutating_parent(tmp_path, monkeypatch):
+    _make_executable(
+        tmp_path / "env-tool",
+        (
+            "#!/bin/sh\n"
+            'if [ -n "${BLOCKED_APP_VAR+x}" ]; then exit 78; fi\n'
+            'echo "$PROBE_ONLY_VALUE"\n'
+        ),
+    )
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+    monkeypatch.setenv("BLOCKED_APP_VAR", "inherited")
+
+    result = probe_command(
+        "env-tool",
+        env={"PROBE_ONLY_VALUE": "child-only"},
+        remove_env=("BLOCKED_APP_VAR",),
+    )
+
+    assert result.ok
+    assert result.output == "child-only"
+    assert os.environ["BLOCKED_APP_VAR"] == "inherited"
+    assert "PROBE_ONLY_VALUE" not in os.environ
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_nonzero_exit_classified_as_error(tmp_path, monkeypatch):
-    script = _make_executable(
+    _make_executable(
         tmp_path / "failing-tool", "#!/bin/sh\necho 'boom' >&2\nexit 3\n"
     )
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
@@ -62,7 +87,7 @@ def test_nonzero_exit_classified_as_error(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="shell script fixture is POSIX-only")
 def test_exit_127_classified_as_broken(tmp_path, monkeypatch):
-    script = _make_executable(tmp_path / "wrapper-tool", "#!/bin/sh\nexit 127\n")
+    _make_executable(tmp_path / "wrapper-tool", "#!/bin/sh\nexit 127\n")
     monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
 
     r = probe_command("wrapper-tool", package="wrapper-pkg")
@@ -74,7 +99,7 @@ def test_exit_127_classified_as_broken(tmp_path, monkeypatch):
 def test_retries_help_transient_failures(tmp_path, monkeypatch):
     """First call fails (exit 1), second succeeds — retries=1 should return ok."""
     marker = tmp_path / "ran-once"
-    script = _make_executable(
+    _make_executable(
         tmp_path / "flaky-tool",
         f"#!/bin/sh\nif [ -f {marker} ]; then echo ok; exit 0; fi\ntouch {marker}\nexit 1\n",
     )

--- a/tests/test_reddit_channel.py
+++ b/tests/test_reddit_channel.py
@@ -1,218 +1,226 @@
 # -*- coding: utf-8 -*-
-"""Dedicated tests for the ``reddit`` channel.
+"""Dedicated tests for Reddit's read-only multi-backend health check."""
 
-Reddit is a tier-1, multi-backend channel (OpenCLI → rdt-cli) with no
-zero-config path, so its ``check`` has the richest branching of the text
-channels: per-backend probing, ok/warn/error/off precedence, and a
-hand-rolled ``rdt status --json`` parse that must map every subprocess
-outcome onto the probe vocabulary. Follow-up to #331 — completes dedicated
-coverage after rss (#360), github (#361) and web (#363).
-"""
-
+import json
+import time
 from unittest.mock import Mock, patch
 
 from agent_reach.channels.reddit import RedditChannel
 
 
-def _cp(stdout="", stderr="", returncode=0):
-    m = Mock()
-    m.stdout = stdout
-    m.stderr = stderr
-    m.returncode = returncode
-    return m
-
-
-# --- can_handle ---
-
 def test_can_handle_matches_reddit_hosts():
-    ch = RedditChannel()
+    channel = RedditChannel()
     for url in [
         "https://reddit.com/r/python",
         "https://www.reddit.com/r/python/comments/abc/title/",
         "https://old.reddit.com/r/python",
         "https://redd.it/abc123",
-        "HTTPS://REDDIT.COM/r/Python",  # case-insensitive netloc
+        "HTTPS://REDDIT.COM/r/Python",
     ]:
-        assert ch.can_handle(url) is True, url
+        assert channel.can_handle(url) is True, url
 
 
 def test_can_handle_rejects_non_reddit():
-    ch = RedditChannel()
-    # Matching is netloc-substring based (the codebase-wide convention), so
-    # use hosts that genuinely don't contain the reddit markers.
+    channel = RedditChannel()
     for url in ["https://example.com/r/python", "https://twitter.com/u", ""]:
-        assert ch.can_handle(url) is False, url
+        assert channel.can_handle(url) is False, url
 
-
-# --- _check_rdt: map every subprocess outcome onto the probe vocabulary ---
 
 def test_check_rdt_returns_none_when_not_installed():
-    ch = RedditChannel()
     with patch("shutil.which", return_value=None):
-        assert ch._check_rdt() is None
+        assert RedditChannel()._check_rdt() is None
 
 
-def test_check_rdt_authenticated_with_username_is_ok():
-    ch = RedditChannel()
-    payload = '{"data": {"authenticated": true, "username": "alice"}}'
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stdout=payload, returncode=0)
-    ):
-        status, message = ch._check_rdt()
-    assert status == "ok"
-    assert "alice" in message
+def test_check_rdt_missing_credential_is_warn():
+    with patch("shutil.which", return_value="/usr/local/bin/rdt"):
+        status, message = RedditChannel()._check_rdt()
 
-
-def test_check_rdt_authenticated_without_username_is_ok_no_suffix():
-    ch = RedditChannel()
-    payload = '{"data": {"authenticated": true}}'
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stdout=payload, returncode=0)
-    ):
-        status, message = ch._check_rdt()
-    assert status == "ok"
-    assert "已登录" not in message
-
-
-def test_check_rdt_not_authenticated_is_warn():
-    ch = RedditChannel()
-    payload = '{"data": {"authenticated": false}}'
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stdout=payload, returncode=0)
-    ):
-        status, message = ch._check_rdt()
     assert status == "warn"
-    assert "未登录" in message
+    assert "Cookie-Editor" in message
 
 
-def test_check_rdt_unparseable_status_is_warn():
-    ch = RedditChannel()
+def test_check_rdt_saved_credential_is_unverified_not_false_ok(
+    isolated_home,
+):
+    path = isolated_home / ".config" / "rdt-cli" / "credential.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cookies": {"reddit_session": "explicit"},
+                "saved_at": time.time(),
+            }
+        ),
+        encoding="utf-8",
+    )
     with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stdout="not json", returncode=0)
-    ):
-        status, message = ch._check_rdt()
+        "subprocess.run"
+    ) as run:
+        status, message = RedditChannel()._check_rdt()
+
     assert status == "warn"
-    assert "无法解析" in message
+    assert "未实时验证" in message
+    run.assert_not_called()
 
 
-def test_check_rdt_broken_exit_code_is_error_with_venv_hint():
-    ch = RedditChannel()
+def test_check_rdt_stale_credential_is_not_refreshed(isolated_home):
+    path = isolated_home / ".config" / "rdt-cli" / "credential.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cookies": {"reddit_session": "explicit"},
+                "saved_at": time.time() - 8 * 86400,
+            }
+        ),
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
     with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stderr="", returncode=127)
-    ):
-        status, message = ch._check_rdt()
-    assert status == "error"
-    assert "强制重装" in message  # the venv-relink prescription
+        "subprocess.run"
+    ) as run:
+        status, message = RedditChannel()._check_rdt()
+
+    assert status == "warn"
+    assert "超过 7 天" in message
+    assert path.read_bytes() == before
+    run.assert_not_called()
 
 
-def test_check_rdt_nonzero_exit_reports_tail():
-    ch = RedditChannel()
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", return_value=_cp(stderr="boom: network down", returncode=1)
-    ):
-        status, message = ch._check_rdt()
-    assert status == "error"
-    assert "exit 1" in message
-    assert "boom: network down" in message
+def test_check_rdt_unparseable_credential_is_warn(isolated_home):
+    path = isolated_home / ".config" / "rdt-cli" / "credential.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("not json", encoding="utf-8")
+    with patch("shutil.which", return_value="/usr/local/bin/rdt"):
+        status, message = RedditChannel()._check_rdt()
+
+    assert status == "warn"
+    assert "无法安全解析" in message
 
 
-def test_check_rdt_timeout_is_error():
-    import subprocess
-    ch = RedditChannel()
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="rdt", timeout=10)
-    ):
-        status, message = ch._check_rdt()
-    assert status == "error"
-    assert "超时" in message
+def test_check_rdt_refuses_symlink_credential(isolated_home):
+    victim = isolated_home / "victim.json"
+    victim.write_text('{"secret": "do-not-read"}', encoding="utf-8")
+    path = isolated_home / ".config" / "rdt-cli" / "credential.json"
+    path.parent.mkdir(parents=True)
+    path.symlink_to(victim)
+    with patch("shutil.which", return_value="/usr/local/bin/rdt"):
+        status, message = RedditChannel()._check_rdt()
+
+    assert status == "warn"
+    assert "符号链接" in message
 
 
-def test_check_rdt_oserror_is_broken():
-    ch = RedditChannel()
-    with patch("shutil.which", return_value="/usr/local/bin/rdt"), patch(
-        "subprocess.run", side_effect=OSError("exec format error")
-    ):
-        status, message = ch._check_rdt()
-    assert status == "error"
-    assert "强制重装" in message
+def test_check_rdt_refuses_ancestor_symlink(isolated_home):
+    victim_dir = isolated_home / "victim-config"
+    credential_path = victim_dir / "rdt-cli" / "credential.json"
+    credential_path.parent.mkdir(parents=True)
+    credential_path.write_text(
+        '{"cookies": {"reddit_session": "do-not-read"}}',
+        encoding="utf-8",
+    )
+    (isolated_home / ".config").symlink_to(
+        victim_dir,
+        target_is_directory=True,
+    )
 
+    with patch("shutil.which", return_value="/usr/local/bin/rdt"):
+        status, message = RedditChannel()._check_rdt()
 
-# --- _check_opencli: maps OpenCLIStatus onto the probe vocabulary ---
+    assert status == "warn"
+    assert "符号链接" in message
+
 
 def _opencli(installed=True, broken=False, ready=True, hint=""):
     return Mock(installed=installed, broken=broken, ready=ready, hint=hint)
 
 
 def test_check_opencli_not_installed_is_none():
-    ch = RedditChannel()
-    with patch("agent_reach.backends.opencli_status", return_value=_opencli(installed=False)):
-        assert ch._check_opencli() is None
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(installed=False),
+    ):
+        assert RedditChannel()._check_opencli() is None
 
 
 def test_check_opencli_broken_is_error():
-    ch = RedditChannel()
-    with patch("agent_reach.backends.opencli_status",
-               return_value=_opencli(broken=True, hint="reinstall opencli")):
-        status, message = ch._check_opencli()
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(broken=True, hint="reinstall opencli"),
+    ):
+        status, message = RedditChannel()._check_opencli()
     assert status == "error"
     assert message == "reinstall opencli"
 
 
-def test_check_opencli_ready_is_ok():
-    ch = RedditChannel()
-    with patch("agent_reach.backends.opencli_status", return_value=_opencli(ready=True)):
-        status, message = ch._check_opencli()
-    assert status == "ok"
-    assert "OpenCLI" in message
+def test_check_opencli_bridge_ready_is_unverified():
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(ready=True),
+    ):
+        status, message = RedditChannel()._check_opencli()
+    assert status == "warn"
+    assert "桥接已连接" in message
+    assert "登录态和实际命令未实时验证" in message
 
 
 def test_check_opencli_installed_not_ready_is_warn():
-    ch = RedditChannel()
-    with patch("agent_reach.backends.opencli_status",
-               return_value=_opencli(ready=False, hint="connect the extension")):
-        status, message = ch._check_opencli()
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(ready=False, hint="connect the extension"),
+    ):
+        status, message = RedditChannel()._check_opencli()
     assert status == "warn"
     assert message == "connect the extension"
 
 
-# --- check(): precedence across backends + active_backend selection ---
-
 def test_check_prefers_ok_over_warn_regardless_of_probe_order():
-    # OpenCLI probes first and only warns; rdt-cli is fully ok. The ok
-    # backend must win and become active even though it was probed second.
-    ch = RedditChannel()
-    with patch.object(ch, "_check_opencli", return_value=("warn", "opencli sleepy")), \
-         patch.object(ch, "_check_rdt", return_value=("ok", "rdt ready")):
-        status, message = ch.check()
+    channel = RedditChannel()
+    with patch.object(
+        channel, "_check_opencli", return_value=("warn", "opencli sleepy")
+    ), patch.object(
+        channel, "_check_rdt", return_value=("ok", "rdt ready")
+    ):
+        status, message = channel.check()
+
     assert status == "ok"
     assert message == "rdt ready"
-    assert ch.active_backend == "rdt-cli"
+    assert channel.active_backend == "rdt-cli"
 
 
-def test_check_first_ok_backend_becomes_active():
-    ch = RedditChannel()
-    with patch.object(ch, "_check_opencli", return_value=("ok", "opencli ready")), \
-         patch.object(ch, "_check_rdt", return_value=("warn", "rdt not logged in")):
-        status, _ = ch.check()
-    assert status == "ok"
-    assert ch.active_backend == "OpenCLI"
+def test_check_warn_has_no_active_backend():
+    channel = RedditChannel()
+    with patch.object(
+        channel, "_check_opencli", return_value=("warn", "not ready")
+    ), patch.object(
+        channel, "_check_rdt", return_value=("warn", "unverified")
+    ):
+        status, message = channel.check()
+
+    assert status == "warn"
+    assert message == "not ready"
+    assert channel.active_backend is None
 
 
 def test_check_all_errors_returns_error_and_no_active_backend():
-    ch = RedditChannel()
-    with patch.object(ch, "_check_opencli", return_value=("error", "e1")), \
-         patch.object(ch, "_check_rdt", return_value=("error", "e2")):
-        status, message = ch.check()
+    channel = RedditChannel()
+    with patch.object(
+        channel, "_check_opencli", return_value=("error", "e1")
+    ), patch.object(channel, "_check_rdt", return_value=("error", "e2")):
+        status, message = channel.check()
+
     assert status == "error"
     assert "e1" in message and "e2" in message
-    assert ch.active_backend is None
+    assert channel.active_backend is None
 
 
 def test_check_no_backend_installed_is_off():
-    ch = RedditChannel()
-    with patch.object(ch, "_check_opencli", return_value=None), \
-         patch.object(ch, "_check_rdt", return_value=None):
-        status, message = ch.check()
+    channel = RedditChannel()
+    with patch.object(channel, "_check_opencli", return_value=None), patch.object(
+        channel, "_check_rdt", return_value=None
+    ):
+        status, message = channel.check()
+
     assert status == "off"
-    assert "零配置" in message  # "no zero-config path" guidance
-    assert ch.active_backend is None
+    assert "零配置" in message
+    assert channel.active_backend is None

--- a/tests/test_scrub_credentials.py
+++ b/tests/test_scrub_credentials.py
@@ -1,0 +1,103 @@
+"""Secrets embedded in URLs must not reach user-facing diagnostics."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agent_reach import cookie_extract
+from agent_reach.channels import v2ex as v2ex_module
+from agent_reach.channels import xueqiu as xueqiu_module
+from agent_reach.channels.v2ex import V2EXChannel
+from agent_reach.channels.xueqiu import XueqiuChannel
+from agent_reach.utils.text import scrub_url_credentials
+
+
+def test_scrubs_userinfo_and_sensitive_query_values():
+    raw = (
+        "proxy http://user:pass@proxy.example:8080 failed; "
+        "upstream https://api.example.test/path?access_token=secret"
+        "&page=2&api_key=another-secret"
+    )
+
+    scrubbed = scrub_url_credentials(raw)
+
+    assert "user:pass" not in scrubbed
+    assert "secret" not in scrubbed
+    assert "another-secret" not in scrubbed
+    assert "http://***@proxy.example:8080" in scrubbed
+    assert "access_token=***" in scrubbed
+    assert "page=2" in scrubbed
+    assert "api_key=***" in scrubbed
+
+
+def test_scrubs_multiple_schemes_and_fragment_tokens():
+    raw = (
+        "socks5://token@host:1080 "
+        "https://example.test/#auth_token=fragment-secret"
+    )
+
+    scrubbed = scrub_url_credentials(ValueError(raw))
+
+    assert scrubbed == (
+        "socks5://***@host:1080 "
+        "https://example.test/#auth_token=***"
+    )
+
+
+def test_scrubs_bare_user_password_host_diagnostics():
+    raw = "proxy handshake for user:pass@proxy.test failed"
+    assert scrub_url_credentials(raw) == "proxy handshake for ***@proxy.test failed"
+
+
+def test_leaves_non_secret_urls_and_plain_text_unchanged():
+    raw = "See https://example.test/search?q=python&page=2 after timeout"
+    assert scrub_url_credentials(raw) == raw
+
+
+@pytest.mark.parametrize(
+    ("module", "channel"),
+    [
+        (v2ex_module, V2EXChannel()),
+        (xueqiu_module, XueqiuChannel()),
+    ],
+)
+def test_channel_health_messages_scrub_url_secrets(module, channel, monkeypatch):
+    def fail(_url):
+        raise RuntimeError(
+            "proxy http://user:pass@proxy.test:8080 refused "
+            "https://api.test/data?access_token=top-secret"
+        )
+
+    monkeypatch.setattr(module, "_get_json", fail)
+
+    _status, message = channel.check()
+
+    assert "user:pass" not in message
+    assert "top-secret" not in message
+    assert "***" in message
+
+
+def test_browser_backend_errors_scrub_url_secrets(monkeypatch):
+    def chrome(_domains):
+        raise RuntimeError(
+            "failed via http://user:pass@proxy.test "
+            "https://api.test/?token=top-secret"
+        )
+
+    fake_rookiepy = SimpleNamespace(
+        chrome=chrome,
+        firefox=lambda domains: [],
+        edge=lambda domains: [],
+        brave=lambda domains: [],
+        opera=lambda domains: [],
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+
+    with pytest.raises(RuntimeError) as error:
+        cookie_extract.extract_all("chrome", platform="xueqiu")
+
+    message = str(error.value)
+    assert "user:pass" not in message
+    assert "top-secret" not in message
+    assert "***" in message

--- a/tests/test_scrub_credentials.py
+++ b/tests/test_scrub_credentials.py
@@ -63,7 +63,7 @@ def test_leaves_non_secret_urls_and_plain_text_unchanged():
     ],
 )
 def test_channel_health_messages_scrub_url_secrets(module, channel, monkeypatch):
-    def fail(_url):
+    def fail(_url, *_args, **_kwargs):
         raise RuntimeError(
             "proxy http://user:pass@proxy.test:8080 refused "
             "https://api.test/data?access_token=top-secret"

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for agent_reach.transcribe — provider routing, fallback, and errors."""
 
+import subprocess
 from pathlib import Path
 from typing import List
 
@@ -27,6 +28,12 @@ def chunk_file(tmp_path):
     p = tmp_path / "chunk.m4a"
     p.write_bytes(b"\x00fake-m4a-bytes")
     return p
+
+
+@pytest.fixture
+def bounded_audio_duration(monkeypatch):
+    """Treat synthetic fixture bytes as a short valid audio stream."""
+    monkeypatch.setattr(tr, "_probe_audio_duration", lambda _path: 60.0)
 
 
 class FakeResponse:
@@ -161,6 +168,96 @@ class TestFallback:
 
 
 class TestOrchestrator:
+    def test_rejects_overlong_audio_before_compression(
+        self, monkeypatch, fake_config, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        events = []
+
+        def fake_run(cmd, **_kwargs):
+            events.append(cmd[0])
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=str(tr.MAX_AUDIO_SECONDS + 1),
+                stderr="",
+            )
+
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            tr,
+            "compress_audio",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("overlong audio must fail before compression")
+            ),
+        )
+
+        with pytest.raises(tr.TranscribeError, match="duration.*limit"):
+            tr.transcribe(str(chunk_file), config=fake_config)
+
+        assert events == ["ffprobe"]
+
+    def test_duration_probe_timeout_fails_before_compression(
+        self, monkeypatch, fake_config, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        observed = {}
+
+        def timeout_probe(cmd, **_kwargs):
+            observed["timeout"] = _kwargs.get("timeout")
+            raise subprocess.TimeoutExpired(
+                cmd,
+                timeout=tr.FFPROBE_TIMEOUT_SECONDS,
+            )
+
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr.subprocess, "run", timeout_probe)
+        monkeypatch.setattr(
+            tr,
+            "compress_audio",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("timed-out probe must fail before compression")
+            ),
+        )
+
+        with pytest.raises(
+            tr.TranscribeError,
+            match=r"ffprobe timed out.*30s",
+        ):
+            tr.transcribe(str(chunk_file), config=fake_config)
+
+        assert observed["timeout"] == tr.FFPROBE_TIMEOUT_SECONDS
+
+    def test_unparseable_duration_fails_before_compression(
+        self, monkeypatch, fake_config, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(
+            tr.subprocess,
+            "run",
+            lambda cmd, **_kwargs: subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="N/A\n",
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(
+            tr,
+            "compress_audio",
+            lambda *_args: (_ for _ in ()).throw(
+                AssertionError("invalid duration must fail before compression")
+            ),
+        )
+
+        with pytest.raises(
+            tr.TranscribeError,
+            match=r"ffprobe could not parse.*duration",
+        ):
+            tr.transcribe(str(chunk_file), config=fake_config)
+
     def test_rejects_oversized_source_before_compression(
         self, monkeypatch, fake_config, chunk_file
     ):
@@ -177,7 +274,14 @@ class TestOrchestrator:
         with pytest.raises(tr.TranscribeError, match="source.*limit"):
             tr.transcribe(str(chunk_file), config=fake_config)
 
-    def test_local_file_skips_yt_dlp(self, monkeypatch, fake_config, tmp_path, chunk_file):
+    def test_local_file_skips_yt_dlp(
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        chunk_file,
+        bounded_audio_duration,
+    ):
         fake_config.set("groq_api_key", "gsk_test")
 
         def boom_download(*a, **k):
@@ -206,7 +310,12 @@ class TestOrchestrator:
         assert text == "transcript text"
 
     def test_chunks_concatenated_with_newlines(
-        self, monkeypatch, fake_config, tmp_path, chunk_file
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        chunk_file,
+        bounded_audio_duration,
     ):
         fake_config.set("groq_api_key", "gsk_test")
         # Force the "needs chunking" path by writing a file above the size limit.
@@ -234,7 +343,12 @@ class TestOrchestrator:
         assert text == "part one\npart two"
 
     def test_rejects_too_many_chunks_before_any_provider_call(
-        self, monkeypatch, fake_config, tmp_path, chunk_file
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        chunk_file,
+        bounded_audio_duration,
     ):
         fake_config.set("groq_api_key", "gsk_test")
         monkeypatch.setattr(tr, "SIZE_LIMIT_BYTES", 1)
@@ -262,7 +376,12 @@ class TestOrchestrator:
         assert provider_calls == []
 
     def test_rejects_excessive_total_chunk_bytes_before_provider_calls(
-        self, monkeypatch, fake_config, tmp_path, chunk_file
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        chunk_file,
+        bounded_audio_duration,
     ):
         fake_config.set("groq_api_key", "gsk_test")
         monkeypatch.setattr(tr, "SIZE_LIMIT_BYTES", 10)
@@ -297,7 +416,13 @@ class TestOrchestrator:
         with pytest.raises(tr.TranscribeError, match="unknown provider"):
             tr.transcribe(str(chunk_file), provider="azure", config=fake_config)
 
-    def test_auto_temp_dir_is_cleaned_up(self, monkeypatch, fake_config, tmp_path):
+    def test_auto_temp_dir_is_cleaned_up(
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        bounded_audio_duration,
+    ):
         fake_config.set("groq_api_key", "gsk_test")
         created_work_dirs = []
 
@@ -341,7 +466,13 @@ class TestOrchestrator:
         assert created_work_dirs
         assert not created_work_dirs[0].exists()
 
-    def test_explicit_out_dir_is_preserved(self, monkeypatch, fake_config, tmp_path):
+    def test_explicit_out_dir_is_preserved(
+        self,
+        monkeypatch,
+        fake_config,
+        tmp_path,
+        bounded_audio_duration,
+    ):
         fake_config.set("groq_api_key", "gsk_test")
         work = tmp_path / "caller-owned"
 
@@ -451,6 +582,61 @@ class TestDownloadAudioSafety:
         tr.download_audio("https://youtu.be/abc123", tmp_path)
 
         assert captured["cmd"][-1] == "https://youtu.be/abc123"
+
+
+class TestMediaGenerationBudget:
+    def test_compression_has_hard_duration_cap(
+        self, monkeypatch, tmp_path, chunk_file
+    ):
+        captured = {}
+
+        def fake_run(cmd, timeout=600):
+            captured["cmd"] = cmd
+            (tmp_path / "compressed.m4a").write_bytes(b"compressed")
+
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr, "_run", fake_run)
+
+        tr.compress_audio(chunk_file, tmp_path)
+
+        duration_index = captured["cmd"].index("-t")
+        assert captured["cmd"][duration_index + 1] == str(tr.MAX_AUDIO_SECONDS)
+
+    def test_chunk_generation_has_hard_duration_cap(
+        self, monkeypatch, tmp_path, chunk_file
+    ):
+        captured = {}
+
+        def fake_run(cmd, timeout=600):
+            captured["cmd"] = cmd
+            (tmp_path / "chunk_000.m4a").write_bytes(b"chunk")
+
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr, "_run", fake_run)
+
+        tr.chunk_audio(chunk_file, tmp_path)
+
+        duration_index = captured["cmd"].index("-t")
+        assert captured["cmd"][duration_index + 1] == str(tr.MAX_AUDIO_SECONDS)
+
+    def test_chunk_generation_rejects_segment_size_that_can_exceed_budget(
+        self, monkeypatch, tmp_path, chunk_file
+    ):
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(
+            tr,
+            "_run",
+            lambda *_args, **_kwargs: pytest.fail(
+                "unsafe chunk budget must fail before ffmpeg"
+            ),
+        )
+
+        with pytest.raises(tr.TranscribeError, match=r"chunk.*limit.*24"):
+            tr.chunk_audio(
+                chunk_file,
+                tmp_path,
+                segment_seconds=tr.CHUNK_SECONDS - 1,
+            )
 
 
 # --- YouTubeChannel integration --------------------------------------- #

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -161,6 +161,22 @@ class TestFallback:
 
 
 class TestOrchestrator:
+    def test_rejects_oversized_source_before_compression(
+        self, monkeypatch, fake_config, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        monkeypatch.setattr(tr, "MAX_SOURCE_BYTES", 4)
+        monkeypatch.setattr(
+            tr,
+            "compress_audio",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("oversized source must fail before ffmpeg")
+            ),
+        )
+
+        with pytest.raises(tr.TranscribeError, match="source.*limit"):
+            tr.transcribe(str(chunk_file), config=fake_config)
+
     def test_local_file_skips_yt_dlp(self, monkeypatch, fake_config, tmp_path, chunk_file):
         fake_config.set("groq_api_key", "gsk_test")
 
@@ -216,6 +232,62 @@ class TestOrchestrator:
             config=fake_config,
         )
         assert text == "part one\npart two"
+
+    def test_rejects_too_many_chunks_before_any_provider_call(
+        self, monkeypatch, fake_config, tmp_path, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        monkeypatch.setattr(tr, "SIZE_LIMIT_BYTES", 1)
+        compressed = tmp_path / "compressed.m4a"
+        compressed.write_bytes(b"xx")
+        monkeypatch.setattr(tr, "compress_audio", lambda *_args: compressed)
+
+        chunks = []
+        for index in range(tr.MAX_CHUNKS + 1):
+            chunk = tmp_path / f"chunk_{index:03d}.m4a"
+            chunk.write_bytes(b"x")
+            chunks.append(chunk)
+        monkeypatch.setattr(tr, "chunk_audio", lambda *_args: chunks)
+
+        provider_calls = []
+        monkeypatch.setattr(
+            tr,
+            "_transcribe_with_fallback",
+            lambda *_args: provider_calls.append("called") or "text",
+        )
+
+        with pytest.raises(tr.TranscribeError, match="chunks.*limit"):
+            tr.transcribe(str(chunk_file), out_dir=tmp_path / "work", config=fake_config)
+
+        assert provider_calls == []
+
+    def test_rejects_excessive_total_chunk_bytes_before_provider_calls(
+        self, monkeypatch, fake_config, tmp_path, chunk_file
+    ):
+        fake_config.set("groq_api_key", "gsk_test")
+        monkeypatch.setattr(tr, "SIZE_LIMIT_BYTES", 10)
+        monkeypatch.setattr(tr, "MAX_TOTAL_CHUNK_BYTES", 5)
+        compressed = tmp_path / "compressed.m4a"
+        compressed.write_bytes(b"x" * 11)
+        monkeypatch.setattr(tr, "compress_audio", lambda *_args: compressed)
+
+        first = tmp_path / "chunk_000.m4a"
+        second = tmp_path / "chunk_001.m4a"
+        first.write_bytes(b"aaa")
+        second.write_bytes(b"bbb")
+        monkeypatch.setattr(tr, "chunk_audio", lambda *_args: [first, second])
+
+        provider_calls = []
+        monkeypatch.setattr(
+            tr,
+            "_transcribe_with_fallback",
+            lambda *_args: provider_calls.append("called") or "text",
+        )
+
+        with pytest.raises(tr.TranscribeError, match="total.*limit"):
+            tr.transcribe(str(chunk_file), out_dir=tmp_path / "work", config=fake_config)
+
+        assert provider_calls == []
 
     def test_no_provider_configured_fails_fast(self, fake_config, chunk_file):
         with pytest.raises(tr.NoProviderConfigured):
@@ -298,6 +370,20 @@ class TestOrchestrator:
 
 
 class TestDownloadAudioSafety:
+    def test_rejects_download_that_exceeds_limit(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr, "MAX_SOURCE_BYTES", 4)
+
+        def fake_run(_cmd, timeout=600):
+            (tmp_path / "source.m4a").write_bytes(b"audio")
+
+        monkeypatch.setattr(tr, "_run", fake_run)
+
+        with pytest.raises(tr.TranscribeError, match="downloaded source.*limit"):
+            tr.download_audio("https://example.com/watch?v=123", tmp_path)
+
     def test_rejects_private_network_url_before_yt_dlp(self, monkeypatch, tmp_path):
         monkeypatch.setattr(tr, "_require", lambda binary: None)
 
@@ -323,8 +409,11 @@ class TestDownloadAudioSafety:
 
         assert audio == tmp_path / "source.m4a"
         assert "--" in captured["cmd"]
+        assert "--no-playlist" in captured["cmd"]
         marker_index = captured["cmd"].index("--")
         assert captured["cmd"][marker_index + 1] == "https://example.com/watch?v=123"
+        max_size_index = captured["cmd"].index("--max-filesize")
+        assert captured["cmd"][max_size_index + 1] == str(tr.MAX_SOURCE_BYTES)
 
     def test_preserves_bare_public_urls_supported_by_yt_dlp(self, monkeypatch, tmp_path):
         monkeypatch.setattr(tr, "_require", lambda binary: None)

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -1,38 +1,36 @@
 # -*- coding: utf-8 -*-
+"""Twitter health checks must never trigger upstream browser-cookie fallback."""
 
 import os
 from unittest.mock import Mock, patch
 
-from agent_reach.channels.twitter import TwitterChannel
+from agent_reach.backends import OpenCLIStatus
+from agent_reach.channels.twitter import (
+    TwitterChannel,
+    twitter_cli_child_env,
+)
 
 
-def _cp(stdout="", stderr="", returncode=0):
-    m = Mock()
-    m.stdout = stdout
-    m.stderr = stderr
-    m.returncode = returncode
-    return m
+def _which(*present):
+    return lambda name: f"/usr/local/bin/{name}" if name in present else None
 
 
-# --- twitter-cli tests ---
-
-def test_check_twitter_cli_found_and_auth_ok():
-    """twitter-cli found + twitter status ok → ok."""
+def test_twitter_cli_without_explicit_auth_is_unverified():
     channel = TwitterChannel()
-    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None), patch(
+    with patch("shutil.which", side_effect=_which("twitter")), patch(
         "subprocess.run",
-        return_value=_cp(stdout="ok: true\nusername: testuser\n", returncode=0),
+        side_effect=AssertionError("twitter status must not run"),
     ):
         status, message = channel.check()
-    assert status == "ok"
-    assert "twitter-cli" in message
-    assert "完整可用" in message
-    assert channel.active_backend == "twitter-cli"
+
+    assert status == "warn"
+    assert "Cookie-Editor" in message
+    assert channel.active_backend is None
 
 
-def test_check_uses_credentials_saved_by_agent_reach_only_in_child_env(monkeypatch):
-    """Saved cookies must make the independent doctor probe authenticated."""
-    channel = TwitterChannel()
+def test_saved_credentials_are_recognised_without_starting_upstream(
+    monkeypatch,
+):
     config = Mock()
     config.get.side_effect = lambda key: {
         "twitter_auth_token": "saved-auth-token",
@@ -41,25 +39,24 @@ def test_check_uses_credentials_saved_by_agent_reach_only_in_child_env(monkeypat
     monkeypatch.delenv("TWITTER_AUTH_TOKEN", raising=False)
     monkeypatch.delenv("TWITTER_CT0", raising=False)
 
-    with patch(
-        "shutil.which",
-        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
-    ), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="ok: true\n", returncode=0),
+    with patch("shutil.which", side_effect=_which("twitter")), patch(
+        "subprocess.run"
     ) as run:
-        status, _ = channel.check(config)
+        channel = TwitterChannel()
+        status, message = channel.check(config)
 
-    child_env = run.call_args.kwargs["env"]
-    assert status == "ok"
-    assert child_env["TWITTER_AUTH_TOKEN"] == "saved-auth-token"
-    assert child_env["TWITTER_CT0"] == "saved-ct0"
+    assert status == "warn"
+    assert "已配置" in message
+    assert "不会执行" in message
+    assert channel.active_backend is None
+    run.assert_not_called()
     assert "TWITTER_AUTH_TOKEN" not in os.environ
     assert "TWITTER_CT0" not in os.environ
 
 
-def test_existing_twitter_env_takes_priority_over_saved_config(monkeypatch):
-    channel = TwitterChannel()
+def test_child_env_keeps_existing_shell_credentials_authoritative(
+    monkeypatch,
+):
     config = Mock()
     config.get.side_effect = lambda key: {
         "twitter_auth_token": "saved-auth-token",
@@ -68,173 +65,107 @@ def test_existing_twitter_env_takes_priority_over_saved_config(monkeypatch):
     monkeypatch.setenv("TWITTER_AUTH_TOKEN", "shell-auth-token")
     monkeypatch.setenv("TWITTER_CT0", "shell-ct0")
 
-    with patch(
-        "shutil.which",
-        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
-    ), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="ok: true\n", returncode=0),
-    ) as run:
-        status, _ = channel.check(config)
-
-    child_env = run.call_args.kwargs["env"]
-    assert status == "ok"
-    assert child_env["TWITTER_AUTH_TOKEN"] == "shell-auth-token"
-    assert child_env["TWITTER_CT0"] == "shell-ct0"
+    assert twitter_cli_child_env(config) == {}
     assert os.environ["TWITTER_AUTH_TOKEN"] == "shell-auth-token"
     assert os.environ["TWITTER_CT0"] == "shell-ct0"
 
 
-def test_check_twitter_cli_found_auth_missing():
-    """twitter-cli found + not_authenticated → warn about auth."""
-    channel = TwitterChannel()
-    with patch("shutil.which", side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None), patch(
+def test_child_env_supplies_only_missing_saved_credentials(monkeypatch):
+    config = Mock()
+    config.get.side_effect = lambda key: {
+        "twitter_auth_token": "saved-auth-token",
+        "twitter_ct0": "saved-ct0",
+    }.get(key)
+    monkeypatch.setenv("TWITTER_AUTH_TOKEN", "shell-auth-token")
+    monkeypatch.delenv("TWITTER_CT0", raising=False)
+
+    assert twitter_cli_child_env(config) == {"TWITTER_CT0": "saved-ct0"}
+
+
+def test_bird_with_explicit_env_remains_unverified(monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "explicit-auth")
+    monkeypatch.setenv("CT0", "explicit-ct0")
+    with patch("shutil.which", side_effect=_which("bird")), patch(
         "subprocess.run",
-        return_value=_cp(
-            stderr="ok: false\nerror:\n  code: not_authenticated\n",
-            returncode=1,
-        ),
+        side_effect=AssertionError("bird check must not run"),
     ):
+        channel = TwitterChannel()
         status, message = channel.check()
+
     assert status == "warn"
-    assert "未认证" in message
-    # 未认证是业务态：工具进程活着，后端仍可用
-    assert channel.active_backend == "twitter-cli"
+    assert "未实时验证" in message
+    assert channel.active_backend is None
 
 
-# --- bird CLI fallback tests ---
-
-def test_check_bird_fallback_auth_ok():
-    """No twitter-cli, but bird found + bird check ok → ok."""
-    channel = TwitterChannel()
-    def which_side_effect(name):
-        if name == "bird":
-            return "/usr/local/bin/bird"
-        return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="Authenticated as @user\n", returncode=0),
-    ):
+def test_bird_without_explicit_env_is_warn(monkeypatch):
+    monkeypatch.delenv("AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("CT0", raising=False)
+    with patch("shutil.which", side_effect=_which("bird")):
+        channel = TwitterChannel()
         status, message = channel.check()
-    assert status == "ok"
-    assert "bird" in message
-    assert channel.active_backend == "bird CLI (legacy)"
 
-
-def test_check_bird_fallback_auth_missing():
-    """No twitter-cli, bird found but Missing credentials → warn."""
-    channel = TwitterChannel()
-    def which_side_effect(name):
-        if name == "bird":
-            return "/usr/local/bin/bird"
-        return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stderr="Missing credentials\n", returncode=1),
-    ):
-        status, message = channel.check()
     assert status == "warn"
-    assert "未配置认证" in message
+    assert "未检测到显式" in message
+    assert channel.active_backend is None
 
 
-# --- neither installed ---
-
-def test_check_nothing_installed():
-    """Neither twitter-cli nor bird → warn with install hint."""
+def test_nothing_installed_returns_install_hint():
     channel = TwitterChannel()
     with patch("shutil.which", return_value=None):
         status, message = channel.check()
+
     assert status == "warn"
     assert "twitter-cli" in message
     assert channel.active_backend is None
 
 
-# --- twitter-cli preferred over bird ---
-
-def test_twitter_cli_preferred_over_bird():
-    """When both are installed, twitter-cli is used."""
-    channel = TwitterChannel()
-    def which_side_effect(name):
-        if name == "twitter":
-            return "/usr/local/bin/twitter"
-        if name == "bird":
-            return "/usr/local/bin/bird"
-        return None
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run",
-        return_value=_cp(stdout="ok: true\n", returncode=0),
-    ):
-        status, message = channel.check()
-    assert status == "ok"
-    assert "twitter-cli" in message
-    assert channel.active_backend == "twitter-cli"
-
-
-# --- broken install (stale venv shim) ---
-
-def test_check_twitter_cli_broken_reports_error_with_reinstall_hint():
-    """which 命中但 exec 抛 FileNotFoundError（venv 断链）→ error + 重装处方。"""
-    channel = TwitterChannel()
+def test_opencli_bridge_ready_is_unverified_for_twitter():
     with patch(
-        "shutil.which",
-        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
-    ), patch("subprocess.run", side_effect=FileNotFoundError("/usr/local/bin/twitter")):
-        status, message = channel.check()
-    assert status == "error"
-    assert "无法执行" in message
-    assert "uv tool install --force twitter-cli" in message
-    assert "pipx reinstall twitter-cli" in message
-    assert channel.active_backend is None
-
-
-def test_check_twitter_cli_broken_falls_back_to_bird():
-    """twitter-cli 断链但 bird 健康 → 回退到 bird，后端正确归属。"""
-    channel = TwitterChannel()
-
-    def which_side_effect(name):
-        if name in ("twitter", "bird"):
-            return f"/usr/local/bin/{name}"
-        return None
-
-    def run_side_effect(cmd, **kwargs):
-        if "twitter" in cmd[0]:
-            raise FileNotFoundError(cmd[0])
-        return _cp(stdout="Authenticated as @user\n", returncode=0)
-
-    with patch("shutil.which", side_effect=which_side_effect), patch(
-        "subprocess.run", side_effect=run_side_effect
+        "agent_reach.backends.opencli_status",
+        return_value=OpenCLIStatus(
+            installed=True,
+            extension_connected=True,
+            version="1.8.6",
+        ),
     ):
-        status, message = channel.check()
-    assert status == "ok"
-    assert "bird" in message
-    assert channel.active_backend == "bird CLI (legacy)"
+        status, message = TwitterChannel()._check_opencli()
+
+    assert status == "warn"
+    assert "桥接已连接" in message
+    assert "登录态和实际命令未实时验证" in message
 
 
-def test_unauthenticated_twitter_cli_does_not_block_working_opencli():
-    """warn 候选不得屏蔽排在后面的 ok 候选(Codex review 发现)。"""
+def test_verified_backend_result_wins_over_unverified_twitter_cli():
     channel = TwitterChannel()
     with patch.object(
-        TwitterChannel, "_check_twitter_cli",
-        return_value=("warn", "twitter-cli 已安装但未认证"),
+        TwitterChannel,
+        "_check_twitter_cli",
+        return_value=("warn", "twitter-cli 未验证"),
     ), patch.object(
-        TwitterChannel, "_check_opencli",
-        return_value=("ok", "OpenCLI 可用（复用浏览器登录态）"),
+        TwitterChannel,
+        "_check_opencli",
+        return_value=("ok", "OpenCLI 可用"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
-        status, msg = channel.check()
+        status, message = channel.check()
+
     assert status == "ok"
+    assert message == "OpenCLI 可用"
     assert channel.active_backend == "OpenCLI"
 
 
-def test_all_warn_falls_back_to_first_warn():
+def test_all_warn_returns_first_warning_without_active_backend():
     channel = TwitterChannel()
     with patch.object(
-        TwitterChannel, "_check_twitter_cli",
-        return_value=("warn", "twitter-cli 未认证"),
+        TwitterChannel,
+        "_check_twitter_cli",
+        return_value=("warn", "twitter-cli 未验证"),
     ), patch.object(
-        TwitterChannel, "_check_opencli",
+        TwitterChannel,
+        "_check_opencli",
         return_value=("warn", "扩展未连接"),
     ), patch.object(TwitterChannel, "_check_bird", return_value=None):
-        status, msg = channel.check()
+        status, message = channel.check()
+
     assert status == "warn"
-    assert channel.active_backend == "twitter-cli"
-    assert "未认证" in msg
+    assert message == "twitter-cli 未验证"
+    assert channel.active_backend is None

--- a/tests/test_twitter_channel.py
+++ b/tests/test_twitter_channel.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import patch, Mock
+import os
+from unittest.mock import Mock, patch
 
 from agent_reach.channels.twitter import TwitterChannel
 
@@ -27,6 +28,61 @@ def test_check_twitter_cli_found_and_auth_ok():
     assert "twitter-cli" in message
     assert "完整可用" in message
     assert channel.active_backend == "twitter-cli"
+
+
+def test_check_uses_credentials_saved_by_agent_reach_only_in_child_env(monkeypatch):
+    """Saved cookies must make the independent doctor probe authenticated."""
+    channel = TwitterChannel()
+    config = Mock()
+    config.get.side_effect = lambda key: {
+        "twitter_auth_token": "saved-auth-token",
+        "twitter_ct0": "saved-ct0",
+    }.get(key)
+    monkeypatch.delenv("TWITTER_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TWITTER_CT0", raising=False)
+
+    with patch(
+        "shutil.which",
+        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
+    ), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: true\n", returncode=0),
+    ) as run:
+        status, _ = channel.check(config)
+
+    child_env = run.call_args.kwargs["env"]
+    assert status == "ok"
+    assert child_env["TWITTER_AUTH_TOKEN"] == "saved-auth-token"
+    assert child_env["TWITTER_CT0"] == "saved-ct0"
+    assert "TWITTER_AUTH_TOKEN" not in os.environ
+    assert "TWITTER_CT0" not in os.environ
+
+
+def test_existing_twitter_env_takes_priority_over_saved_config(monkeypatch):
+    channel = TwitterChannel()
+    config = Mock()
+    config.get.side_effect = lambda key: {
+        "twitter_auth_token": "saved-auth-token",
+        "twitter_ct0": "saved-ct0",
+    }.get(key)
+    monkeypatch.setenv("TWITTER_AUTH_TOKEN", "shell-auth-token")
+    monkeypatch.setenv("TWITTER_CT0", "shell-ct0")
+
+    with patch(
+        "shutil.which",
+        side_effect=lambda name: "/usr/local/bin/twitter" if name == "twitter" else None,
+    ), patch(
+        "subprocess.run",
+        return_value=_cp(stdout="ok: true\n", returncode=0),
+    ) as run:
+        status, _ = channel.check(config)
+
+    child_env = run.call_args.kwargs["env"]
+    assert status == "ok"
+    assert child_env["TWITTER_AUTH_TOKEN"] == "shell-auth-token"
+    assert child_env["TWITTER_CT0"] == "shell-ct0"
+    assert os.environ["TWITTER_AUTH_TOKEN"] == "shell-auth-token"
+    assert os.environ["TWITTER_CT0"] == "shell-ct0"
 
 
 def test_check_twitter_cli_found_auth_missing():

--- a/tests/test_url_security.py
+++ b/tests/test_url_security.py
@@ -14,6 +14,7 @@ from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
 from agent_reach.channels.xiaoyuzhou import XiaoyuzhouChannel
 from agent_reach.channels.xueqiu import XueqiuChannel
 from agent_reach.channels.youtube import YouTubeChannel
+from agent_reach.utils.url import host_matches
 
 
 @pytest.mark.parametrize(
@@ -123,3 +124,16 @@ def test_fixed_domain_channels_reject_suffix_lookalikes_and_userinfo(
     assert not channel.can_handle(f"https://{official_domain}.evil.test/path")
     assert not channel.can_handle(f"https://{official_domain}@evil.test/path")
     assert not channel.can_handle(f"https://user:pass@{official_domain}/path")
+
+
+@pytest.mark.parametrize(
+    "malicious_url",
+    [
+        "https://x.com:not-a-port/path",
+        "https://x.com:65536/path",
+        "https://x.com:-1/path",
+        "https://x.com:999999999999/path",
+    ],
+)
+def test_host_matches_rejects_invalid_ports(malicious_url):
+    assert not host_matches(malicious_url, "x.com")

--- a/tests/test_url_security.py
+++ b/tests/test_url_security.py
@@ -1,0 +1,125 @@
+"""Credential-bearing channels must reject lookalike or disguised hosts."""
+
+import pytest
+
+from agent_reach.channels.bilibili import BilibiliChannel
+from agent_reach.channels.facebook import FacebookChannel
+from agent_reach.channels.github import GitHubChannel
+from agent_reach.channels.instagram import InstagramChannel
+from agent_reach.channels.linkedin import LinkedInChannel
+from agent_reach.channels.reddit import RedditChannel
+from agent_reach.channels.twitter import TwitterChannel
+from agent_reach.channels.v2ex import V2EXChannel
+from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
+from agent_reach.channels.xiaoyuzhou import XiaoyuzhouChannel
+from agent_reach.channels.xueqiu import XueqiuChannel
+from agent_reach.channels.youtube import YouTubeChannel
+
+
+@pytest.mark.parametrize(
+    ("channel", "valid_url"),
+    [
+        (TwitterChannel(), "https://mobile.twitter.com/user/status/1"),
+        (TwitterChannel(), "https://X.COM./user/status/1"),
+        (XiaoHongShuChannel(), "https://www.xiaohongshu.com/explore/1"),
+        (XiaoHongShuChannel(), "https://xhslink.com/a/1"),
+        (BilibiliChannel(), "https://www.bilibili.com/video/BV1"),
+        (BilibiliChannel(), "https://b23.tv/abc"),
+        (XueqiuChannel(), "https://stock.xueqiu.com/v5/stock/quote"),
+    ],
+)
+def test_credential_channels_accept_exact_hosts_and_subdomains(channel, valid_url):
+    assert channel.can_handle(valid_url)
+
+
+@pytest.mark.parametrize(
+    ("channel", "malicious_url"),
+    [
+        (TwitterChannel(), "https://x.com.evil.test/user/status/1"),
+        (TwitterChannel(), "https://notx.com/user/status/1"),
+        (TwitterChannel(), "https://x.com@evil.test/user/status/1"),
+        (TwitterChannel(), "https://user:pass@x.com/user/status/1"),
+        (TwitterChannel(), "ftp://x.com/user/status/1"),
+        (XiaoHongShuChannel(), "https://xiaohongshu.com.evil.test/explore/1"),
+        (XiaoHongShuChannel(), "https://xiaohongshu.com@evil.test/explore/1"),
+        (BilibiliChannel(), "https://bilibili.com.evil.test/video/BV1"),
+        (BilibiliChannel(), "https://b23.tv@evil.test/abc"),
+        (XueqiuChannel(), "https://xueqiu.com.evil.test/S/SH600519"),
+        (XueqiuChannel(), "https://xueqiu.com@evil.test/S/SH600519"),
+    ],
+)
+def test_credential_channels_reject_lookalikes_and_userinfo(channel, malicious_url):
+    assert not channel.can_handle(malicious_url)
+
+
+@pytest.mark.parametrize(
+    ("channel", "subdomain_url", "port_url"),
+    [
+        (
+            GitHubChannel(),
+            "https://api.github.com/repos/openai/openai-python",
+            "https://github.com:443/openai/openai-python",
+        ),
+        (
+            YouTubeChannel(),
+            "https://m.youtube.com/watch?v=abc",
+            "https://youtu.be:443/abc",
+        ),
+        (
+            RedditChannel(),
+            "https://old.reddit.com/r/python",
+            "https://reddit.com:443/r/python",
+        ),
+        (
+            LinkedInChannel(),
+            "https://www.linkedin.com/in/example",
+            "https://linkedin.com:443/in/example",
+        ),
+        (
+            V2EXChannel(),
+            "https://www.v2ex.com/t/1",
+            "https://v2ex.com:443/t/1",
+        ),
+        (
+            XiaoyuzhouChannel(),
+            "https://www.xiaoyuzhoufm.com/episode/1",
+            "https://xiaoyuzhoufm.com:443/episode/1",
+        ),
+        (
+            FacebookChannel(),
+            "https://m.facebook.com/groups/1",
+            "https://facebook.com:443/groups/1",
+        ),
+        (
+            InstagramChannel(),
+            "https://www.instagram.com/example",
+            "https://instagram.com:443/example",
+        ),
+    ],
+)
+def test_fixed_domain_channels_accept_subdomains_and_explicit_ports(
+    channel, subdomain_url, port_url
+):
+    assert channel.can_handle(subdomain_url)
+    assert channel.can_handle(port_url)
+
+
+@pytest.mark.parametrize(
+    ("channel", "official_domain"),
+    [
+        (GitHubChannel(), "github.com"),
+        (YouTubeChannel(), "youtube.com"),
+        (RedditChannel(), "reddit.com"),
+        (LinkedInChannel(), "linkedin.com"),
+        (V2EXChannel(), "v2ex.com"),
+        (XiaoyuzhouChannel(), "xiaoyuzhoufm.com"),
+        (FacebookChannel(), "facebook.com"),
+        (InstagramChannel(), "instagram.com"),
+    ],
+)
+def test_fixed_domain_channels_reject_suffix_lookalikes_and_userinfo(
+    channel, official_domain
+):
+    assert not channel.can_handle(f"https://{official_domain}.evil.test/path")
+    assert not channel.can_handle(f"https://{official_domain}@evil.test/path")
+    assert not channel.can_handle(f"https://user:pass@{official_domain}/path")

--- a/tests/test_xueqiu_channel.py
+++ b/tests/test_xueqiu_channel.py
@@ -43,7 +43,7 @@ def test_check_validates_detail_quote_endpoint():
     with patch.object(
         xq,
         "_get_json",
-        side_effect=lambda url: requested.append(url)
+        side_effect=lambda url, config=None: requested.append(url)
         or {"data": {"quote": {"symbol": "SH601138", "pe_ttm": 38.1}}},
     ):
         status, message = ch.check()
@@ -82,7 +82,11 @@ def test_check_never_reads_browser_cookie_store_implicitly(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
     monkeypatch.setattr(xq, "_cookies_initialized", False)
-    monkeypatch.setattr(xq, "_load_cookies_from_config", lambda: False)
+    monkeypatch.setattr(
+        xq,
+        "_load_cookies_from_config",
+        lambda config=None: False,
+    )
 
     class FakeResponse:
         def __enter__(self):

--- a/tests/test_xueqiu_channel.py
+++ b/tests/test_xueqiu_channel.py
@@ -10,11 +10,12 @@ offline. Follow-up to #331 — extends dedicated channel coverage after rss
 """
 
 import json
+import sys
+import types
 from unittest.mock import patch
 
 from agent_reach.channels import xueqiu as xq
 from agent_reach.channels.xueqiu import XueqiuChannel, _strip_html
-
 
 # --- can_handle ---
 
@@ -36,17 +37,28 @@ def test_strip_html_removes_tags_and_decodes_entities():
 
 # --- check(): single public endpoint, items present/empty/error ---
 
-def test_check_ok_when_items_present():
+def test_check_validates_detail_quote_endpoint():
     ch = XueqiuChannel()
-    with patch.object(xq, "_get_json", return_value={"data": {"items": [{"quote": {}}]}}):
+    requested = []
+    with patch.object(
+        xq,
+        "_get_json",
+        side_effect=lambda url: requested.append(url)
+        or {"data": {"quote": {"symbol": "SH601138", "pe_ttm": 38.1}}},
+    ):
         status, message = ch.check()
+
     assert status == "ok"
     assert ch.active_backend == ch.backends[0]
+    assert requested == [
+        "https://stock.xueqiu.com/v5/stock/quote.json"
+        "?symbol=SH601138&extend=detail"
+    ]
 
 
-def test_check_warn_when_items_empty():
+def test_check_warn_when_quote_empty():
     ch = XueqiuChannel()
-    with patch.object(xq, "_get_json", return_value={"data": {"items": []}}):
+    with patch.object(xq, "_get_json", return_value={"data": {"quote": {}}}):
         status, message = ch.check()
     assert status == "warn"
     assert "为空" in message
@@ -63,22 +75,60 @@ def test_check_warn_on_exception():
     assert ch.active_backend is None
 
 
+def test_check_never_reads_browser_cookie_store_implicitly(monkeypatch):
+    browser_reads = []
+    fake_rookiepy = types.SimpleNamespace(
+        chrome=lambda *_args, **_kwargs: browser_reads.append("rookiepy") or []
+    )
+    monkeypatch.setitem(sys.modules, "rookiepy", fake_rookiepy)
+    monkeypatch.setattr(xq, "_cookies_initialized", False)
+    monkeypatch.setattr(xq, "_load_cookies_from_config", lambda: False)
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b'{"data":{"quote":{"symbol":"SH601138","pe_ttm":38.1}}}'
+
+    monkeypatch.setattr(xq._opener, "open", lambda *_args, **_kwargs: FakeResponse())
+
+    status, _message = XueqiuChannel().check()
+
+    assert status == "ok"
+    assert browser_reads == []
+
+
 # --- get_stock_quote: field mapping + missing-data fallback ---
 
 def test_get_stock_quote_maps_fields():
     ch = XueqiuChannel()
-    payload = {"data": {"items": [{"quote": {
+    payload = {"data": {"quote": {
         "symbol": "SH600519", "name": "贵州茅台", "current": 1700.5,
-        "percent": 1.23, "pe_ttm": 30.1,
-    }}]}}
-    with patch.object(xq, "_get_json", return_value=payload):
+        "percent": 1.23, "volume": 1234, "pe_ttm": 30.1,
+        "pe_forecast": 27.4, "pb": 8.2, "eps": 59.0,
+    }}}
+    requested = []
+    with patch.object(
+        xq, "_get_json", side_effect=lambda url: requested.append(url) or payload
+    ):
         q = ch.get_stock_quote("SH600519")
+
+    assert requested == [
+        "https://stock.xueqiu.com/v5/stock/quote.json"
+        "?symbol=SH600519&extend=detail"
+    ]
     assert q["symbol"] == "SH600519"
     assert q["name"] == "贵州茅台"
     assert q["current"] == 1700.5
+    assert q["volume"] == 1234
     assert q["pe_ttm"] == 30.1
-    # keys are always present even when the source omits them
-    assert q["volume"] is None
+    assert q["pe_forecast"] == 27.4
+    assert q["pb"] == 8.2
+    assert q["eps"] == 59.0
 
 
 def test_get_stock_quote_falls_back_when_no_items():

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -138,6 +138,7 @@ def test_check_does_not_prescribe_unverified_flag_when_version_is_unknown():
     assert status == "warn"
     assert "无法确认" in message
     assert "升级" in message
+    assert "yt-dlp[default]" in message
     assert "--js-runtimes" not in message
     assert ch.active_backend == "yt-dlp"
 

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -11,11 +11,12 @@ channel coverage after rss (#360), github (#361), web (#363),
 reddit (#364), xueqiu (#365) and v2ex (#366).
 """
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
-from agent_reach.probe import ProbeResult
 from agent_reach.channels import youtube as yt
 from agent_reach.channels.youtube import YouTubeChannel, _has_js_runtime_config
+from agent_reach.probe import ProbeResult
 
 
 def _which(*present):
@@ -110,6 +111,68 @@ def test_check_warn_when_node_only_and_config_missing_flag():
         status, message = ch.check()
     assert status == "warn"
     assert ch.active_backend == "yt-dlp"
+
+
+def test_check_tells_user_to_upgrade_when_ytdlp_predates_js_runtimes():
+    ch = YouTubeChannel()
+    probe = ProbeResult("ok", output="2025.10.22")
+    with patch.object(yt, "probe_command", return_value=probe), \
+         patch("shutil.which", side_effect=_which("node")), \
+         patch.object(yt, "_has_js_runtime_config", return_value=False):
+        status, message = ch.check()
+
+    assert status == "warn"
+    assert "升级" in message
+    assert "--js-runtimes" not in message
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_does_not_prescribe_unverified_flag_when_version_is_unknown():
+    ch = YouTubeChannel()
+    probe = ProbeResult("ok", output="dev-build")
+    with patch.object(yt, "probe_command", return_value=probe), \
+         patch("shutil.which", side_effect=_which("node")), \
+         patch.object(yt, "_has_js_runtime_config", return_value=False):
+        status, message = ch.check()
+
+    assert status == "warn"
+    assert "无法确认" in message
+    assert "升级" in message
+    assert "--js-runtimes" not in message
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_check_prescribes_js_runtimes_from_first_supported_stable_release():
+    ch = YouTubeChannel()
+    probe = ProbeResult("ok", output="2025.11.12")
+    with patch.object(yt, "probe_command", return_value=probe), \
+         patch("shutil.which", side_effect=_which("node")), \
+         patch.object(yt, "_has_js_runtime_config", return_value=False):
+        status, message = ch.check()
+
+    assert status == "warn"
+    assert "--js-runtimes node" in message
+    assert ch.active_backend == "yt-dlp"
+
+
+def test_constraints_pin_ytdlp_to_current_stable_release():
+    constraints = Path(__file__).parents[1] / "constraints.txt"
+    pin = next(
+        line
+        for line in constraints.read_text(encoding="utf-8").splitlines()
+        if line.startswith("yt-dlp==")
+    )
+
+    assert pin == "yt-dlp==2026.07.04"
+
+
+def test_project_installs_official_ytdlp_default_dependencies():
+    root = Path(__file__).parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    constraints = (root / "constraints.txt").read_text(encoding="utf-8")
+
+    assert '"yt-dlp[default]>=2026.07.04"' in pyproject
+    assert "yt-dlp-ejs==0.8.0" in constraints
 
 
 def test_check_ok_with_deno():

--- a/tests/test_youtube_channel.py
+++ b/tests/test_youtube_channel.py
@@ -4,7 +4,7 @@
 YouTube's readiness is layered: yt-dlp must probe alive (missing / broken /
 unrunnable are distinct), a JS runtime is mandatory (deno works out of the
 box, Node needs an explicit ``--js-runtimes`` config), and transcription
-readiness (whisper provider + ffmpeg) is surfaced for ``doctor`` without
+readiness (whisper provider + ffmpeg/ffprobe) is surfaced for ``doctor`` without
 gating the backend. These tests stub ``probe_command`` / ``shutil.which``
 so every branch runs offline. Follow-up to #331 — extends dedicated
 channel coverage after rss (#360), github (#361), web (#363),
@@ -57,10 +57,13 @@ def test_has_js_runtime_config_false_when_flag_absent(tmp_path):
     assert _has_js_runtime_config(cfg) is False
 
 
-def test_has_js_runtime_config_swallows_oserror():
-    bad = Mock()
-    bad.exists.return_value = True
-    with patch.object(yt, "read_utf8_text", side_effect=OSError("denied")):
+def test_has_js_runtime_config_swallows_oserror(tmp_path):
+    bad = tmp_path / "config"
+    with patch.object(
+        yt,
+        "read_small_text_no_follow",
+        side_effect=OSError("denied"),
+    ):
         assert _has_js_runtime_config(bad) is False
 
 
@@ -71,6 +74,7 @@ def test_check_off_when_ytdlp_missing():
     with patch.object(yt, "probe_command", return_value=ProbeResult("missing")):
         status, message = ch.check()
     assert status == "off"
+    assert "yt-dlp[default]" in message
     assert ch.active_backend is None
 
 
@@ -80,6 +84,7 @@ def test_check_error_when_ytdlp_broken():
         status, message = ch.check()
     assert status == "error"
     assert "relink venv" in message
+    assert "yt-dlp[default]" in message
     assert ch.active_backend is None
 
 
@@ -193,7 +198,7 @@ def test_check_ok_reports_transcription_when_provider_and_ffmpeg_present():
     cfg = Mock()
     cfg.is_configured = lambda key: key == "groq_whisper"
     with patch.object(yt, "probe_command", return_value=ProbeResult("ok")), \
-         patch("shutil.which", side_effect=_which("deno", "ffmpeg")):
+         patch("shutil.which", side_effect=_which("deno", "ffmpeg", "ffprobe")):
         status, message = ch.check(config=cfg)
     assert status == "ok"
     assert "groq" in message
@@ -209,3 +214,15 @@ def test_check_ok_flags_missing_ffmpeg_for_transcription():
         status, message = ch.check(config=cfg)
     assert status == "ok"
     assert "ffmpeg" in message
+
+
+def test_check_ok_flags_missing_ffprobe_for_transcription():
+    ch = YouTubeChannel()
+    cfg = Mock()
+    cfg.is_configured = lambda key: key == "openai_whisper"
+    with patch.object(yt, "probe_command", return_value=ProbeResult("ok")), \
+         patch("shutil.which", side_effect=_which("deno", "ffmpeg")):
+        status, message = ch.check(config=cfg)
+    assert status == "ok"
+    assert "ffprobe" in message
+    assert "可转写音频" not in message


### PR DESCRIPTION
## What changed

- require explicit credential configuration instead of silently reading browser cookie stores
- make `doctor` diagnostics observably read-only and avoid upstream commands that may create caches, device IDs, or login state
- report partial or unauthenticated channel states honestly instead of returning a false green result
- harden private config writes, symlink handling, cookie-domain validation, and credential-bearing URL scrubbing
- bound transcription input size, duration, chunk count, output size, and processing time before any paid provider call
- align YouTube installation with the required `yt-dlp` default/EJS dependencies, XDG config path, and supported runtime flags
- safely map Xueqiu quote-detail fields without implicit browser extraction
- update multilingual authentication guidance to require explicit Cookie-Editor exports

## Why

Several configuration and diagnostic paths crossed trust boundaries: a seemingly read-only check could invoke an upstream CLI that reads browser credentials or writes local state, setup failures could proceed too far, and media processing lacked strict resource limits. This PR makes those paths fail closed and keeps Agent Reach within its installer/doctor/config role.

## User impact

Users get safer setup and diagnostics, clearer warnings when a platform is not actually usable, a working YouTube runtime installation, and protection against oversized or unexpectedly expensive transcription jobs.

## Validation

- `428 passed` on the exact PR head
- full test suite passed under Python 3.10, 3.11, 3.12, and 3.13
- Ruff checks passed for changed non-CLI source files; no new CLI lint regressions relative to `main`
- mypy checks passed
- wheel and sdist built and installed successfully under Python 3.10
- live YouTube metadata read succeeded with the packaged dependencies
- real `yt-dlp` XDG configuration loading was verified
- real `ffmpeg`/`ffprobe` processing was verified with a generated audio sample
- isolated `doctor` run exited successfully with zero filesystem writes

## Known boundaries

- The upstream Twitter CLI still does not consume Agent Reach's saved configuration, so #506 should not be closed by this PR. The unsafe automatic validation path is blocked, but fully bridging that configuration would require upstream support or a project-level design change.
- Xueqiu's unauthenticated live endpoint currently returns HTTP 400. Parsing and credential boundaries are covered, but this PR does not claim anonymous live access is available.