### PR TITLE
fix: decode yt-dlp and ffmpeg output as UTF-8

### DIFF
--- a/agent_reach/transcribe.py
+++ b/agent_reach/transcribe.py
@@ -100,6 +100,8 @@ def _probe_audio_duration(path: Path) -> float:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=FFPROBE_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
@@ -148,9 +150,19 @@ def _run(cmd: List[str], timeout: int = 600) -> None:
 
     cmd carries user-supplied URLs/paths into yt-dlp/ffmpeg — a stalled
     network read or a hung probe must not block the CLI forever.
+
+    yt-dlp and ffmpeg emit UTF-8; decoding with the locale codec instead breaks
+    on CJK titles.
     """
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
     except subprocess.TimeoutExpired:
         raise TranscribeError(f"{cmd[0]} timed out after {timeout}s")
     if proc.returncode != 0:

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -674,3 +674,49 @@ class TestConfigOpenAIWhisper:
         assert not fake_config.is_configured("openai_whisper")
         fake_config.set("openai_api_key", "sk-test")
         assert fake_config.is_configured("openai_whisper")
+
+
+# --- Subprocess output decoding ---------------------------------------- #
+
+
+class TestSubprocessDecoding:
+    """yt-dlp and ffmpeg emit UTF-8 regardless of the platform locale.
+
+    Without an explicit encoding, text=True decodes with the locale codec, which
+    is gbk on a Chinese Windows system. Decoding fails inside the reader thread,
+    so subprocess.run returns with stdout/stderr set to None and the caller hits
+    AttributeError on .strip() instead of the intended TranscribeError.
+    """
+
+    CJK_BYTES = "中文标题".encode("utf-8")
+
+    def _decoding_run(self, returncode: int):
+        """subprocess.run that decodes CJK output the way the real call does."""
+
+        def fake_run(cmd, **kwargs):
+            encoding = kwargs.get("encoding") or "gbk"
+            errors = kwargs.get("errors") or "strict"
+            text = self.CJK_BYTES.decode(encoding, errors)
+            return subprocess.CompletedProcess(cmd, returncode, text, text)
+
+        return fake_run
+
+    def test_run_reports_a_failure_with_cjk_output(self, monkeypatch):
+        monkeypatch.setattr(tr.subprocess, "run", self._decoding_run(1))
+        with pytest.raises(tr.TranscribeError) as exc:
+            tr._run(["yt-dlp", "https://example.com/v"], timeout=5)
+        assert "yt-dlp" in str(exc.value)
+
+    def test_run_succeeds_with_cjk_output(self, monkeypatch):
+        monkeypatch.setattr(tr.subprocess, "run", self._decoding_run(0))
+        tr._run(["yt-dlp", "https://example.com/v"], timeout=5)
+
+    def test_probe_duration_reports_a_failure_with_cjk_output(self, monkeypatch, tmp_path):
+        # _require raises MissingDependency, a TranscribeError subclass, when
+        # ffprobe is absent. Without stubbing it the test passes on a machine
+        # that has no ffprobe without ever reaching subprocess.run.
+        monkeypatch.setattr(tr, "_require", lambda _binary: None)
+        monkeypatch.setattr(tr.subprocess, "run", self._decoding_run(1))
+        with pytest.raises(tr.TranscribeError) as exc:
+            tr._probe_audio_duration(tmp_path / "a.m4a")
+        assert "duration" in str(exc.value)


### PR DESCRIPTION
`yt-dlp` and `ffmpeg` emit UTF-8 on every platform, but `subprocess.run(..., text=True)` without an explicit `encoding` decodes with the locale codec, which is `gbk` on a Chinese Windows system.

A CJK video title then fails to decode inside subprocess's reader thread. `run` returns with `stdout`/`stderr` as `None`, and the caller raises `AttributeError: 'NoneType' object has no attribute 'strip'` instead of `TranscribeError`, after an unrelated thread traceback. The real error is lost.

Repro with a stand-in for yt-dlp that exits nonzero and writes a UTF-8 CJK title:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xad in position 2: illegal multibyte sequence
RESULT: AttributeError: 'NoneType' object has no attribute 'strip'
```

Same root cause as #262, which fixed the `mcporter` call in `channels/wechat.py`. Two sites weren't covered: `_probe_audio_duration` (ffprobe) and `_run` (yt-dlp and ffmpeg, three callers).

Both now pass `encoding="utf-8", errors="replace"`, so an odd byte can't turn a subprocess failure into a crash that hides the original error.

Three tests decode CJK the way the real call does; all three fail on main. `ruff`, `mypy` and `pytest` give the same results before and after on my machine (20 ruff findings, 1 mypy error in `cli.py`, 9 failures, all pre-existing and POSIX-only). Tests go 393 → 396 passed.

Windows 11, Python 3.14.