### PR TITLE
fix(bilibili): bypass proxy in Bilibili search API health check

### DIFF
--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -22,10 +22,17 @@ _SEARCH_API = "https://api.bilibili.com/x/web-interface/search/all/v2?keyword=te
 
 
 def _search_api_ok() -> bool:
-    """Return True if Bilibili search API responds with code 0."""
+    """Return True if Bilibili search API responds with code 0.
+
+    Bypasses HTTP_PROXY/HTTPS_PROXY because bilibili is a domestic
+    Chinese site that should be accessed directly.  Routing it through
+    an outbound proxy configured for Reddit/Twitter would cause a false
+    negative in doctor.
+    """
     req = urllib.request.Request(_SEARCH_API, headers={"User-Agent": _UA})
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        with opener.open(req, timeout=_TIMEOUT) as resp:
             data = json.loads(resp.read())
             return data.get("code") == 0
     except Exception:


### PR DESCRIPTION
## Summary

Fix a bug where `_search_api_ok()` in the Bilibili channel would fail when a user has configured an HTTP proxy for international sites (Reddit/Twitter).

## Problem

`_search_api_ok()` used `urllib.request.urlopen()` which routes through system `HTTP_PROXY`/`HTTPS_PROXY`. When a user sets up a proxy for Reddit/Twitter (blocked sites in mainland China), the Bilibili search API check — a domestic Chinese site that should be accessed directly — would also go through the proxy, producing a **false negative** in `agent-reach doctor`.

## Fix

Use `urllib.request.ProxyHandler({})` to explicitly bypass the proxy, consistent with the pattern already established in `xiaohongshu._mcp_service_reachable()`.

## Testing

All 428 tests pass:

```
============================= 428 passed in 12.02s =============================
```

## Diff

- `agent_reach/channels/bilibili.py`: 1 file, +9 −2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)