### PR TITLE
fix(skill): use registered Exa search tools

### DIFF
--- a/agent_reach/skill/references/search.md
+++ b/agent_reach/skill/references/search.md
@@ -4,11 +4,11 @@ Exa AI 搜索引擎。
 
 ## Exa AI 搜索
 
-高质量 AI 搜索引擎，擅长技术和代码搜索。
+高质量 AI 搜索引擎，适合查找技术文档、官方示例和相关网页。
 
 ```bash
 mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
-mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
+mcporter call 'exa.web_search_exa(query: "library API code example", numResults: 5)'
 ```
 
 ### 使用场景
@@ -16,12 +16,15 @@ mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)
 | 场景 | 参数 |
 |-----|------|
 | 网页搜索 | `web_search_exa(query: "...", numResults: 5)` |
-| 代码搜索 | `get_code_context_exa(query: "...", tokensNum: 3000)` |
+| 技术/代码资料 | `web_search_exa(query: "框架名 API 示例", numResults: 5)` |
+
+> Exa MCP 的 `get_code_context_exa` 已弃用且默认不注册。代码问题也使用
+> `web_search_exa`；需要精确搜索仓库内容时，改用 `dev.md` 中的 GitHub 搜索。
 
 ### 特点
 
 - 擅长英文内容和技术文档
-- 支持代码上下文搜索
+- 可通过查询词定位官方文档和代码示例
 - 结果质量高
 
 ## 与其他搜索工具对比

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -23,6 +23,18 @@ class TestSkillCommand(unittest.TestCase):
         self.assertTrue(default_skill.strip())
         self.assertTrue(english_skill.strip())
 
+    def test_exa_reference_uses_default_registered_tools_only(self):
+        """Agent instructions must not call Exa tools disabled by default."""
+        search_reference = (
+            importlib.resources.files("agent_reach")
+            .joinpath("skill", "references", "search.md")
+            .read_text(encoding="utf-8")
+        )
+
+        self.assertIn("web_search_exa", search_reference)
+        self.assertNotIn("exa.get_code_context_exa", search_reference)
+        self.assertNotIn("get_code_context_exa(", search_reference)
+
     def test_install_skill_creates_skill_md(self):
         """_install_skill should create SKILL.md in the first available skill dir."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- replace the deprecated `get_code_context_exa` example with the registered `web_search_exa` tool
- direct exact repository/code lookup to Agent Reach's GitHub workflow
- add a packaged-skill contract test that rejects unavailable Exa tool calls

## Root cause

Exa deprecated `get_code_context_exa` and no longer registers it by default, but the bundled search reference still instructed agents to call it. This caused an otherwise valid research workflow to fail at tool selection.

## User impact

Generated skill guidance now uses tools available in a default Exa MCP setup and routes exact code search to the existing GitHub integration.

## Validation

- `python -m pytest tests/test_v2ex_channel.py tests/test_doctor.py tests/test_channel_contracts.py tests/test_skill_command.py -q` — 37 passed
- `python -m ruff check agent_reach/channels/v2ex.py tests/test_v2ex_channel.py tests/test_skill_command.py`
- `git diff --check`

Closes #523