### PR TITLE
docs(security): pin Agent Reach install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 
 **Agent Reach 把这件事变成一句话：**
 
+> ⚠️ **安装来源提醒：** Agent Reach 不发布到 PyPI。请从下方固定版本的 GitHub 压缩包安装；不要运行 `pip install agent-reach`，PyPI 上的同名包不是本项目。
+
 ```
 帮我安装 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/install.md
 ```
@@ -135,7 +137,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 <details>
 <summary>它会做什么？（点击展开）</summary>
 
-1. **安装 CLI 工具** — `pip install` 装好 `agent-reach` 命令行（自带 yt-dlp、feedparser）
+1. **安装 CLI 工具** — 从固定版本的 GitHub 压缩包安装 `agent-reach`（不要运行 `pip install agent-reach`；PyPI 同名包不是本项目）
 2. **安装系统基建** — 自动检测并安装 Node.js、gh CLI、mcporter
 3. **配置搜索引擎** — 通过 MCP 接入 Exa（免费，无需 API Key）
 4. **检测环境** — 判断是本地电脑还是服务器，给出对应的配置建议

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1961,7 +1961,7 @@ _UPDATE_INSTRUCTIONS = (
     "更新方式（推荐，复制这句话给你的 AI Agent，会完整更新本体+上游工具+skill）：\n"
     "  帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md\n"
     "仅更新本体（不含上游工具和 skill）：\n"
-    "  pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip"
+    "  pip install --upgrade https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip"
 )
 
 

--- a/agent_reach/integrations/mcp_server.py
+++ b/agent_reach/integrations/mcp_server.py
@@ -28,7 +28,11 @@ except ImportError:
 
 def create_server():
     if not HAS_MCP:
