### PR TITLE
feat(skill): add fallback policy — WebSearch 用完时自动用 Agent 读文章

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -68,6 +68,24 @@ metadata:
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
 | YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
 
+## 回退策略：链接阅读
+
+用户发送链接时，按以下优先级处理：
+
+1. **WebSearch 还有额度** → 正常搜索 / 阅读
+2. **WebSearch 已用完** → 默认启动 **Agent 子代理直接读文章**，不报错、不卡住
+
+子代理根据链接类型自动路由到对应读取工具：
+
+| 链接类型 | 读取工具 |
+|---------|---------|
+| 通用网页 | Jina Reader (`curl -s https://r.jina.ai/URL`) |
+| 需要格式 / 图片 | web-reader MCP (`web-reader.webReader`) |
+| GitHub | `gh` CLI / zread MCP |
+| 视频 / 播客 | yt-dlp 字幕（见 [references/video.md](references/video.md)） |
+
+**关键**：Agent 负责选工具 + 读全文 + 返回摘要，主对话不阻塞。
+
 ## 零配置快速命令
 
 ```bash


### PR DESCRIPTION
## 改动

在 `agent_reach/skill/SKILL.md` 路由表后新增 **「回退策略：链接阅读」** 段。

### 规则

当用户发送链接时：

1. **WebSearch 还有额度** → 正常搜索 / 阅读
2. **WebSearch 已用完** → 默认启动 **Agent 子代理直接读文章**，不报错、不卡住

子代理根据链接类型自动路由到对应读取工具：

| 链接类型 | 读取工具 |
|---------|---------|
| 通用网页 | Jina Reader |
| 需要格式 / 图片 | web-reader MCP |
| GitHub | gh CLI / zread MCP |
| 视频 / 播客 | yt-dlp 字幕 |

### 背景

实际使用中遇到 WebSearch 额度用完的情况，此时不应卡住或报错，而应自动回退到用 Agent 子代理直接读文章正文，由子代理根据链接类型选合适的读取工具。

**Diff**: 18 行新增，0 行删除。