### PR TITLE
feat(polish): make transcript-polishing LLM backend configurable; add MiniMax

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,11 @@
 
 # OpenAI Whisper (optional fallback when Groq is rate-limited) — https://platform.openai.com
 # OPENAI_API_KEY=sk-your_key_here
+
+# MiniMax transcript polishing (optional, replaces the default Groq Llama polish)
+# Set POLISH_PROVIDER=minimax when running xiaoyuzhou transcribe.sh --polish.
+# Global endpoint: https://api.minimax.io  |  China endpoint: https://api.minimaxi.com
+# MINIMAX_API_KEY=your_minimax_key_here
+# POLISH_PROVIDER=minimax
+# POLISH_MODEL=MiniMax-M3   # or MiniMax-M2.7
+# MINIMAX_REGION=global_en  # or cn_zh for the China endpoint

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -81,6 +81,7 @@ def main():
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
     p_conf.add_argument("key", nargs="?", default=None,
                         choices=["proxy", "github-token", "groq-key", "openai-key",
+                                 "minimax-key",
                                  "twitter-cookies", "youtube-cookies",
                                  "xhs-cookies"],
                         help="What to configure (omit if using --from-browser)")
@@ -1320,6 +1321,11 @@ def _cmd_configure(args):
     elif args.key == "openai-key":
         config.set("openai_api_key", value)
         print(f"✅ OpenAI key configured!")
+
+    elif args.key == "minimax-key":
+        config.set("minimax_api_key", value)
+        print("✅ MiniMax key configured! Use it for transcript polishing with "
+              "POLISH_PROVIDER=minimax (model MiniMax-M3 or MiniMax-M2.7).")
 
 
 def _cmd_transcribe(args):

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -107,6 +107,7 @@ class Config:
         "twitter_xreach": ["twitter_auth_token", "twitter_ct0"],  # legacy key name; used by twitter-cli
         "groq_whisper": ["groq_api_key"],
         "openai_whisper": ["openai_api_key"],
+        "minimax_polish": ["minimax_api_key"],
         "github_token": ["github_token"],
     }
 

