### PR TITLE
修复(skill)：改用兼容 PowerShell 的 mcporter 参数语法

### DIFF
--- a/agent_reach/guides/setup-exa.md
+++ b/agent_reach/guides/setup-exa.md
@@ -23,7 +23,7 @@ mcporter config add exa https://mcp.exa.ai/mcp --scope home
 ### 3. 验证
 ```bash
 agent-reach doctor | grep "Search"
-mcporter call 'exa.web_search_exa(query: "test", numResults: 1)'
+mcporter call exa.web_search_exa query="test" numResults=1
 ```
 
 ## 需要用户手动做的步骤

--- a/agent_reach/guides/setup-reddit.md
+++ b/agent_reach/guides/setup-reddit.md
@@ -48,7 +48,7 @@ rdt read POST_ID
 如果你已经配置了 Exa（通过 mcporter），也可以通过 Exa 搜索 Reddit 内容：
 
 ```bash
-mcporter call 'exa.web_search_exa(query: "python best practices", numResults: 5, includeDomains: ["reddit.com"])'
+mcporter call exa.web_search_exa query="site:reddit.com python best practices" numResults=5
 ```
 
 rdt-cli 是当前推荐方案，无需额外配置即可使用。

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -72,7 +72,7 @@ metadata:
 
 ```bash
 # Exa 网页搜索
-mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
+mcporter call exa.web_search_exa query="query" numResults=5
 
 # 通用网页阅读
 curl -s "https://r.jina.ai/URL"

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -60,7 +60,7 @@ these platforms — do not invent your own approach.**
 
 ```bash
 # Exa web search
-mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
+mcporter call exa.web_search_exa query="query" numResults=5
 
 # Read any web page
 curl -s "https://r.jina.ai/URL"

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -6,16 +6,16 @@ LinkedIn。
 
 ```bash
 # 获取个人资料
-mcporter call 'linkedin-scraper.get_person_profile(linkedin_url: "https://linkedin.com/in/username")'
+mcporter call linkedin-scraper.get_person_profile linkedin_url="https://linkedin.com/in/username"
 
 # 搜索人才
-mcporter call 'linkedin-scraper.search_people(keyword: "AI engineer", limit: 10)'
+mcporter call linkedin-scraper.search_people keyword="AI engineer" limit=10
 
 # 获取公司资料
-mcporter call 'linkedin-scraper.get_company_profile(linkedin_url: "https://linkedin.com/company/xxx")'
+mcporter call linkedin-scraper.get_company_profile linkedin_url="https://linkedin.com/company/xxx"
 
 # 搜索职位
-mcporter call 'linkedin-scraper.search_jobs(keyword: "software engineer", limit: 10)'
+mcporter call linkedin-scraper.search_jobs keyword="software engineer" limit=10
 ```
 
 > **需要登录**: LinkedIn scraper 需要有效的登录态。

--- a/agent_reach/skill/references/search.md
+++ b/agent_reach/skill/references/search.md
@@ -7,8 +7,8 @@ Exa AI 搜索引擎。
 高质量 AI 搜索引擎，擅长技术和代码搜索。
 
 ```bash
-mcporter call 'exa.web_search_exa(query: "query", numResults: 5)'
-mcporter call 'exa.get_code_context_exa(query: "code question", tokensNum: 3000)'
+mcporter call exa.web_search_exa query="query" numResults=5
+mcporter call exa.get_code_context_exa query="code question" tokensNum=3000
 ```
 
 ### 使用场景

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -38,13 +38,13 @@ opencli xiaohongshu user USER_ID -f yaml
 agent-reach configure xhs-cookies "导出的 Cookie Header String"
 
 # 只读检查当前状态
-mcporter call 'xiaohongshu.check_login_status()' --timeout 120000
+mcporter call xiaohongshu.check_login_status --timeout 120000
 
 # 搜索
-mcporter call 'xiaohongshu.search_feeds(keyword: "query")' --timeout 120000
+mcporter call xiaohongshu.search_feeds keyword="query" --timeout 120000
 
 # 笔记详情+评论（feed_id 和 xsec_token 从搜索结果取）
-mcporter call 'xiaohongshu.get_feed_detail(feed_id: "...", xsec_token: "...")' --timeout 120000
+mcporter call xiaohongshu.get_feed_detail feed_id="..." xsec_token="..." --timeout 120000
 ```
 
 > 首次调用会自动下载约 150MB 无头浏览器，务必带 `--timeout 120000`。

--- a/agent_reach/skill/references/web.md
+++ b/agent_reach/skill/references/web.md
@@ -18,13 +18,13 @@ curl -s "https://r.jina.ai/https://example.com/article"
 
 ```bash
 # 读取网页内容 (Markdown 格式)
-mcporter call 'web-reader.webReader(url: "https://example.com")'
+mcporter call web-reader.webReader url="https://example.com"
 
 # 保留图片
-mcporter call 'web-reader.webReader(url: "https://example.com", retain_images: true)'
+mcporter call web-reader.webReader url="https://example.com" retain_images=true
 
 # 纯文本格式
