### PR TITLE
fix: resolve symlinked $HOME so the config dir doesn't trip the symlink guard

### DIFF
--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -12,6 +12,7 @@ from agent_reach.probe import probe_command
 from agent_reach.utils.paths import (
     PrivatePathError,
     read_small_text_no_follow,
+    user_home,
 )
 
 from .base import Channel
@@ -45,7 +46,7 @@ def _gh_hosts_path() -> Path:
         if app_data:
             return Path(app_data) / "GitHub CLI" / "hosts.yml"
 
-    return Path.home() / ".config" / "gh" / "hosts.yml"
+    return user_home() / ".config" / "gh" / "hosts.yml"
 
 
 def _saved_github_host_configured() -> bool:

--- a/agent_reach/channels/mcporter.py
+++ b/agent_reach/channels/mcporter.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from agent_reach.utils.paths import (
     PrivatePathError,
     read_small_text_no_follow,
+    user_home,
 )
 
 _MAX_CONFIG_BYTES = 1024 * 1024
@@ -94,7 +95,7 @@ def _select_config_layers(
         return [(Path(os.path.abspath(os.fspath(expanded))), "explicit")]
 
     layers = []
-    home_base = Path.home() / ".mcporter"
+    home_base = user_home() / ".mcporter"
     for name in ("mcporter.json", "mcporter.jsonc"):
         candidate = home_base / name
         if os.path.lexists(candidate):

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -12,11 +12,11 @@ logged-in session: OpenCLI reuses the browser's, rdt-cli imports cookies.
 import json
 import shutil
 import time
-from pathlib import Path
 
 from agent_reach.utils.paths import (
     PrivatePathError,
     read_small_text_no_follow,
+    user_home,
 )
 
 from .base import Channel
@@ -92,7 +92,7 @@ class RedditChannel(Channel):
         if not shutil.which("rdt"):
             return None
 
-        credential_path = Path.home() / ".config" / "rdt-cli" / "credential.json"
+        credential_path = user_home() / ".config" / "rdt-cli" / "credential.json"
         try:
             payload = read_small_text_no_follow(
                 credential_path,

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -14,11 +14,11 @@ import shutil
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
 
 from agent_reach.utils.paths import (
     PrivatePathError,
     read_small_text_no_follow,
+    user_home,
 )
 
 from .base import Channel
@@ -256,7 +256,7 @@ class XiaoHongShuChannel(Channel):
         """Inspect saved xhs-cli cookies without invoking browser extraction."""
         if not shutil.which("xhs"):
             return None
-        cookie_path = Path.home() / ".xiaohongshu-cli" / "cookies.json"
+        cookie_path = user_home() / ".xiaohongshu-cli" / "cookies.json"
         try:
             payload = read_small_text_no_follow(
                 cookie_path,

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -18,6 +18,7 @@ from agent_reach.utils.paths import (
     ensure_no_symlink_path,
     make_private_dir,
     read_small_text_no_follow,
+    user_home,
 )
 
 _MAX_CONFIG_BYTES = 1024 * 1024
@@ -98,7 +99,7 @@ def _atomic_write_yaml(target: Path, data: dict) -> None:
 class Config:
     """Manages Agent Reach configuration."""
 
-    CONFIG_DIR = Path.home() / ".agent-reach"
+    CONFIG_DIR = user_home() / ".agent-reach"
     CONFIG_FILE = CONFIG_DIR / "config.yaml"
 
     # Feature → required config keys

--- a/agent_reach/utils/paths.py
+++ b/agent_reach/utils/paths.py
@@ -30,6 +30,26 @@ def ensure_no_symlink_path(path: str | Path, label: str = "路径") -> Path:
     return target
 
 
+def user_home() -> Path:
+    """Return the home directory with any symlinked prefix resolved.
+
+    ``Path.home()`` returns ``$HOME`` verbatim. When ``$HOME`` itself is a
+    symlink — a relocated ``/home`` pointing at a larger disk, an NFS-mounted
+    home, or a container bind-mount — every agent-reach-owned path built
+    beneath it (``~/.agent-reach``, ``~/.config/...``) would traverse that link
+    and be rejected by :func:`ensure_no_symlink_path`, even though the link is
+    supplied by the system/administrator rather than an attacker.
+
+    Resolving only the home *prefix* keeps the guard meaningful: the paths
+    agent-reach creates under the returned directory (``.agent-reach``,
+    ``config.yaml``, cookie/credential files) are still checked for symlinks
+    component-by-component, so a link planted *inside* the home directory is
+    still refused. An attacker who could rewrite a root-owned ``$HOME`` symlink
+    already holds higher privileges, so resolving it yields no safety loss.
+    """
+    return Path(os.path.realpath(Path.home()))
+
+
 def make_private_dir(path: str | Path) -> Path:
     """Create a directory restricted to the current user where supported."""
     target = ensure_no_symlink_path(path, "私密目录")
@@ -175,7 +195,7 @@ def get_ytdlp_config_dir() -> Path:
     """
 
     xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
-    config_home = Path(xdg_config_home) if xdg_config_home else Path.home() / ".config"
+    config_home = Path(xdg_config_home) if xdg_config_home else user_home() / ".config"
     return config_home / "yt-dlp"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@
 import pytest
 
 from agent_reach.config import Config, ConfigReadOnlyError, ConfigSecurityError
+from agent_reach.utils import paths
 
 
 @pytest.fixture
@@ -144,6 +145,34 @@ class TestConfig:
             assert not (mode & stat.S_IXGRP), "group execute should not be set"
             assert not (mode & stat.S_IROTH), "other read should not be set"
             assert not (mode & stat.S_IXOTH), "other execute should not be set"
+
+    def test_config_dir_under_symlinked_home_initializes_and_saves(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression: a symlinked ``$HOME`` used to abort every command with
+        ConfigSecurityError. The default CONFIG_DIR resolves the home prefix,
+        so Config now initializes and persists there normally."""
+        real_home = tmp_path / "real-home"
+        real_home.mkdir(mode=0o700)
+        linked_home = tmp_path / "linked-home"
+        try:
+            linked_home.symlink_to(real_home, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        monkeypatch.setattr(
+            paths.Path, "home", classmethod(lambda cls: linked_home)
+        )
+        from agent_reach.utils.paths import user_home
+
+        config_file = user_home() / ".agent-reach" / "config.yaml"
+        assert not config_file.is_relative_to(linked_home)
+
+        config = Config(config_path=config_file)
+        config.set("key", "value")
+
+        assert config.get("key") == "value"
+        assert config_file.is_relative_to(real_home)
 
     def test_load_refuses_symlink_config_path(self, tmp_path):
         victim = tmp_path / "victim.yaml"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,6 +4,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from agent_reach.utils import paths
 
 
@@ -35,3 +37,44 @@ def test_ytdlp_config_dir_matches_upstream_first_user_location(
     expected = Path(next(get_user_config_dirs("yt-dlp")))
 
     assert paths.get_ytdlp_config_dir() == expected
+
+
+def test_user_home_resolves_symlinked_home(monkeypatch, tmp_path):
+    """A symlinked ``$HOME`` (relocated /home, NFS, bind-mount) resolves to
+    its real target so paths built beneath it don't trip the symlink guard."""
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    linked_home = tmp_path / "linked-home"
+    try:
+        linked_home.symlink_to(real_home, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: linked_home))
+
+    resolved = paths.user_home()
+
+    assert resolved == real_home
+    # Whatever agent-reach builds beneath it is now symlink-free end to end.
+    paths.ensure_no_symlink_path(resolved / ".agent-reach" / "config.yaml")
+
+
+def test_user_home_still_rejects_symlink_inside_home(monkeypatch, tmp_path):
+    """Resolving the home *prefix* must not weaken the guard on components the
+    tool creates below it: a link planted inside home is still refused."""
+    real_home = tmp_path / "myhome"
+    real_home.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    linked_child = real_home / ".agent-reach"
+    try:
+        linked_child.symlink_to(victim, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: real_home))
+
+    with pytest.raises(paths.PrivatePathError, match="符号链接"):
+        paths.ensure_no_symlink_path(
+            paths.user_home() / ".agent-reach" / "config.yaml"
+        )


### PR DESCRIPTION
## Problem

On a host where `\$HOME` is itself a **symlink** — a relocated `/home` pointing at a larger disk, an NFS-mounted home, or a container bind-mount — **every** `agent-reach` command aborts immediately:

```
agent_reach.config.ConfigSecurityError: 配置目录不能经过符号链接：/home/<user>
```

### Reproduce

```bash
# /home/<user> -> /data00/home/<user>  (root-owned symlink, common on servers)
$ ls -ld /home/<user>
lrwxrwxrwx 1 root root 23 ... /home/<user> -> /data00/home/<user>

$ agent-reach doctor
ConfigSecurityError: 配置目录不能经过符号链接：/home/<user>
```

### Root cause

`Config.CONFIG_DIR` (and the per-backend credential paths in `github`/`reddit`/`xiaohongshu`/`mcporter`, plus `get_ytdlp_config_dir`) are built from `Path.home()`, which returns `\$HOME` **verbatim**. `Config.load()` then runs `ensure_no_symlink_path()`, which walks the path component-by-component with `os.lstat` and rejects it the moment *any* segment is a symlink. When `\$HOME` itself is the symlink, the check fires on the home segment and the process dies before doing anything.

## Fix

Add `utils.paths.user_home()`, which resolves **only the home prefix** via `os.path.realpath(Path.home())`, and route the six `Path.home()` call sites through it.

The symlink guard is **not weakened**. Everything agent-reach *creates* beneath home — `.agent-reach/`, `config.yaml`, cookie/credential files — is still checked component-by-component by `ensure_no_symlink_path`, so a symlink planted *inside* the home directory is still refused, and an explicitly-passed symlinked `config_path` is still rejected (existing tests `test_config_directory_symlink_is_rejected` / `test_config_ancestor_symlink_is_rejected` stay green).

### Why this is safe

The guard exists to stop a credential write/read from being **redirected** through an attacker-controlled symlink (TOCTOU). A system-supplied `\$HOME` symlink is a different thing: it is owned by root/the administrator, not the user. An attacker who could rewrite a root-owned `\$HOME` symlink already holds higher privileges than the agent-reach process — so resolving that one prefix yields **no** safety loss, while unblocking a large class of legitimate environments (relocated `/home`, NFS homes, containers).

Resolving the prefix also fixes a quieter bug: on a symlinked home, the YouTube JS-runtime detection (`get_ytdlp_config_dir` → `read_small_text_no_follow`) silently failed the same way.

## Tests

`tests/` (431 tests) pass. Added regression coverage:

- `test_user_home_resolves_symlinked_home` — `user_home()` resolves a symlinked home; a config path built beneath it is symlink-free end to end.
- `test_user_home_still_rejects_symlink_inside_home` — a link planted *inside* home is still refused (guard intact).
- `test_config_dir_under_symlinked_home_initializes_and_saves` — the original crash: `Config` now initializes **and** persists under a symlinked home.

## Notes for the maintainer

- Scope is deliberately minimal (8 files, +103/−8); I did **not** run `ruff format`, because the touched files were already "unformatted" by ruff's formatter on `main` and CI only runs `pytest -q` — reformatting would add unrelated noise. `ruff check` is clean on every touched file and `mypy` is clean on the changed sources.
- Optional follow-up (not included, your call): a `AGENT_REACH_CONFIG_DIR` env override for users who want the config elsewhere. `user_home()` alone fixes the reported breakage without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)