### PR TITLE
Report a failed container restart in xhs-cookies

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1553,11 +1553,19 @@ def _configure_xhs_cookies(value) -> bool:
         # Restart container so it reloads cookies from disk
         print("  Restarting container to reload cookies...", end=" ", flush=True)
         try:
-            subprocess.run(
+            # subprocess.run does not raise on a non-zero exit, so the result has
+            # to be checked; the cookies are on disk but unread until the restart
+            # actually happens.
+            restart = subprocess.run(
                 [docker, "restart", container_name],
                 capture_output=True, encoding="utf-8", timeout=30,
             )
-            print("done")
+            if restart.returncode != 0:
+                detail = (restart.stderr or "").strip()[:200] or f"exit {restart.returncode}"
+                print(f"\n  [!] Could not restart container: {detail}")
+                print(f"  Restart manually: docker restart {container_name}")
+            else:
+                print("done")
         except Exception as e:
             print(f"\n  [!] Could not restart container: {e}")
             print(f"  Restart manually: docker restart {container_name}")

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -901,3 +901,55 @@ def test_uninstall_preserves_mcporter_entries_without_agent_reach_provenance(
     output = capsys.readouterr().out
     assert not any("remove" in call for call in calls)
     assert "来源无法证明" in output
+
+
+def test_xhs_docker_cookie_restart_failure_is_reported(monkeypatch, capsys):
+    """A failed container restart must not be reported as done.
+
+    The cookies are already on disk at this point, but the container only reads
+    them on restart, so claiming success leaves the user with stale cookies and
+    no reason to look here.
+    """
+
+    def fake_which(name):
+        return "/usr/bin/docker" if name == "docker" else None
+
+    def fake_run(args, **_kwargs):
+        if args[1] == "ps":
+            return _docker_result(args, stdout="xiaohongshu-mcp\n")
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return _docker_result(args, stdout="/app/data/cookies.json\n")
+        if args[1] == "restart":
+            return _docker_result(args, returncode=1, stderr="no such container")
+        return _docker_result(args)
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._configure_xhs_cookies("web_session=xhs_secret")
+
+    output = capsys.readouterr().out
+    assert "Could not restart container" in output
+    assert "no such container" in output
+    assert "Restart manually" in output
+
+
+def test_xhs_docker_cookie_restart_success_still_reports_done(monkeypatch, capsys):
+    def fake_which(name):
+        return "/usr/bin/docker" if name == "docker" else None
+
+    def fake_run(args, **_kwargs):
+        if args[1] == "ps":
+            return _docker_result(args, stdout="xiaohongshu-mcp\n")
+        if args[1:3] == ["exec", "xiaohongshu-mcp"]:
+            return _docker_result(args, stdout="/app/data/cookies.json\n")
+        return _docker_result(args)
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._configure_xhs_cookies("web_session=xhs_secret")
+
+    output = capsys.readouterr().out
+    assert "done" in output
+    assert "Could not restart container" not in output


### PR DESCRIPTION
`_configure_xhs_cookies` restarts the container so it reloads the cookies, but never checks the result:

```python
subprocess.run([docker, "restart", container_name], capture_output=True, encoding="utf-8", timeout=30)
print("done")
```

`subprocess.run` only raises on timeout or OSError, not on a non-zero exit, so `docker restart` failing (container gone, daemon down, permissions) still prints `done`. The `docker cp` right above it does check `returncode`.

The cookies are on disk by then, but xiaohongshu-mcp only reads them on restart. So the user is told configuration succeeded and keeps hitting auth failures with nothing pointing back here.

Now prints the stderr and the manual command, same shape as the `docker cp` failure path.

Two tests, one for each branch. The failure one fails on main. Suite goes 393 → 395 passed; `ruff` and `mypy` unchanged (20 findings and 1 pre-existing error in `cli.py`).