-mcporter call 'web-reader.webReader(url: "https://example.com", return_format: "text")'
+mcporter call web-reader.webReader url="https://example.com" return_format=text
 ```
 
 **适用场景**: 需要更精确控制输出格式时使用。

--- a/docs/install.md
+++ b/docs/install.md
@@ -377,10 +377,10 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | Instagram | `opencli` | `opencli instagram user nasa -f yaml` |
 | GitHub | `gh` | `gh search repos "query"` |
 | Web | `curl` + Jina | `curl -s "https://r.jina.ai/URL"` |
-| Exa Search | `mcporter` | `mcporter call 'exa.web_search_exa(...)'` |
+| Exa Search | `mcporter` | `mcporter call exa.web_search_exa query="..." numResults=5` |
 | 小红书 | `opencli`（服务器 `mcporter`） | `opencli xiaohongshu search "query" -f yaml` |
 | 小宇宙播客 | `transcribe.sh` | `bash ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh <URL>` |
-| LinkedIn | `mcporter` | `mcporter call 'linkedin.get_person_profile(...)'` |
+| LinkedIn | `mcporter` | `mcporter call linkedin.get_person_profile linkedin_url="..."` |
 | RSS | `feedparser` | `python3 -c "import feedparser; ..."` |
 
 > 多后端平台以 `agent-reach doctor --json` 的 `active_backend` 为准。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,7 +52,7 @@ proxychains twitter search "test" -n 1
 twitter-cli 不可用时，可以直接用 Exa 搜索 Twitter 内容：
 
 ```bash
-mcporter call 'exa.web_search_exa(query: "site:x.com 搜索词", numResults: 5)'
+mcporter call exa.web_search_exa query="site:x.com 搜索词" numResults=5
 ```
 
 ### 方案 4：检查认证

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -3,8 +3,10 @@
 
 import importlib.resources
 import os
+import re
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from agent_reach.cli import _install_skill, _uninstall_skill
@@ -22,6 +24,22 @@ class TestSkillCommand(unittest.TestCase):
 
         self.assertTrue(default_skill.strip())
         self.assertTrue(english_skill.strip())
+
+    def test_mcporter_examples_use_shell_safe_named_arguments(self):
+        """Packaged guidance must avoid function-call syntax that breaks in PowerShell."""
+        repo_root = Path(__file__).resolve().parents[1]
+        markdown_files = [
+            *(repo_root / "agent_reach" / "skill").rglob("*.md"),
+            *(repo_root / "agent_reach" / "guides").rglob("*.md"),
+            repo_root / "docs" / "install.md",
+            repo_root / "docs" / "troubleshooting.md",
+        ]
+        function_call = re.compile(r"mcporter call\s+['\"][^'\"\r\n]+\(")
+
+        for markdown_file in markdown_files:
+            with self.subTest(markdown_file=markdown_file):
+                content = markdown_file.read_text(encoding="utf-8")
+                self.assertNotRegex(content, function_call)
 
     def test_install_skill_creates_skill_md(self):
         """_install_skill should create SKILL.md in the first available skill dir."""


### PR DESCRIPTION
## 概要

- 将函数调用式 `mcporter` 示例替换为跨 Shell 更稳定的命名参数写法
- 将 Exa 的 Reddit 回退搜索改为受支持的 `site:reddit.com` 查询
- 添加回归测试，覆盖随包发布的技能、指南以及当前安装/故障排查文档

## 根因

在 Windows 上，npm 生成的 PowerShell shim 无法可靠保留下列函数调用式写法中的嵌套字符串字面量：

```text
mcporter call 'exa.web_search_exa(query: "test", numResults: 1)'
```

因此，`mcporter` 收到的是标识符而非字符串，并报出 `Unsupported argument expression: Identifier`；查询中包含空格时，还可能把部分表达式误识别为临时 MCP 服务名。

本 PR 统一改用 `mcporter` 官方支持的 `key=value` 参数形式：

```text
mcporter call exa.web_search_exa query="test" numResults=1
```

该写法已在 PowerShell 中实际验证，同时兼容 Bash。

## 用户影响

Windows 用户的 Agent 按照内置技能调用 Exa 时，不再在发出 MCP 请求前就因参数解析失败。其他 MCP 后端的当前技能示例与配置指南也统一采用相同的可移植写法。

## 验证

- `python -m pytest tests/test_skill_command.py -v`：6 项通过，15 个子测试通过
- `python -m ruff check tests/test_skill_command.py`：通过
- `git diff --check`：通过
- 实际运行 `mcporter call exa.web_search_exa query="Agent Reach GitHub repository" numResults=1`：成功返回真实搜索结果
- Windows 完整测试：403 项通过、14 项跳过；另有 12 项与本改动无关的既有失败，集中在 POSIX `/bin/sh`、符号链接与 HOME 隔离
- 全项目 ruff：存在 20 个与本改动无关的既有问题；本次修改的 Python 文件检查通过
- 全项目 mypy：存在 1 个与本改动无关的既有错误，位于 `agent_reach/cli.py:1747`

## 相关工作

PR #537 处理的是另一个问题：Exa 工具契约中包含已弃用工具。本 PR 只处理 PowerShell 下的参数传递兼容性；两者在搜索参考文档中有少量行级重叠，合并顺序不同可能需要一次简单 rebase。
