### PR TITLE
feat(channels): add Substack discovery channel (OpenCLI + Exa fallback)

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -15,6 +15,7 @@ from .instagram import InstagramChannel
 from .linkedin import LinkedInChannel
 from .reddit import RedditChannel
 from .rss import RSSChannel
+from .substack import SubstackChannel
 from .twitter import TwitterChannel
 from .v2ex import V2EXChannel
 from .web import WebChannel
@@ -36,6 +37,7 @@ ALL_CHANNELS: List[Channel] = [
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),
+    SubstackChannel(),
     RSSChannel(),
     ExaSearchChannel(),
     WebChannel(),

--- a/agent_reach/channels/substack.py
+++ b/agent_reach/channels/substack.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Substack — multi-backend discovery: OpenCLI / Exa via mcporter.
+
+Scope (deliberate): discovery only — `search` (find posts/newsletters) and
+`publication` (latest posts from a named newsletter). Both are PUBLIC on the
+OpenCLI side (verified live 2026-07: `opencli substack search` is tagged
+[public], no cookie). The logged-in `feed` command is intentionally out of
+scope so this channel never carries login state.
+
+Honest tiering: tier 0 because a genuine zero-config discovery path exists —
+Exa semantic search scoped to substack.com needs no browser, no key. OpenCLI
+is preferred when its bridge is live because results come from Substack's own
+search (fresher, exact); Exa is the approximate fallback. `publication` reads
+degrade on the Exa path (semantic approximation, not the real archive feed).
+
+Unlike login-bound OpenCLI channels (Reddit/Instagram), a live bridge here is
+sufficient evidence of usability: there is no login state left to verify for
+public commands, so ready → "ok" rather than the usual "warn".
+"""
+
+import shutil
+
+from .base import Channel
+
+_OPENCLI_USAGE = (
+    "opencli substack search \"query\" -f yaml   # 搜索文章和 Newsletter\n"
+    "  opencli substack publication <name> -f yaml # 指定 Newsletter 最新文章"
+)
+
+_EXA_USAGE = (
+    "mcporter call 'exa.web_search_exa(query=\"... site:substack.com\")'"
+)
+
+
+class SubstackChannel(Channel):
+    name = "substack"
+    description = "Substack 文章搜索与 Newsletter"
+    backends = ["OpenCLI", "Exa via mcporter"]
+    tier = 0  # zero-config path exists: Exa fallback — see module docstring
+
+    def can_handle(self, url: str) -> bool:
+        from agent_reach.utils.url import host_matches
+
+        # host_matches covers publication subdomains (lenny.substack.com).
+        # Custom domains (e.g. stratechery.com) can't be enumerated — those
+        # fall through to the generic web channel by design.
+        return host_matches(url, "substack.com")
+
+    def check(self, config=None):
+        """Probe candidates in order; first usable backend wins."""
+        self.active_backend = None
+        findings = []
+
+        for backend in self.ordered_backends(config):
+            if backend == "OpenCLI":
+                result = self._check_opencli()
+            else:
+                result = self._check_exa()
+            if result is None:
+                continue
+            findings.append((backend, *result))
+
+        for wanted in ("ok", "warn"):
+            for backend, status, message in findings:
+                if status == wanted:
+                    self.active_backend = backend if status == "ok" else None
+                    return status, message
+
+        if findings:
+            return "error", "\n".join(m for _, _, m in findings)
+
+        return "off", (
+            "未安装任何 Substack 后端。两条路径任选：\n"
+            "  桌面（推荐，精确搜索）：agent-reach install --channels substack\n"
+            "       （OpenCLI 公开命令，无需登录 Substack）\n"
+            "  零配置（近似搜索）：npm install -g mcporter\n"
+            "       mcporter config add exa https://mcp.exa.ai/mcp --scope home"
+        )
+
+    def _check_opencli(self):
+        """OpenCLI candidate. None = not installed."""
+        from agent_reach.backends import opencli_status
+
+        st = opencli_status()
+        if not st.installed:
+            return None
+        if st.broken:
+            return "error", st.hint
+        if st.ready:
+            # Public commands + live bridge: nothing left unverified that a
+            # login could invalidate, so this is honestly "ok" (contrast
+            # Reddit, where login state keeps ready at "warn").
+            return "ok", f"Substack 搜索可用（OpenCLI 公开命令）：\n  {_OPENCLI_USAGE}"
+        return "warn", st.hint
+
+    def _check_exa(self):
+        """Exa fallback candidate. None = mcporter not installed."""
+        from .mcporter import McporterConfigError, inspect_mcporter_config
+
+        if not shutil.which("mcporter"):
+            return None
+        try:
+            inspection = inspect_mcporter_config()
+        except McporterConfigError as exc:
+            return "error", f"mcporter 配置检查失败：{exc}"
+        if "exa" in inspection.server_names:
+            # Degraded but genuinely serving discovery: semantic search over
+            # the public web scoped to substack.com. publication 读取降级。
+            return "ok", (
+                "Substack 搜索通过 Exa 降级可用（近似语义搜索；"
+                "publication 精确读取需要 OpenCLI 桥接）：\n"
+                f"  {_EXA_USAGE}\n"
+                "  恢复完整能力：打开 Chrome（OpenCLI 扩展所在 profile）"
+            )
+        return "off", (
+            "mcporter 已装但 Exa 未配置。运行：\n"
+            "  mcporter config add exa https://mcp.exa.ai/mcp --scope home"
+        )

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -75,7 +75,7 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,substack,bilibili,linkedin,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -224,6 +224,7 @@ def _cmd_install(args):
         "reddit":      _install_reddit_deps,
         "facebook":    _install_opencli_deps,
         "instagram":   _install_opencli_deps,
+        "substack":    _install_opencli_deps,  # search/publication are public — no login
         "bilibili":    _install_bili_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
@@ -268,7 +269,9 @@ def _cmd_install(args):
         tools_dir = os.path.expanduser("~/.agent-reach/tools")
         os.makedirs(tools_dir, exist_ok=True)
 
-    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
+    # substack's INSTALL step is desktop-only (it only adds OpenCLI); the
+    # channel itself still works headless via the Exa fallback in core.
+    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram", "substack"}
     COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "xiaohongshu"}
 
     # Auto-detect environment

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,18 +7,18 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
-  雪球/股票行情, RSS feeds, or any web URL.
+  Instagram, Substack/newsletter, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube,
+  GitHub code search, 小宇宙播客, 雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
-  Zero config for 6 channels. Run `agent-reach doctor --json` to see which
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  Zero config for 7 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
   NOT for: 写报告/数据分析/翻译等内容加工（本 skill 只负责从互联网获取内容）；
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/Substack) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -30,6 +30,7 @@ triggers:
     - Reddit: reddit
     - Facebook: facebook/fb/facebook groups
     - Instagram: instagram/ig
+    - Substack: substack/newsletter
   - career: 招聘/职位/求职/linkedin/领英/找工作
   - dev: github/代码/仓库/gh/issue/pr/分支/commit
   - web: 网页/链接/文章/rss/读一下/打开这个
@@ -42,7 +43,7 @@ metadata:
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
@@ -62,7 +63,7 @@ metadata:
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
-| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
+| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/Substack | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
@@ -88,6 +89,11 @@ curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1
 
 # B站搜索（bili-cli，无需登录）
 bili search "query" --type video -n 5
+
+# Substack 搜索（OpenCLI 公开命令，无需登录，需桌面 Chrome 桥接；
+# 无桥接时用 Exa 近似：query 加 site:substack.com）
+opencli substack search "query" -f yaml
+opencli substack publication NAME -f yaml   # 指定 Newsletter 最新文章
 ```
 
 ## 需登录态的平台（按 doctor 的 active_backend 选命令）
@@ -135,7 +141,7 @@ agent-reach doctor --json
 根据用户需求，阅读对应的详细文档：
 
 - [搜索工具](references/search.md) — Exa AI 搜索
-- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
+- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram, Substack（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -6,11 +6,12 @@ description: >
   web for X", "see what people say about X", "look this up".
 
   Also MUST USE when user mentions any platform or shares any URL/link:
-  Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
-  Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
+  Twitter/X, Reddit, Facebook, Instagram, Substack/newsletters, YouTube, GitHub,
+  Bilibili, XiaoHongShu, Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX,
+  Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
-  Zero config for 6 channels. Run `agent-reach doctor --json` to see which
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  Zero config for 7 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
   NOT for: writing reports/analysis/translation (this skill only FETCHES
@@ -23,7 +24,7 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
@@ -50,7 +51,7 @@ these platforms — do not invent your own approach.**
 | User intent | Category | Details |
 |---------|------|---------|
 | Web / code search | search | [references/search.md](references/search.md) |
-| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
+| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram / Substack | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
@@ -76,6 +77,11 @@ curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1
 
 # Bilibili search (bili-cli, no login needed)
 bili search "query" --type video -n 5
+
+# Substack search (OpenCLI public commands, no login, needs desktop Chrome
+# bridge; without the bridge fall back to Exa with site:substack.com)
+opencli substack search "query" -f yaml
+opencli substack publication NAME -f yaml   # latest posts from one newsletter
 ```
 
 ## Login-backed platforms (pick by doctor's active_backend)
@@ -128,7 +134,7 @@ common cases; references hold per-backend command groups, caveats, retry
 chains — note: reference docs are written in Chinese, commands are universal):
 
 - [Search](references/search.md) — Exa AI search
-- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)
+- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram, Substack (multi-backend/login-backed groups)
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -299,3 +299,30 @@ opencli instagram saved --limit 20 -f yaml
 ```
 
 > 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 instagram.com。`instagram search` 是用户搜索；读帖子需要先确定 username，再用 `instagram user USERNAME`。若出现 429 / login required，先让用户在 Chrome 里重新登录并降低频率。
+
+---
+
+## Substack（多后端，无需登录）
+
+发现/搜索 Newsletter 与文章。先跑 `agent-reach doctor --json` 看 substack 的 `active_backend`。
+
+### 后端 A：OpenCLI（桌面首选，公开命令）
+
+```bash
+# 搜索文章和 Newsletter（公开命令，无需登录 Substack）
+opencli substack search "query" -f yaml
+
+# 指定 Newsletter 的最新文章
+opencli substack publication lenny -f yaml
+```
+
+> 要求 Chrome 打开且装了 OpenCLI 扩展，但**不需要**登录 substack.com（search/publication 都是 [public] 命令）。登录态的 `feed` 命令不在本渠道范围内。
+
+### 后端 B：Exa（零配置降级）
+
+```bash
+# 近似语义搜索（无浏览器时的降级路径）
+mcporter call 'exa.web_search_exa(query: "query site:substack.com", numResults: 5)'
+```
+
+> Exa 是近似搜索：发现类查询效果好，但 `publication` 式的精确归档读取会降级。读单篇文章正文用通用网页渠道：`curl -s "https://r.jina.ai/文章URL"`。自定义域名的 Newsletter（如 stratechery.com）不匹配本渠道，直接走 web 渠道。

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,7 +117,7 @@ agent-reach install --env=auto --channels=facebook,instagram    # Example: deskt
 agent-reach install --env=auto --channels=all              # User wants everything
 ```
 
-Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `bilibili`, `linkedin`, `all`
+Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `substack`, `bilibili`, `linkedin`, `all`
 
 ### Step 3: Fix what's broken
 

--- a/tests/test_substack_channel.py
+++ b/tests/test_substack_channel.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Dedicated tests for Substack's multi-backend discovery health check."""
+
+from unittest.mock import Mock, patch
+
+from agent_reach.backends.opencli import OpenCLIStatus
+from agent_reach.channels.substack import SubstackChannel
+
+
+def test_can_handle_matches_substack_hosts():
+    channel = SubstackChannel()
+    for url in [
+        "https://substack.com/home",
+        "https://www.substack.com/browse",
+        "https://lenny.substack.com/p/some-post",
+        "HTTPS://LENNY.SUBSTACK.COM/archive",
+    ]:
+        assert channel.can_handle(url) is True, url
+
+
+def test_can_handle_rejects_non_substack():
+    channel = SubstackChannel()
+    for url in [
+        "https://example.com/substack",
+        "https://substack.com.evil.test/p/x",
+        "https://stratechery.com/2026/post",  # custom domains → web channel
+        "",
+    ]:
+        assert channel.can_handle(url) is False, url
+
+
+def _opencli(**kwargs) -> OpenCLIStatus:
+    return OpenCLIStatus(**kwargs)
+
+
+def test_check_opencli_ready_is_ok_with_active_backend():
+    ready = _opencli(installed=True, extension_connected=True, daemon_running=True)
+    with patch("agent_reach.backends.opencli_status", return_value=ready):
+        channel = SubstackChannel()
+        status, message = channel.check()
+
+    assert status == "ok"
+    assert channel.active_backend == "OpenCLI"
+    assert "opencli substack search" in message
+
+
+def test_check_falls_back_to_exa_when_bridge_down():
+    down = _opencli(installed=True, extension_connected=False, hint="bridge down")
+    inspection = Mock(server_names={"exa"}, imports_unchecked=False)
+    with patch("agent_reach.backends.opencli_status", return_value=down), patch(
+        "shutil.which", return_value="/usr/local/bin/mcporter"
+    ), patch(
+        "agent_reach.channels.mcporter.inspect_mcporter_config",
+        return_value=inspection,
+    ):
+        channel = SubstackChannel()
+        status, message = channel.check()
+
+    assert status == "ok"
+    assert channel.active_backend == "Exa via mcporter"
+    assert "降级" in message
+
+
+def test_check_opencli_missing_and_exa_configured_uses_exa():
+    inspection = Mock(server_names={"exa"}, imports_unchecked=False)
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(installed=False),
+    ), patch("shutil.which", return_value="/usr/local/bin/mcporter"), patch(
+        "agent_reach.channels.mcporter.inspect_mcporter_config",
+        return_value=inspection,
+    ):
+        channel = SubstackChannel()
+        status, _ = channel.check()
+
+    assert status == "ok"
+    assert channel.active_backend == "Exa via mcporter"
+
+
+def test_check_nothing_installed_is_off_with_both_paths():
+    with patch(
+        "agent_reach.backends.opencli_status",
+        return_value=_opencli(installed=False),
+    ), patch("shutil.which", return_value=None):
+        channel = SubstackChannel()
+        status, message = channel.check()
+
+    assert status == "off"
+    assert channel.active_backend is None
+    assert "--channels substack" in message
+    assert "mcporter" in message
+
+
+def test_check_opencli_installed_but_disconnected_warns_when_no_exa():
+    down = _opencli(installed=True, extension_connected=False, hint="连接提示")
+    with patch("agent_reach.backends.opencli_status", return_value=down), patch(
+        "shutil.which", return_value=None
+    ):
+        channel = SubstackChannel()
+        status, message = channel.check()
+
+    assert status == "warn"
+    assert channel.active_backend is None
+    assert message == "连接提示"
+
+
+def test_backend_override_prefers_exa(monkeypatch):
+    """<channel>_backend config moves Exa to the front of the probe order."""
+    channel = SubstackChannel()
+    config = Mock()
+    config.get = Mock(
+        side_effect=lambda key: "Exa" if key == "substack_backend" else None
+    )
+    assert channel.ordered_backends(config)[0] == "Exa via mcporter"