--- a/agent_reach/polish.py
+++ b/agent_reach/polish.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""Transcript-polishing LLM backend.
+
+After Whisper transcription, Chinese podcasts often lack punctuation. The
+polish step asks an OpenAI-compatible chat-completion model to add Chinese
+punctuation and reasonable paragraph breaks without altering the words.
+
+The backend is configurable so users are not locked to a single vendor. Two
+providers are supported:
+
+- ``groq``: Groq's OpenAI-compatible endpoint (default, free tier).
+- ``minimax``: MiniMax's OpenAI-compatible global (``api.minimax.io``) and
+  China (``api.minimaxi.com``) endpoints, exposing the ``MiniMax-M3`` and
+  ``MiniMax-M2.7`` text models.
+
+Provider, model, region and API key are resolved from explicit kwargs, then
+environment variables, then the Agent Reach config file. The shell
+transcription script invokes :func:`polish_chunk_file` via
+``python3 -m agent_reach.polish`` so the same registry is used at runtime and
+in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+from urllib.parse import urljoin
+
+# Prompts and limits are shared across providers.
+PROMPT_TMPL = (
+    "以下是一段中文普通话播客的语音转写片段，由于 Whisper 对中文标点支持较弱，"
+    "整段几乎没有标点。请你**只做一件事**：在合适位置补充中文标点（，。！？：；），"
+    "可以适度分段。\n\n"
+    "**严格要求**：\n"
+    "- 不得修改、删除、增加任何汉字或英文/数字\n"
+    "- 不得改写、润色、总结\n"
+    "- 不得添加任何解释、前言、后记\n"
+    "- 直接输出加好标点+合理分段后的全文\n\n"
+    "原文：\n{}"
+)
+
+MAX_DEPTH = 3
+REQUEST_TIMEOUT = 180
+USER_AGENT = "agent-reach-polish/1.0"
+
+# Provider registry. Each entry exposes:
+#   endpoint:    default OpenAI-compatible chat-completions URL
+#   model:       default model id
+#   key_field:   Agent Reach config key holding the API key
+#   key_env:     environment variable holding the API key
+#   regions:     optional regional base URLs (without /chat/completions)
+#   models:      supported model ids for this provider
+POLISH_PROVIDERS: dict[str, dict[str, Any]] = {
+    "groq": {
+        "endpoint": "https://api.groq.com/openai/v1/chat/completions",
+        "model": "llama-3.3-70b-versatile",
+        "key_field": "groq_api_key",
+        "key_env": "GROQ_API_KEY",
+        "models": ["llama-3.3-70b-versatile"],
+    },
+    "minimax": {
+        # Endpoint is derived from the selected region below.
+        "endpoint": "https://api.minimax.io/v1/chat/completions",
+        "model": "MiniMax-M3",
+        "key_field": "minimax_api_key",
+        "key_env": "MINIMAX_API_KEY",
+        "regions": {
+            "global_en": "https://api.minimax.io/v1",
+            "cn_zh": "https://api.minimaxi.com/v1",
+        },
+        "models": ["MiniMax-M3", "MiniMax-M2.7"],
+    },
+}
+
+DEFAULT_PROVIDER = "groq"
+DEFAULT_MINIMAX_REGION = "global_en"
+
+
+class PolishError(RuntimeError):
+    """Raised when transcript polishing cannot complete."""
+
+
+def _config_get(key: str, config: Optional[Any] = None) -> Optional[str]:
+    """Read a value from an Agent Reach Config without importing it eagerly."""
+    if config is not None:
+        try:
+            val = config.get(key)
+        except Exception:
+            val = None
+        return val or None
+    # Fall back to the config file via a lazy import so this module stays
+    # importable in environments where the full config stack is unavailable.
+    try:
+        from agent_reach.config import Config  # local import avoids cycles
+    except Exception:
+        return None
+    try:
+        cfg = Config()
+        val = cfg.get(key)
+    except Exception:
+        return None
+    return val or None
+
+
+def resolve(
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    region: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    config: Optional[Any] = None,
+) -> dict[str, str]:
+    """Resolve the endpoint, model and API key for a polish request.
+
+    Resolution order for every field: explicit argument → environment variable
+    → Agent Reach config file → provider default.
+    """
+    provider = provider or os.environ.get("POLISH_PROVIDER") or DEFAULT_PROVIDER
+    if provider not in POLISH_PROVIDERS:
+        raise PolishError(f"unknown polish provider: {provider} (use {'|'.join(POLISH_PROVIDERS)})")
+    info = POLISH_PROVIDERS[provider]
+
+    # Endpoint: explicit base_url → region → provider default.
+    endpoint = info["endpoint"]
+    regions = info.get("regions") or {}
+    if base_url is None:
+        base_url = os.environ.get("MINIMAX_BASE_URL")
+    if base_url is None and regions:
+        region = region or os.environ.get("MINIMAX_REGION") or DEFAULT_MINIMAX_REGION
+        if region not in regions:
+            raise PolishError(f"unknown minimax region: {region} (use {'|'.join(regions)})")
+        base_url = regions[region]
+    if base_url:
+        # base_url is the OpenAI-compatible root (e.g. .../v1); append the
+        # standard chat-completions path. urljoin keeps trailing slashes sane.
+        endpoint = urljoin(base_url.rstrip("/") + "/", "chat/completions")
+
+    # Model: explicit → env → provider default.
+    if model is None:
+        model = os.environ.get("POLISH_MODEL")
+    if not model:
+        model = info["model"]
+
+    # API key: explicit → env → config.
+    if not api_key:
+        api_key = os.environ.get(info["key_env"])
+    if not api_key:
+        api_key = _config_get(info["key_field"], config)
+    if not api_key:
+        raise PolishError(
+            f"{provider}: missing {info['key_field']} "
+            f"(configure with `agent-reach configure "
+            f"{_configure_key(provider)} ...`)"
+        )
+
+    return {
+        "provider": provider,
+        "endpoint": endpoint,
+        "model": model,
+        "api_key": api_key,
+    }
+
+
+def _configure_key(provider: str) -> str:
+    """Map a polish provider to its `agent-reach configure` key."""
+    return "minimax-key" if provider == "minimax" else "groq-key"
+
+
+def _call_chat_completion(
+    endpoint: str, model: str, api_key: str, text: str, timeout: int
+) -> tuple[str, Optional[str]]:
+    """POST one chat-completion request; return (content, finish_reason)."""
+    body = json.dumps(
+        {
+            "model": model,
+            "temperature": 0.2,
+            "max_completion_tokens": 8192,
+            "messages": [{"role": "user", "content": PROMPT_TMPL.format(text)}],
+        }
+    ).encode()
+    req = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.load(resp)
+    choice = payload["choices"][0]
+    return (
+        choice["message"]["content"].strip(),
+        choice.get("finish_reason"),
+    )
+
+
+def polish_text(
+    text: str,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    region: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    config: Optional[Any] = None,
+    timeout: int = REQUEST_TIMEOUT,
+) -> str:
+    """Polish a transcript chunk, returning the punctuated text.
+
+    If the model truncates the output (``finish_reason == "length"``), the
+    input is split in half and each half is polished recursively, mirroring the
+    original shell-script behaviour. On HTTP/transport errors the raw input is
+    returned rather than raised, so polishing degrades gracefully.
+    """
+    resolved = resolve(
+        provider=provider,
+        model=model,
+        region=region,
+        base_url=base_url,
+        api_key=api_key,
+        config=config,
+    )
+
+    def _polish(chunk: str, depth: int) -> str:
+        try:
+            out, finish = _call_chat_completion(
+                resolved["endpoint"],
+                resolved["model"],
+                resolved["api_key"],
+                chunk,
+                timeout,
+            )
+        except urllib.error.HTTPError as exc:
+            sys.stderr.write(
+                f"polish HTTP {exc.code}: {exc.read().decode(errors='replace')[:200]}\n"
+            )
+            return chunk
+        except Exception as exc:  # noqa: BLE001 - degrade to raw on any error
+            sys.stderr.write(f"polish error: {exc}\n")
+            return chunk
+        if finish != "length" or depth >= MAX_DEPTH:
+            return out
+        mid = len(chunk) // 2
+        return _polish(chunk[:mid], depth + 1) + _polish(chunk[mid:], depth + 1)
+
+    return _polish(text.strip(), 0)
+
+
+def polish_chunk_file(
+    in_path: str,
+    out_path: str,
+    **kwargs: Any,
+) -> int:
+    """Polish one transcript file and write the result. Returns char count."""
+    content = open(in_path, encoding="utf-8").read().strip()
+    result = polish_text(content, **kwargs)
+    open(out_path, "w", encoding="utf-8").write(result + "\n")
+    return len(result)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry: ``python3 -m agent_reach.polish IN OUT``."""
+    args = list(argv if argv is not None else sys.argv[1:])
+    if len(args) != 2:
+        sys.stderr.write("usage: python3 -m agent_reach.polish IN_FILE OUT_FILE\n")
+        return 2
+    try:
+        chars = polish_chunk_file(args[0], args[1])
+    except PolishError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    print(f"✅ ({chars} 字)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 # 小宇宙播客转文字脚本
 # 用法: bash transcribe.sh [--polish] <小宇宙链接> [输出文件路径]
-# 环境变量: GROQ_API_KEY (必须)
+# 环境变量: GROQ_API_KEY (必须, Whisper 转录)
 #
-# --polish: 转录后调用 Groq Llama 3.3 70B 给文稿补中文标点+合理分段
+# --polish: 转录后用 OpenAI 兼容的 chat 模型给文稿补中文标点+合理分段
 #           （Whisper 对中文标点支持较弱，开启后阅读体验显著更好）
+#
+# 可选润色配置 (覆盖默认 Groq Llama 3.3 70B):
+#   POLISH_PROVIDER   groq (默认) | minimax
+#   POLISH_MODEL       模型 id (如 MiniMax-M3、MiniMax-M2.7)
+#   MINIMAX_REGION     global_en (默认, https://api.minimax.io) | cn_zh (https://api.minimaxi.com)
+#   MINIMAX_BASE_URL   自定义 OpenAI 兼容根 (覆盖 MINIMAX_REGION)
+#   MINIMAX_API_KEY    MiniMax API key (或 agent-reach configure minimax-key)
 
 set -e
 
@@ -160,78 +167,24 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
     echo "✅ ($CHARS 字)"
 done
 
-# Step 6.5 (可选): 用 Llama 3.3 70B 给文稿补标点+分段
+# Step 6.5 (可选): 用 OpenAI 兼容 chat 模型给文稿补标点+分段
+# 默认 groq (Llama 3.3 70B)；设 POLISH_PROVIDER=minimax 用 MiniMax-M3/M2.7
 if [ "$POLISH" = "1" ]; then
-    echo "✨ 正在润色（Llama 3.3 70B 加标点+分段）..."
+    POLISH_PROVIDER="${POLISH_PROVIDER:-groq}"
+    if [ "$POLISH_PROVIDER" = "minimax" ]; then
+        POLISH_MODEL_DEFAULT="MiniMax-M3"
+    else
+        POLISH_MODEL_DEFAULT="llama-3.3-70b-versatile"
+    fi
+    POLISH_LABEL="$POLISH_PROVIDER/${POLISH_MODEL:-$POLISH_MODEL_DEFAULT}"
+    echo "✨ 正在润色（$POLISH_LABEL 加标点+分段）..."
+    # agent_reach.polish 解析 POLISH_PROVIDER / POLISH_MODEL /
+    # MINIMAX_REGION / MINIMAX_BASE_URL / MINIMAX_API_KEY / GROQ_API_KEY
+    # (环境变量优先，其次 ~/.agent-reach/config.yaml)。
+    export GROQ_API_KEY
     for i in $(seq 0 $((NUM_CHUNKS - 1))); do
         echo -n "   段 $((i+1))/$NUM_CHUNKS... "
-        IN_FILE="$TMPDIR/transcript_${i}.txt" \
-        OUT_FILE="$TMPDIR/polished_${i}.txt" \
-        GROQ_API_KEY="$GROQ_API_KEY" \
-        python3 <<'PY'
-import json, os, sys, urllib.request, urllib.error
-
-KEY = os.environ["GROQ_API_KEY"]
-IN = os.environ["IN_FILE"]
-OUT = os.environ["OUT_FILE"]
-
-MODEL = "llama-3.3-70b-versatile"
-MAX_DEPTH = 3
-PROMPT_TMPL = (
-    "以下是一段中文普通话播客的语音转写片段，由于 Whisper 对中文标点支持较弱，"
-    "整段几乎没有标点。请你**只做一件事**：在合适位置补充中文标点（，。！？：；），"
-    "可以适度分段。\n\n"
-    "**严格要求**：\n"
-    "- 不得修改、删除、增加任何汉字或英文/数字\n"
-    "- 不得改写、润色、总结\n"
-    "- 不得添加任何解释、前言、后记\n"
-    "- 直接输出加好标点+合理分段后的全文\n\n"
-    "原文：\n{}"
-)
-
-def call_groq(text):
-    body = json.dumps({
-        "model": MODEL,
-        "temperature": 0.2,
-        "max_completion_tokens": 8192,
-        "messages": [{"role": "user", "content": PROMPT_TMPL.format(text)}],
-    }).encode()
-    req = urllib.request.Request(
-        "https://api.groq.com/openai/v1/chat/completions",
-        data=body,
-        headers={
-            "Authorization": f"Bearer {KEY}",
-            "Content-Type": "application/json",
-            "User-Agent": "agent-reach-xiaoyuzhou/1.0",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=180) as r:
-        resp = json.load(r)
-    return (
-        resp["choices"][0]["message"]["content"].strip(),
-        resp["choices"][0].get("finish_reason"),
-    )
-
-def polish(text, depth=0):
-    try:
-        out, fr = call_groq(text)
-    except urllib.error.HTTPError as e:
-        sys.stderr.write(f"polish HTTP {e.code}: {e.read().decode(errors='replace')[:200]}\n")
-        return text  # fallback to raw
-    except Exception as e:
-        sys.stderr.write(f"polish error: {e}\n")
-        return text
-    if fr != "length" or depth >= MAX_DEPTH:
-        return out
-    # 输出被截断：从中点切两半递归处理
-    mid = len(text) // 2
-    return polish(text[:mid], depth + 1) + polish(text[mid:], depth + 1)
-
-content = open(IN, encoding="utf-8").read().strip()
-result = polish(content)
-open(OUT, "w", encoding="utf-8").write(result + "\n")
-print(f"✅ ({len(result)} 字)")
-PY
+        python3 -m agent_reach.polish "$TMPDIR/transcript_${i}.txt" "$TMPDIR/polished_${i}.txt"
     done
 fi
 
@@ -245,7 +198,7 @@ echo "📄 正在合并文字稿..."
     echo "时长: ${DURATION_MIN}分${DURATION_SEC}秒"
     echo "转录时间: $(date '+%Y-%m-%d %H:%M')"
     if [ "$POLISH" = "1" ]; then
-        echo "润色: Groq Llama 3.3 70B"
+        echo "润色: $POLISH_LABEL"
     fi
     echo ""
     echo "---"

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -99,16 +99,26 @@ curl -s -b /tmp/bili_ck.txt -A "$UA" -e "https://www.bilibili.com/" \
 ### 转录单集播客（可选 --polish 增强标点）
 
 ```bash
-# 输出 Markdown 文件到 /tmp/。--polish 让 Llama 3.3 70B 给文稿补中文标点+合理分段
+# 输出 Markdown 文件到 /tmp/。--polish 用 OpenAI 兼容的 chat 模型给文稿补中文标点+合理分段
 ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
 ```
 
-> 转写 prompt 已要求 Whisper 输出中文标点；若标点效果仍不理想，可加 `--polish` 用 Groq 上免费的 Llama 3.3 70B 补标点+合理分段（9 分钟播客约多 ~7 秒）。每次转写多一轮 LLM 调用，按需使用。
+> 转写 prompt 已要求 Whisper 输出中文标点；若标点效果仍不理想，可加 `--polish` 让一个 OpenAI 兼容的 chat 模型补标点+合理分段（9 分钟播客约多 ~7 秒）。每次转写多一轮 LLM 调用，按需使用。
+>
+> 润色后端可配置（默认 Groq 的 Llama 3.3 70B）。改用 MiniMax：
+>
+> ```bash
+> agent-reach configure minimax-key YOUR_MINIMAX_KEY
+> POLISH_PROVIDER=minimax POLISH_MODEL=MiniMax-M3 \
+>   ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish "URL"
+> ```
+>
+> MiniMax 走 OpenAI 兼容的全球（`https://api.minimax.io`）和中国（`https://api.minimaxi.com`）端点，支持 `MiniMax-M3` 与 `MiniMax-M2.7`；用 `MINIMAX_REGION=cn_zh` 切到中国端点，或用 `MINIMAX_BASE_URL` 自定义根地址。
 
 ### 前置要求
 
 1. **ffmpeg**: `brew install ffmpeg`
-2. **Groq API Key** (免费): https://console.groq.com/keys
+2. **Groq API Key** (免费, Whisper 转写): https://console.groq.com/keys
 3. **配置 Key**: `agent-reach configure groq-key YOUR_KEY`
 4. **首次运行**: `agent-reach install --env=auto` 安装工具
 

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent_reach.polish — the configurable transcript-polishing backend."""
+
+import pytest
+
+from agent_reach import polish
+from agent_reach.config import Config
+
+
+@pytest.fixture
+def fake_config(tmp_path, monkeypatch):
+    """A Config that writes to a temp dir and never touches the user's HOME."""
+    cfg_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(Config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(Config, "CONFIG_FILE", cfg_path)
+    return Config(config_path=cfg_path)
+
+
+# --- Provider registry -------------------------------------------------- #
+
+
+class TestPolishProviderRegistry:
+    def test_groq_and_minimax_are_registered(self):
+        assert set(polish.POLISH_PROVIDERS) >= {"groq", "minimax"}
+
+    def test_minimax_exposes_global_and_cn_regions(self):
+        regions = polish.POLISH_PROVIDERS["minimax"]["regions"]
+        assert regions["global_en"] == "https://api.minimax.io/v1"
+        assert regions["cn_zh"] == "https://api.minimaxi.com/v1"
+
+    def test_minimax_supports_current_text_models(self):
+        models = polish.POLISH_PROVIDERS["minimax"]["models"]
+        assert "MiniMax-M3" in models
+        assert "MiniMax-M2.7" in models
+        # the provider default is MiniMax-M3
+        assert polish.POLISH_PROVIDERS["minimax"]["model"] == "MiniMax-M3"
+
+    def test_minimax_uses_minimax_api_key_field(self):
+        assert polish.POLISH_PROVIDERS["minimax"]["key_field"] == "minimax_api_key"
+        assert polish.POLISH_PROVIDERS["minimax"]["key_env"] == "MINIMAX_API_KEY"
+
+    def test_groq_keeps_default_model(self):
+        # backward compatible default — polishing is configurable, not removed
+        assert polish.POLISH_PROVIDERS["groq"]["model"] == "llama-3.3-70b-versatile"
+
+
+# --- resolve() ---------------------------------------------------------- #
+
+
+class TestResolve:
+    def test_minimax_global_endpoint_derived_from_region(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("POLISH_PROVIDER", raising=False)
+        monkeypatch.delenv("POLISH_MODEL", raising=False)
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+        monkeypatch.delenv("MINIMAX_REGION", raising=False)
+        resolved = polish.resolve(
+            provider="minimax",
+            api_key="k",
+            region="global_en",
+        )
+        assert resolved["endpoint"] == "https://api.minimax.io/v1/chat/completions"
+        assert resolved["model"] == "MiniMax-M3"
+        assert resolved["api_key"] == "k"
+
+    def test_minimax_cn_endpoint_derived_from_region(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+        monkeypatch.delenv("MINIMAX_REGION", raising=False)
+        resolved = polish.resolve(
+            provider="minimax",
+            api_key="k",
+            region="cn_zh",
+        )
+        assert resolved["endpoint"] == "https://api.minimaxi.com/v1/chat/completions"
+
+    def test_minimax_model_override(self, monkeypatch):
+        resolved = polish.resolve(
+            provider="minimax",
+            model="MiniMax-M2.7",
+            api_key="k",
+            region="global_en",
+        )
+        assert resolved["model"] == "MiniMax-M2.7"
+
+    def test_minimax_base_url_override(self, monkeypatch):
+        resolved = polish.resolve(
+            provider="minimax",
+            api_key="k",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert resolved["endpoint"] == "https://api.minimax.io/v1/chat/completions"
+
+    def test_groq_default_endpoint_and_model(self, monkeypatch):
+        monkeypatch.delenv("POLISH_PROVIDER", raising=False)
+        monkeypatch.delenv("POLISH_MODEL", raising=False)
+        resolved = polish.resolve(provider="groq", api_key="g")
+        assert resolved["endpoint"] == "https://api.groq.com/openai/v1/chat/completions"
+        assert resolved["model"] == "llama-3.3-70b-versatile"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(polish.PolishError, match=r"unknown polish provider"):
+            polish.resolve(provider="acme", api_key="k")
+
+    def test_missing_key_raises(self, monkeypatch, fake_config):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_REGION", raising=False)
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+        with pytest.raises(polish.PolishError, match=r"missing minimax_api_key"):
+            polish.resolve(provider="minimax", config=fake_config)
+
+    def test_key_read_from_config(self, monkeypatch, fake_config):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_REGION", raising=False)
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+        fake_config.set("minimax_api_key", "from-config")
+        resolved = polish.resolve(provider="minimax", config=fake_config)
+        assert resolved["api_key"] == "from-config"
+
+
+# --- Config feature requirement ---------------------------------------- #
+
+
+class TestConfigMinimaxPolish:
+    def test_minimax_polish_feature_registered(self, fake_config):
+        assert "minimax_polish" in Config.FEATURE_REQUIREMENTS
+        assert Config.FEATURE_REQUIREMENTS["minimax_polish"] == ["minimax_api_key"]
+        assert not fake_config.is_configured("minimax_polish")
+        fake_config.set("minimax_api_key", "mm-test")
+        assert fake_config.is_configured("minimax_polish")
+
+
+# --- polish_text routing ----------------------------------------------- #
+
+
+class TestPolishTextRouting:
+    def test_minimax_calls_resolved_endpoint(self, monkeypatch):
+        captured = {}
+
+        def fake_call(endpoint, model, api_key, text, timeout):
+            captured.update(endpoint=endpoint, model=model, api_key=api_key, text=text)
+            return text, "stop"
+
+        monkeypatch.setattr(polish, "_call_chat_completion", fake_call)
+        out = polish.polish_text(
+            "raw",
+            provider="minimax",
+            model="MiniMax-M3",
+            region="cn_zh",
+            api_key="k",
+        )
+        assert out == "raw"
+        assert captured["endpoint"] == "https://api.minimaxi.com/v1/chat/completions"
+        assert captured["model"] == "MiniMax-M3"
+        assert captured["api_key"] == "k"
+
+    def test_transport_error_returns_raw_text(self, monkeypatch):
+        def raise_(endpoint, model, api_key, text, timeout):
+            raise polish.urllib.error.URLError("boom")
+
+        monkeypatch.setattr(polish, "_call_chat_completion", raise_)
+        out = polish.polish_text(
+            "raw chunk",
+            provider="groq",
+            api_key="g",
+        )
+        # graceful degradation: original text returned unchanged
+        assert out == "raw chunk"


### PR DESCRIPTION
Reason: provider-add — make the transcript-polishing LLM backend configurable and add MiniMax (MiniMax-M3, MiniMax-M2.7) via MiniMax's OpenAI-compatible global and CN endpoints instead of hard-coding a single Groq/Llama combo.

## What changed

The Xiaoyuzhou podcast `--polish` step hard-coded Groq's `llama-3.3-70b-versatile` endpoint and model inside an inline Python snippet in `transcribe_xiaoyuzhou.sh`. This makes the polishing backend configurable and adds MiniMax as a provider.

- **New `agent_reach/polish.py`** — a small, importable, tested module that mirrors the existing `agent_reach/transcribe.py` provider-registry pattern:
  - `POLISH_PROVIDERS` registry with `groq` (backward-compatible default) and `minimax`.
  - MiniMax exposes the OpenAI-compatible **global** (`https://api.minimax.io/v1`) and **China** (`https://api.minimaxi.com/v1`) regional endpoints, and the current text models `MiniMax-M3` (provider default) and `MiniMax-M2.7`.
  - `resolve()` resolves provider → model → region/base_url → API key from explicit args, then env vars (`POLISH_PROVIDER`, `POLISH_MODEL`, `MINIMAX_REGION`, `MINIMAX_BASE_URL`, `MINIMAX_API_KEY`, `GROQ_API_KEY`), then `~/.agent-reach/config.yaml`.
  - `polish_text()` preserves the original truncation-split recursion and degrades to raw text on transport errors.
  - `python3 -m agent_reach.polish IN OUT` entry point so the shell script reuses the same registry at runtime (no duplicated provider config).
- **`agent_reach/scripts/transcribe_xiaoyuzhou.sh`** — the inline 60-line polish snippet is replaced by a `python3 -m agent_reach.polish` call; the provider/model/endpoint are no longer hard-coded. The merged-output label now reflects the resolved provider/model.
- **`agent_reach/cli.py`** — `agent-reach configure minimax-key VALUE` stores `minimax_api_key`.
- **`agent_reach/config.py`** — registers the `minimax_polish` feature requirement (`minimax_api_key`).
- **`.env.example`** and **`agent_reach/skill/references/video.md`** — document the configurable polish backend and the MiniMax global/CN option.
- **`tests/test_polish.py`** — 16 tests covering the registry, regional endpoint derivation, model override, key resolution from config, feature requirement, and graceful error fallback.

## Checks run

- `python -m pytest -q` → 444 passed (full suite, includes the new `tests/test_polish.py`).
- `ruff check agent_reach/polish.py tests/test_polish.py` → clean.
- `ruff format agent_reach/polish.py tests/test_polish.py` → applied.
- `bash -n agent_reach/scripts/transcribe_xiaoyuzhou.sh` → syntax OK.
- `python3 -m agent_reach.polish` smoke-tested for arg/missing-key handling.

No other model, provider, or vendor is referenced in code, tests, or this PR text.