-        print("MCP not installed. Install: pip install agent-reach[mcp]", file=sys.stderr)
+        print(
+            "MCP not installed. Install its dependency: "
+            'python -m pip install "mcp[cli]>=1.0"',
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     server = Server("agent-reach")

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -57,6 +57,8 @@ metadata:
    https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md」。
    不要中断当前任务去更新，也不要重复提醒同一个版本。
 
+> **安装来源注意：** Agent Reach 不发布到 PyPI。安装/更新时只能使用固定版本的 GitHub archive（当前为 `v1.5.0`）；不要运行 `pip install agent-reach`，PyPI 同名包不是本项目。
+
 ## 路由表
 
 | 用户意图 | 分类 | 详细文档 |

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -45,6 +45,8 @@ these platforms — do not invent your own approach.**
    https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md".
    Never interrupt the current task to update; never nag about the same version twice.
 
+> **Install source boundary:** Agent Reach is not distributed on PyPI. For install/update guidance, use the pinned GitHub archive (`v1.5.0`); never run `pip install agent-reach`, because the same-name PyPI package is unrelated.
+
 ## Routing table
 
 | User intent | Category | Details |

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -93,6 +93,8 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 ## Quick Start
 
+> ⚠️ **Install source:** Agent Reach is not distributed on PyPI. Use the pinned GitHub archive in the manual-install snippet below; do not run `pip install agent-reach`, which installs an unrelated project with the same name.
+
 > ⚠️ **OpenClaw users: enable `exec` permission first**
 >
 > Agent Reach relies on the Agent running shell commands (`pip install`, `mcporter`, `twitter`, etc.). If your OpenClaw uses the default `messaging` tool profile, the Agent won't be able to run them. **Enable `exec` before installing:**
@@ -125,7 +127,7 @@ The Agent auto-installs, detects your environment, and tells you what's ready.
 <summary>Manual install</summary>
 
 ```bash
-pip install https://github.com/Panniantong/agent-reach/archive/main.zip
+pip install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 agent-reach install --env=auto
 ```
 </details>

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -84,6 +84,8 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 ## クイックスタート
 
+> ⚠️ **インストール元に注意:** Agent Reach は PyPI では配布していません。下記の固定済み GitHub アーカイブからインストールしてください。`pip install agent-reach` は実行しないでください。PyPI の同名パッケージはこのプロジェクトとは無関係です。
+
 以下をAIエージェント（Claude Code、OpenClaw、Cursor等）にコピーしてください：
 
 ```
@@ -101,7 +103,7 @@ Install Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/m
 <summary>手動インストール</summary>
 
 ```bash
-pip install https://github.com/Panniantong/agent-reach/archive/main.zip
+pip install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 agent-reach install --env=auto
 ```
 </details>
@@ -272,7 +274,7 @@ Agent Reach は [rdt-cli](https://github.com/public-clis/rdt-cli) でRedditに�
 <details>
 <summary><strong>Agent Reach は Claude Code / Cursor / Windsurf / OpenClaw で動作する？</strong></summary>
 
-はい！Agent Reach はインストーラー + 設定ツールです。シェルコマンドを実行できるあらゆるAIコーディングエージェントで使用できます — Claude Code、Cursor、Windsurf、OpenClaw、Codex等。`pip install agent-reach` を実行し、`agent-reach install` を実行するだけで、エージェントはすぐに上流ツールを使い始められます。
+はい！Agent Reach はインストーラー + 設定ツールです。シェルコマンドを実行できるあらゆるAIコーディングエージェントで使用できます — Claude Code、Cursor、Windsurf、OpenClaw、Codex等。上記の固定済み GitHub アーカイブからインストールし、`agent-reach install` を実行するだけで、エージェントはすぐに上流ツールを使い始められます。
 </details>
 
 <details>

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -84,6 +84,8 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 ## 빠른 시작
 
+> ⚠️ **설치 출처 주의:** Agent Reach는 PyPI에 배포되지 않습니다. 아래의 고정된 GitHub 아카이브에서 설치하세요. `pip install agent-reach`를 실행하지 마세요. PyPI의 같은 이름 패키지는 이 프로젝트와 무관합니다.
+
 이 명령을 AI 에이전트(Claude Code, OpenClaw, Cursor 등)에 입력하세요:
 
 ```
@@ -101,7 +103,7 @@ Install Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/m
 <summary>수동 설치</summary>
 
 ```bash
-pip install https://github.com/Panniantong/agent-reach/archive/main.zip
+pip install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 agent-reach install --env=auto
 ```
 </details>
@@ -273,7 +275,7 @@ Agent Reach는 Reddit을 위해 [rdt-cli](https://github.com/public-clis/rdt-cli
 <details>
 <summary><strong>Agent Reach는 Claude Code / Cursor / Windsurf / OpenClaw와 호환되나요?</strong></summary>
 
-네! Agent Reach는 설치 + 설정 도구입니다. Shell 명령을 실행할 수 있는 모든 AI 코딩 에이전트가 사용할 수 있습니다 — Claude Code, Cursor, Windsurf, OpenClaw, Codex 등. `pip install agent-reach`만 실행하고 `agent-reach install`을 실행하면, 에이전트가 즉시 업스트림 도구 사용을 시작할 수 있습니다.
+네! Agent Reach는 설치 + 설정 도구입니다. Shell 명령을 실행할 수 있는 모든 AI 코딩 에이전트가 사용할 수 있습니다 — Claude Code, Cursor, Windsurf, OpenClaw, Codex 등. 위의 고정된 GitHub 아카이브에서 설치한 뒤 `agent-reach install`을 실행하면, 에이전트가 즉시 업스트림 도구 사용을 시작할 수 있습니다.
 </details>
 
 <details>

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,16 +48,18 @@ All Agent Reach files go in dedicated directories — **never in the agent works
 
 ### Step 1: Install the basics
 
+> ⚠️ **Install source:** Agent Reach is not published on PyPI. Do not run `pip install agent-reach`; the PyPI package with that name is unrelated. The commands below install the pinned `v1.5.0` GitHub archive.
+
 ```bash
 # 推荐：pipx（最省心）
-pipx install https://github.com/Panniantong/agent-reach/archive/main.zip
+pipx install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 agent-reach install --env=auto
 
 # 如果你的 Python 来自 Homebrew / 遇到 PEP 668（externally-managed-environment）
 # 用虚拟环境安装：
 python3 -m venv ~/.agent-reach-venv
 source ~/.agent-reach-venv/bin/activate
-pip install https://github.com/Panniantong/agent-reach/archive/main.zip
+pip install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 agent-reach install --env=auto
 ```
 
@@ -70,7 +72,7 @@ agent-reach install --env=auto
 > ```powershell
 > py -3 -m venv $env:USERPROFILE\.agent-reach-venv
 > $env:USERPROFILE\.agent-reach-venv\Scripts\Activate.ps1
-> python -m pip install https://github.com/Panniantong/agent-reach/archive/main.zip
+> python -m pip install https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 > agent-reach install --env=auto
 > ```
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -36,13 +36,15 @@ If it says "已是最新版本", skip to Step 4 (verify). Otherwise continue.
 
 ### Step 2: Update Agent Reach package
 
+> ⚠️ Agent Reach is not installed from the PyPI name `agent-reach`. Use the pinned GitHub archive below; that PyPI name currently belongs to an unrelated project.
+
 ```bash
-pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip
+pip install --upgrade https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip
 ```
 
 > If pip complains about `externally-managed-environment` (PEP 668), the user
 > originally installed via pipx or a venv — use the matching command:
-> `pipx install --force https://github.com/Panniantong/agent-reach/archive/main.zip`
+> `pipx install --force https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip`
 > or activate `~/.agent-reach-venv` first.
 
 ### Step 3: Refresh upstream tools

--- a/llms.txt
+++ b/llms.txt
@@ -29,4 +29,4 @@
 ## Optional
 
 - [SKILL.md](https://github.com/Panniantong/Agent-Reach/blob/main/agent_reach/skill/SKILL.md): Integration guide for AI agent frameworks (OpenClaw, Claude Code, etc.)
-- [PyPI Package](https://pypi.org/project/agent-reach/): `pip install agent-reach`
+- [Installation source](https://github.com/Panniantong/Agent-Reach/archive/v1.5.0.zip): install from this pinned GitHub archive; do not run `pip install agent-reach` because the same-name PyPI package is unrelated.

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ source "$TEST_DIR/venv/bin/activate"
 
 # ── 2. 安装 ──
 echo "📥 从 GitHub 安装..."
-pip install -q https://github.com/Panniantong/agent-reach/archive/main.zip 2>&1 | tail -1
+pip install -q https://github.com/Panniantong/agent-reach/archive/v1.5.0.zip 2>&1 | tail -1
 echo ""
 
 # ── 3. 自动配置 ──


### PR DESCRIPTION
## Summary

- Fixes #547.
- Fix ambiguous install guidance for the `agent-reach` PyPI namespace reported in #547.
- Pin project installation and update examples to the `v1.5.0` GitHub archive instead of mutable `main.zip`.
- Add explicit warnings that the same-name PyPI package is unrelated to Agent Reach.
- Keep the warning consistent across the Chinese, English, Korean, and Japanese READMEs, install/update guides, `llms.txt`, generated skills, the CLI update message, the MCP diagnostic, and the integration test helper.

## Why

The repository's current package version is `1.5.0`, and the `v1.5.0` tag is available. Live PyPI metadata observed during the audit returned an unrelated `agent-reach` 0.1.0 project (`github.com/jgalea/agent-reach`). This patch does not claim maliciousness and does not attempt namespace transfer, publishing, or release configuration.

## Verification

- `git diff --check` — passed.
- `python3 -m compileall -q agent_reach` — passed.
- `bash -n test.sh` — passed.
- Dependency-free updater-message assertion — passed.
- Dependency-free MCP diagnostic assertion — passed; expected exit 1 and the actual `mcp[cli]>=1.0` dependency guidance was observed.
- Repository-wide stale-reference assertion — passed: no `archive/main.zip`; remaining bare `pip install agent-reach` text is prohibition/warning text only.
- `python3 -m pytest tests/test_cli.py -q` — 18 passed, 5 blocked before assertions by missing optional environment dependency `loguru`; no packages were installed in this read-only audit.
- `ruff` was not available in the environment.

## Scope and safety

- The contribution is limited to this single branch commit; no release, PyPI, or unrelated upstream changes were performed.
- No runtime routing behavior was changed; the Python changes update user-facing installation/error messages only.
- DCO sign-off is included.

## Review receipt

- Base: `b4d52c46c9113cb0f653d6df4cf71ebadf4930ac`
- Branch: `agent-reach-547-docs-pin`
- Commit: `188d9404ee0b8b928762997fd01ea8ad43cabf74`
- Patch SHA-256: `5f1c6dd3de487fcf65cc3210beab76d762532d8e52d6d774e7c12a254c17f8a5`

## Independent review gate

- **Status:** `PASS`
- Independent review: **PASS** on the current commit; no issues found.
- Provider smoke verification: **PASS**; the inherited-provider child started successfully.
- This PR contains no release, publishing, or PyPI configuration changes.