### PR DESCRIPTION
## What

Adds a **Substack** channel for newsletter/post discovery — multi-backend, following the Reddit channel's probe pattern.

- **OpenCLI preferred**: `opencli substack search` / `publication` are **[public] commands** (verified live) — no login needed, so unlike login-bound OpenCLI channels, a live bridge is honestly `ok` rather than `warn` (rationale in module docstring)
- **Exa via mcporter fallback**: zero-config approximate discovery scoped to substack.com; doctor message states that `publication` reads degrade
- **tier 0** — a genuine zero-config path exists
- The logged-in `feed` command is deliberately out of scope: this channel carries no login state
- Custom-domain publications (e.g. stratechery.com) intentionally fall through to the web channel

## Wiring

- Registry (`channels/__init__.py`), installer (`--channels substack`; install step is desktop-only since it only adds OpenCLI — headless still gets the Exa path from core)
- Skill docs: SKILL.md + SKILL_en.md (counts 15→16 platforms, 6→7 zero-config) + `references/social.md` section
- `docs/install.md` channel list

## Testing

- 8 dedicated tests in `tests/test_substack_channel.py` covering: host matching (incl. lookalike rejection), each doctor state (OpenCLI ok / Exa fallback / warn-no-fallback / off), and `<channel>_backend` override
- Full suite: **436 passed**
- Live-verified on macOS: bridge down + Exa configured → `ok` via `Exa via mcporter` with degradation note; `opencli substack search` confirmed working with bridge up

🤖 Generated with [Claude Code](https://claude.com/claude-code)