### PR TITLE
fix: resolve urgent install, credential, and routing gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 <details>
 <summary>它会做什么？（点击展开）</summary>
 
-1. **安装 CLI 工具** — `pip install` 装好 `agent-reach` 命令行（自带 yt-dlp、feedparser）
+1. **安装 CLI 工具** — 从本仓库安装 `agent-reach` 命令行（自带 yt-dlp、feedparser；不要从 PyPI 安装同名包，它不是本项目）
 2. **安装系统基建** — 自动检测并安装 Node.js、gh CLI、mcporter
 3. **配置搜索引擎** — 通过 MCP 接入 Exa（免费，无需 API Key）
 4. **检测环境** — 判断是本地电脑还是服务器，给出对应的配置建议

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1482,17 +1482,13 @@ def _configure_xhs_cookies(value) -> bool:
     docker = shutil.which("docker")
     if not docker:
         # No Docker - write to a local file for manual import.
-        from pathlib import Path
-
         from agent_reach.utils.paths import (
             PrivatePathError,
             atomic_write_private_text,
+            home_dir,
         )
 
-        cookie_path = (
-            Path(os.path.expanduser("~/.agent-reach"))
-            / "xhs-cookies.json"
-        )
+        cookie_path = home_dir() / ".agent-reach" / "xhs-cookies.json"
         try:
             atomic_write_private_text(cookie_path, cookies_json)
         except (OSError, PrivatePathError) as exc:
@@ -1600,6 +1596,8 @@ def _cmd_uninstall(args):
     import shutil
     import subprocess
 
+    from agent_reach.utils.paths import home_dir
+
     dry_run = args.dry_run
     keep_config = args.keep_config
 
@@ -1615,7 +1613,7 @@ def _cmd_uninstall(args):
     mcporter_cleanup_skipped = False
 
     # ── 1. Config directory (~/.agent-reach/) ──
-    config_dir = os.path.expanduser("~/.agent-reach")
+    config_dir = home_dir() / ".agent-reach"
     if not keep_config:
         if os.path.isdir(config_dir):
             if dry_run:
@@ -1637,8 +1635,8 @@ def _cmd_uninstall(args):
     # provenance marker it would be unsafe to delete them automatically, so
     # surface every exact path that may still contain Twitter credentials.
     legacy_credential_paths = (
-        os.path.expanduser("~/.config/xfetch/session.json"),
-        os.path.expanduser("~/.config/bird/credentials.env"),
+        home_dir() / ".config" / "xfetch" / "session.json",
+        home_dir() / ".config" / "bird" / "credentials.env",
     )
     present_legacy_paths = [
         path for path in legacy_credential_paths if os.path.lexists(path)

--- a/agent_reach/config.py
+++ b/agent_reach/config.py
@@ -16,6 +16,7 @@ import yaml
 from agent_reach.utils.paths import (
     PrivatePathError,
     ensure_no_symlink_path,
+    home_dir,
     make_private_dir,
     read_small_text_no_follow,
 )
@@ -98,7 +99,7 @@ def _atomic_write_yaml(target: Path, data: dict) -> None:
 class Config:
     """Manages Agent Reach configuration."""
 
-    CONFIG_DIR = Path.home() / ".agent-reach"
+    CONFIG_DIR = home_dir() / ".agent-reach"
     CONFIG_FILE = CONFIG_DIR / "config.yaml"
 
     # Feature → required config keys

--- a/agent_reach/cookie_extract.py
+++ b/agent_reach/cookie_extract.py
@@ -352,15 +352,15 @@ def _read_xfetch_session(path: Path) -> dict:
 def _sync_xfetch_session(auth_token: str, ct0: str) -> bool:
     """Sync Twitter credentials to ~/.config/xfetch/session.json (legacy xreach compat)."""
     import json
-    import os
 
     try:
         from agent_reach.utils.paths import (
             atomic_write_private_text,
+            home_dir,
             make_private_dir,
         )
 
-        xfetch_dir = os.path.join(os.path.expanduser("~"), ".config", "xfetch")
+        xfetch_dir = home_dir() / ".config" / "xfetch"
         make_private_dir(xfetch_dir)
         session_path = Path(xfetch_dir) / "session.json"
         session_data = _read_xfetch_session(session_path)
@@ -384,18 +384,18 @@ def _sync_bird_env(auth_token: str, ct0: str) -> bool:
     Values are passed through shlex.quote so a token containing a quote, $, or
     backtick cannot break out into shell syntax when the file is sourced.
     """
-    import os
     import shlex
 
     try:
         from agent_reach.utils.paths import (
             atomic_write_private_text,
+            home_dir,
             make_private_dir,
         )
 
-        bird_dir = os.path.join(os.path.expanduser("~"), ".config", "bird")
+        bird_dir = home_dir() / ".config" / "bird"
         make_private_dir(bird_dir)
-        env_path = os.path.join(bird_dir, "credentials.env")
+        env_path = bird_dir / "credentials.env"
         atomic_write_private_text(
             env_path,
             f"AUTH_TOKEN={shlex.quote(auth_token)}\n"

--- a/agent_reach/integrations/mcp_server.py
+++ b/agent_reach/integrations/mcp_server.py
@@ -28,7 +28,12 @@ except ImportError:
 
 def create_server():
     if not HAS_MCP:
-        print("MCP not installed. Install: pip install agent-reach[mcp]", file=sys.stderr)
+        print(
+            "MCP not installed. Install: python -m pip install "
+            "'agent-reach[mcp] @ "
+            "https://github.com/Panniantong/agent-reach/archive/main.zip'",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     server = Server("agent-reach")

--- a/agent_reach/scripts/transcribe_xiaoyuzhou.sh
+++ b/agent_reach/scripts/transcribe_xiaoyuzhou.sh
@@ -27,11 +27,35 @@ URL="${1:?用法: bash transcribe.sh [--polish] <小宇宙链接> [输出文件�
 OUTPUT="${2:-/tmp/podcast_transcript.txt}"
 TMPDIR="/tmp/xiaoyuzhou_$$"
 
+PYTHON_CMD=()
+ensure_python() {
+    if [ "${#PYTHON_CMD[@]}" -gt 0 ]; then
+        return 0
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        PYTHON_CMD=(python3)
+    elif command -v python >/dev/null 2>&1; then
+        PYTHON_CMD=(python)
+    elif command -v py >/dev/null 2>&1; then
+        PYTHON_CMD=(py -3)
+    else
+        echo "❌ 未找到 Python（尝试过 python3、python、py -3）" >&2
+        return 1
+    fi
+}
+
 # Try env var first, then agent-reach config.yaml
 if [ -z "$GROQ_API_KEY" ]; then
     CONFIG_FILE="$HOME/.agent-reach/config.yaml"
     if [ -f "$CONFIG_FILE" ]; then
-        GROQ_API_KEY=$(python3 -c "import yaml; print((yaml.safe_load(open('$CONFIG_FILE')) or {}).get('groq_api_key',''))" 2>/dev/null || true)
+        ensure_python || exit 1
+        CONFIG_FOR_PYTHON="$CONFIG_FILE"
+        if command -v cygpath >/dev/null 2>&1; then
+            CONFIG_FOR_PYTHON=$(cygpath -w "$CONFIG_FILE")
+        fi
+        GROQ_API_KEY=$(AGENT_REACH_CONFIG_FILE="$CONFIG_FOR_PYTHON" \
+            "${PYTHON_CMD[@]}" -c 'import os, yaml; print((yaml.safe_load(open(os.environ["AGENT_REACH_CONFIG_FILE"])) or {}).get("groq_api_key", ""))' \
+            2>/dev/null || true)
     fi
 fi
 GROQ_API_KEY="${GROQ_API_KEY:?请设置 GROQ_API_KEY 环境变量或运行 agent-reach configure groq-key}"
@@ -81,7 +105,8 @@ echo "⏱️  时长: ${DURATION_MIN}分${DURATION_SEC}秒"
 echo "🔄 正在转码..."
 ffmpeg -y -i "$TMPDIR/original.$EXT" -b:a "$AUDIO_BITRATE" -ac 1 "$TMPDIR/mono.mp3" 2>/dev/null
 MONO_SIZE=$(stat -c%s "$TMPDIR/mono.mp3" 2>/dev/null || stat -f%z "$TMPDIR/mono.mp3")
-echo "📦 转码后: $(echo "$MONO_SIZE / 1024 / 1024" | bc)MB"
+MONO_SIZE_MB=$(awk -v bytes="$MONO_SIZE" 'BEGIN { printf "%.1f", bytes / 1024 / 1024 }')
+echo "📦 转码后: ${MONO_SIZE_MB}MB"
 
 # Step 5: 按大小切片
 MAX_BYTES=$((MAX_CHUNK_SIZE_MB * 1024 * 1024))
@@ -151,6 +176,11 @@ for i in $(seq 0 $((NUM_CHUNKS - 1))); do
                 exit 1
             fi
         else
+            case "$HTTP_CODE" in
+                5??)
+                    echo "   可尝试兜底：agent-reach transcribe \"$AUDIO_URL\""
+                    ;;
+            esac
             exit 1
         fi
     fi
@@ -162,13 +192,14 @@ done
 
 # Step 6.5 (可选): 用 Llama 3.3 70B 给文稿补标点+分段
 if [ "$POLISH" = "1" ]; then
+    ensure_python || exit 1
     echo "✨ 正在润色（Llama 3.3 70B 加标点+分段）..."
     for i in $(seq 0 $((NUM_CHUNKS - 1))); do
         echo -n "   段 $((i+1))/$NUM_CHUNKS... "
         IN_FILE="$TMPDIR/transcript_${i}.txt" \
         OUT_FILE="$TMPDIR/polished_${i}.txt" \
         GROQ_API_KEY="$GROQ_API_KEY" \
-        python3 <<'PY'
+        "${PYTHON_CMD[@]}" <<'PY'
 import json, os, sys, urllib.request, urllib.error
 
 KEY = os.environ["GROQ_API_KEY"]

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -18,7 +18,7 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
 triggers:
   - research: 调研/全网调研/帮我调研/研究一下/research/深入了解
   - search: 搜/查/找/search/搜索/查一下/帮我搜/看看大家怎么说
@@ -47,7 +47,9 @@ metadata:
 ## 常驻规则（全程适用）
 
 1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram）先跑
-   `agent-reach doctor --json`，按各平台 `active_backend` 字段选命令组。
+   `agent-reach doctor --json`。`active_backend` 有值时按它选命令组；`active_backend: null`
+   表示 Doctor 为避免触发浏览器 Cookie 读取或远端写入而没有做实时验证，不代表后端不存在。
+   只有用户任务明确需要该平台时，才按对应 reference 的只读命令手动验证。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
 4. **全网调研类任务**：组合多平台（Exa 搜索 + Twitter/Reddit 看讨论 + 小红书/B站看中文场景），并行收集再汇总。
@@ -67,6 +69,7 @@ metadata:
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
 | YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
+| 雪球/股票行情 | finance | [references/finance.md](references/finance.md) |
 
 ## 零配置快速命令
 
@@ -80,8 +83,8 @@ curl -s "https://r.jina.ai/URL"
 # GitHub 搜索
 gh search repos "query" --sort stars --limit 10
 
-# YouTube 字幕（注意：B站不要用 yt-dlp，见 video.md）
-yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
+# YouTube 字幕（注意：B站不要用 yt-dlp，失败重试链见 video.md）
+yt-dlp --write-sub --write-auto-sub --skip-download -o "/tmp/%(id)s" "URL"
 
 # V2EX 热门
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
@@ -126,6 +129,12 @@ opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
 agent-reach doctor --json
 ```
 
+## OpenCLI 适配器发现
+
+路由表没有覆盖用户需要的平台或命令时，先用 `opencli list` 查已有适配器，再用
+`opencli <平台> --help` 查看公开命令。发现适配器只证明命令存在，不证明登录态或
+目标内容可用；仅在用户任务明确需要该平台时执行只读命令，并以实际非空内容验收。
+
 ## 工作区规则
 
 **不要在 agent workspace 创建文件。** 使用 `/tmp/` 存放临时输出，`~/.agent-reach/` 存放持久数据。
@@ -140,6 +149,7 @@ agent-reach doctor --json
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS
 - [视频播客](references/video.md) — YouTube, B站, 小宇宙
+- [金融行情](references/finance.md) — 雪球股票行情、搜索、热门内容
 
 ## 配置渠道
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -29,8 +29,10 @@ these platforms — do not invent your own approach.**
 ## Standing rules (apply for the whole session)
 
 1. **Health-check before acting**: for multi-backend/login-backed platforms (XiaoHongShu /
-   Reddit / Bilibili / Twitter / Facebook / Instagram), run `agent-reach doctor --json` first and
-   pick the command group matching each platform's `active_backend`.
+   Reddit / Bilibili / Twitter / Facebook / Instagram), run `agent-reach doctor --json` first.
+   Use a populated `active_backend`; `active_backend: null` means Doctor deliberately skipped a
+   live probe to avoid browser-cookie reads or remote writes, not that no backend exists. Only when
+   the user's task requires that platform, run the reference's read-only command to verify it.
 2. **Announce what you use**: say "using agent-reach, platform X via backend Y"
    before starting.
 3. **On failure, follow the retry chains in references/** — never guess
@@ -55,6 +57,7 @@ these platforms — do not invent your own approach.**
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
 | YouTube / Bilibili / podcast transcripts | video | [references/video.md](references/video.md) |
+| Xueqiu / stock quotes | finance | [references/finance.md](references/finance.md) |
 
 ## Zero-config quick commands
 
@@ -68,8 +71,8 @@ curl -s "https://r.jina.ai/URL"
 # GitHub search
 gh search repos "query" --sort stars --limit 10
 
-# YouTube subtitles (NOTE: never use yt-dlp for Bilibili — see video.md)
-yt-dlp --write-sub --skip-download -o "/tmp/%(id)s" "URL"
+# YouTube subtitles (never use yt-dlp for Bilibili; retry chain in video.md)
+yt-dlp --write-sub --write-auto-sub --skip-download -o "/tmp/%(id)s" "URL"
 
 # V2EX hot topics
 curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
@@ -116,6 +119,13 @@ opencli instagram user USERNAME -f yaml        # recent posts from one user
 agent-reach doctor --json
 ```
 
+## Discovering OpenCLI adapters
+
+When the routing table lacks a needed platform or command, run `opencli list`,
+then inspect `opencli <platform> --help`. Discovery proves only that an adapter
+exists, not that authentication or target content works. Run read-only commands
+only when the user's task requires that platform, and require non-empty content.
+
 ## Workspace rules
 
 **Never create files in the agent workspace.** Use `/tmp/` for temporary
@@ -133,6 +143,7 @@ chains — note: reference docs are written in Chinese, commands are universal):
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS
 - [Video](references/video.md) — YouTube, Bilibili, Xiaoyuzhou
+- [Finance](references/finance.md) — Xueqiu quotes, search and market content
 
 ## Configure a channel
 

--- a/agent_reach/skill/references/finance.md
+++ b/agent_reach/skill/references/finance.md
@@ -1,0 +1,46 @@
+# 金融行情
+
+雪球股票行情、搜索与热门内容。行情可能延迟，不构成投资建议。
+
+## 先检查状态
+
+```bash
+agent-reach doctor --json
+```
+
+`xueqiu.active_backend` 有值时按该后端使用；值为 `null` 只表示 Doctor 没有完成
+实时内容验证。雪球需要已登录会话或最小 Cookie，不能把 HTTP 400 当成股票不存在。
+
+## OpenCLI（桌面已有 Chrome 登录态时优先）
+
+```bash
+# 验证当前登录态
+opencli xueqiu whoami -f yaml
+
+# 股票搜索与实时行情
+opencli xueqiu search "英伟达" -f yaml
+opencli xueqiu stock NVDA -f yaml
+
+# 热门内容与热门股票
+opencli xueqiu hot -f yaml
+opencli xueqiu hot-stock -f yaml
+
+# 查看全部只读命令
+opencli xueqiu --help
+```
+
+OpenCLI 只复用用户已经存在且明确控制的浏览器会话。不要自动执行
+`opencli xueqiu login`；没有现成登录态时，让用户先在 Chrome 登录，或显式导入
+雪球所需的最小 Cookie：
+
+```bash
+agent-reach configure --from-browser chrome --platform xueqiu
+```
+
+该配置只读取并保存 `xq_a_token`，不会顺带采集其他平台 Cookie。
+
+## 验收与失败处理
+
+- 以返回股票名称、代码、价格或非空内容列表为成功；退出码 0 但字段为空不算成功。
+- HTTP 400 通常是会话/Cookie 问题，不表示股票代码不存在。
+- `whoami` 成功而 `stock`/`hot` 失败时，按适配器解析或平台接口问题报告，不要误诊成未登录。

--- a/agent_reach/skill/references/video.md
+++ b/agent_reach/skill/references/video.md
@@ -39,6 +39,20 @@ yt-dlp --dump-json "ytsearch5:query"
 > **字幕注意**: 手动上传的字幕提取可靠；自动生成字幕可能存在行间重复，需后处理。
 > **评论注意**: `--write-comments` 基于网页抓取（非 YouTube Data API），部分评论可能丢失。
 
+### 字幕失败时的重试链（按序执行，拿到实质内容即停）
+
+`doctor` 只确认 yt-dlp 本体与 JS runtime 能执行，不会请求具体视频；因此
+`active_backend: yt-dlp` 不等于目标视频的字幕已经通过实时验证。
+
+1. 先用上面的 `yt-dlp --write-sub --write-auto-sub` 命令。
+2. 若出现 bot 校验、字幕响应为空或没有生成字幕文件，且 OpenCLI 已连接：
+   `opencli youtube transcript "URL" -f yaml`。
+3. OpenCLI 若返回 `Caption URL returned empty response`，最多重试 3 次；这是带
+   过期时间的字幕 URL 偶发失效，不能把空响应当成“视频没有字幕”。
+4. 仍失败或视频本来就没有字幕：`agent-reach transcribe "URL"` 下载音频转写。
+
+成功标准是实际得到非空字幕/转录内容，不是命令退出码或 `doctor` 的版本探测结果。
+
 ### 无字幕兜底：Whisper 音频转写
 
 ```bash
@@ -124,7 +138,7 @@ agent-reach doctor
 
 | 场景 | 推荐工具 |
 |-----|---------|
-| YouTube 字幕 | yt-dlp |
+| YouTube 字幕 | yt-dlp；失败时 OpenCLI（最多 3 次）→ agent-reach transcribe |
 | B站视频详情/搜索 | bili-cli |
 | B站字幕 | opencli bilibili subtitle |
 | 播客转录 | 小宇宙 transcribe.sh |

--- a/agent_reach/utils/paths.py
+++ b/agent_reach/utils/paths.py
@@ -14,6 +14,23 @@ class PrivatePathError(RuntimeError):
     """Raised when a private write could be redirected through a symlink."""
 
 
+def home_dir() -> Path:
+    """Return the explicit HOME first, including on Windows.
+
+    Windows' ``expanduser("~")`` ignores HOME and resolves USERPROFILE.  Agent
+    Reach uses HOME as an isolation boundary in tests, containers and managed
+    agent environments, so credential paths must honor it consistently.
+    """
+    explicit_home = os.environ.get("HOME")
+    if explicit_home:
+        return Path(os.path.abspath(explicit_home))
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return Path(expanded)
+    return Path.home()
+
+
 def ensure_no_symlink_path(path: str | Path, label: str = "路径") -> Path:
     """Reject any existing symlink component without resolving the path."""
     target = Path(path)

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -272,7 +272,7 @@ Agent Reach は [rdt-cli](https://github.com/public-clis/rdt-cli) でRedditに�
 <details>
 <summary><strong>Agent Reach は Claude Code / Cursor / Windsurf / OpenClaw で動作する？</strong></summary>
 
-はい！Agent Reach はインストーラー + 設定ツールです。シェルコマンドを実行できるあらゆるAIコーディングエージェントで使用できます — Claude Code、Cursor、Windsurf、OpenClaw、Codex等。`pip install agent-reach` を実行し、`agent-reach install` を実行するだけで、エージェントはすぐに上流ツールを使い始められます。
+はい！Agent Reach はインストーラー + 設定ツールです。シェルコマンドを実行できるあらゆるAIコーディングエージェントで使用できます — Claude Code、Cursor、Windsurf、OpenClaw、Codex等。`pip install https://github.com/Panniantong/agent-reach/archive/main.zip` の後に `agent-reach install` を実行すると、エージェントはすぐに上流ツールを使い始められます。PyPI の同名パッケージは別プロジェクトです。
 </details>
 
 <details>

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -273,7 +273,7 @@ Agent Reach는 Reddit을 위해 [rdt-cli](https://github.com/public-clis/rdt-cli
 <details>
 <summary><strong>Agent Reach는 Claude Code / Cursor / Windsurf / OpenClaw와 호환되나요?</strong></summary>
 
-네! Agent Reach는 설치 + 설정 도구입니다. Shell 명령을 실행할 수 있는 모든 AI 코딩 에이전트가 사용할 수 있습니다 — Claude Code, Cursor, Windsurf, OpenClaw, Codex 등. `pip install agent-reach`만 실행하고 `agent-reach install`을 실행하면, 에이전트가 즉시 업스트림 도구 사용을 시작할 수 있습니다.
+네! Agent Reach는 설치 + 설정 도구입니다. Shell 명령을 실행할 수 있는 모든 AI 코딩 에이전트가 사용할 수 있습니다 — Claude Code, Cursor, Windsurf, OpenClaw, Codex 등. `pip install https://github.com/Panniantong/agent-reach/archive/main.zip` 실행 후 `agent-reach install`을 실행하면, 에이전트가 즉시 업스트림 도구 사용을 시작할 수 있습니다. PyPI의 동명 패키지는 다른 프로젝트입니다.
 </details>
 
 <details>

--- a/tests/test_auth_guidance_policy.py
+++ b/tests/test_auth_guidance_policy.py
@@ -164,3 +164,42 @@ def test_public_guidance_never_installs_the_unrelated_pypi_package():
                 )
 
     assert not violations, "\n".join(violations)
+
+
+def test_skill_explains_unverified_backend_state():
+    """A null backend is an explicit safety state, not a routing instruction."""
+    skills = (
+        ROOT / "agent_reach" / "skill" / "SKILL.md",
+        ROOT / "agent_reach" / "skill" / "SKILL_en.md",
+    )
+    for path in skills:
+        text = path.read_text(encoding="utf-8")
+        assert "active_backend: null" in text, path.relative_to(ROOT)
+        assert "Doctor" in text, path.relative_to(ROOT)
+
+
+def test_video_reference_has_content_level_youtube_fallbacks():
+    """Version-only health must not be presented as proof subtitles work."""
+    text = (
+        ROOT / "agent_reach" / "skill" / "references" / "video.md"
+    ).read_text(encoding="utf-8")
+    assert "opencli youtube transcript" in text
+    assert "最多重试 3 次" in text
+    assert "agent-reach transcribe" in text
+
+
+def test_skill_routes_finance_and_documents_opencli_discovery():
+    skills = (
+        ROOT / "agent_reach" / "skill" / "SKILL.md",
+        ROOT / "agent_reach" / "skill" / "SKILL_en.md",
+    )
+    for path in skills:
+        text = path.read_text(encoding="utf-8")
+        assert "references/finance.md" in text, path.relative_to(ROOT)
+        assert "opencli list" in text, path.relative_to(ROOT)
+        assert "--help" in text, path.relative_to(ROOT)
+
+    finance = ROOT / "agent_reach" / "skill" / "references" / "finance.md"
+    text = finance.read_text(encoding="utf-8")
+    assert "opencli xueqiu stock" in text
+    assert "agent-reach configure --from-browser chrome --platform xueqiu" in text

--- a/tests/test_auth_guidance_policy.py
+++ b/tests/test_auth_guidance_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -139,3 +140,27 @@ def test_localized_readmes_keep_current_bilibili_and_xhs_routes():
             "xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli"
             in text
         ), path.relative_to(ROOT)
+
+
+def test_public_guidance_never_installs_the_unrelated_pypi_package():
+    """The PyPI name is owned by another project; GitHub URLs are required."""
+    candidates = _policy_documents() + [
+        ROOT / "agent_reach" / "integrations" / "mcp_server.py",
+    ]
+    bare_install = re.compile(
+        r"\bpip\s+install(?:\s+--upgrade)?\s+['\"]?agent-reach(?:\[[^\]]+\])?\b",
+        re.IGNORECASE,
+    )
+    violations = []
+    for path in candidates:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if bare_install.search(line) and (
+                "github.com/Panniantong/agent-reach" not in line
+            ):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}"
+                )
+
+    assert not violations, "\n".join(violations)

--- a/tests/test_private_file_writes.py
+++ b/tests/test_private_file_writes.py
@@ -92,6 +92,62 @@ def test_legacy_xfetch_sync_refuses_ancestor_symlink(tmp_path, monkeypatch):
     assert config_dir.is_symlink()
 
 
+def test_credential_writes_honor_home_when_expanduser_disagrees(
+    tmp_path, monkeypatch
+):
+    """Windows expanduser ignores HOME; private writes must not escape it."""
+    intended_home = tmp_path / "isolated-home"
+    windows_profile = tmp_path / "windows-profile"
+    intended_home.mkdir()
+    windows_profile.mkdir()
+    monkeypatch.setenv("HOME", str(intended_home))
+
+    real_expanduser = os.path.expanduser
+
+    def windows_expanduser(value):
+        if value == "~":
+            return str(windows_profile)
+        if value.startswith("~/"):
+            return str(windows_profile / value[2:])
+        return real_expanduser(value)
+
+    monkeypatch.setattr(os.path, "expanduser", windows_expanduser)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    assert _sync_xfetch_session("auth", "ct0") is True
+    assert _sync_bird_env("auth", "ct0") is True
+    assert cli._configure_xhs_cookies("web_session=xhs-secret") is True
+
+    assert (intended_home / ".config" / "xfetch" / "session.json").exists()
+    assert (intended_home / ".config" / "bird" / "credentials.env").exists()
+    assert (intended_home / ".agent-reach" / "xhs-cookies.json").exists()
+    assert list(windows_profile.rglob("*")) == []
+
+
+def test_expanduser_fallback_still_refuses_symlinked_profile(
+    tmp_path, monkeypatch
+):
+    """Without HOME, the USERPROFILE fallback remains guarded end to end."""
+    victim_dir = tmp_path / "victim-profile"
+    victim_dir.mkdir()
+    profile_link = tmp_path / "profile-link"
+    try:
+        profile_link.symlink_to(victim_dir, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
+
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda value: str(profile_link) if value == "~" else value,
+    )
+
+    assert _sync_xfetch_session("auth", "ct0") is False
+    assert _sync_bird_env("auth", "ct0") is False
+    assert list(victim_dir.rglob("*")) == []
+
+
 def test_legacy_xfetch_sync_refuses_oversized_existing_session(
     tmp_path, monkeypatch
 ):

--- a/tests/test_xiaoyuzhou_install.py
+++ b/tests/test_xiaoyuzhou_install.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import agent_reach.cli as cli
+
+ROOT = Path(__file__).resolve().parents[1]
+TRANSCRIBE_SCRIPT = ROOT / "agent_reach" / "scripts" / "transcribe_xiaoyuzhou.sh"
 
 
 class _DummyConfig:
@@ -19,3 +24,16 @@ def test_install_xiaoyuzhou_deps_does_not_raise_when_no_groq_key(capsys):
     out = capsys.readouterr().out
     assert "Xiaoyuzhou" in out
     assert "Groq API key not set" in out
+
+
+def test_transcribe_script_is_cross_platform_shell_syntax():
+    subprocess.run(["bash", "-n", str(TRANSCRIBE_SCRIPT)], check=True)
+
+
+def test_transcribe_script_handles_git_bash_python_and_size_math():
+    text = TRANSCRIBE_SCRIPT.read_text(encoding="utf-8")
+    assert "command -v python3" in text
+    assert "command -v python" in text
+    assert "command -v py" in text
+    assert "cygpath -w" in text
+    assert "| bc" not in text


### PR DESCRIPTION
## Summary

- prevent users from installing the unrelated PyPI package that now owns `agent-reach`
- make credential paths honor explicit `HOME` on Windows while preserving symlink refusal
- clarify that `active_backend: null` is an intentional unverified state
- add content-level YouTube fallback guidance and an OpenCLI-backed Xueqiu reference
- make the Xiaoyuzhou transcription script work in Windows Git Bash without assuming `python3` or `bc`

## Diagnosis

### #547

Live PyPI readback confirms `agent-reach==0.1.0` is a different project. Japanese/Korean docs and the MCP error path still recommended the bare name; the main README also left an ambiguous completion. Public guidance now uses the GitHub archive and a regression test forbids unsafe bare-install instructions.

### #574

The reported symlink bypass did not reproduce: the existing private-write guard rejects a symlinked target, parent, ancestor, or fallback profile. A related Windows isolation bug did reproduce: `expanduser("~")` ignores `HOME` and could send credential writes to `USERPROFILE`. Credential/config paths now use a single HOME-first resolver, with tests for both isolation and symlink refusal.

### #566

Live verification on the same public video produced:

- yt-dlp: non-empty 14.46 KiB subtitle file
- OpenCLI: `Caption URL returned empty response`

So yt-dlp remains the first route; OpenCLI is documented as a bounded retry fallback, followed by audio transcription. Doctor remains zero-write and does not probe credential-backed platforms; the skill now explains the intentional null state. The verified Windows Git Bash failures in the Xiaoyuzhou script are fixed.

Closes #547
Closes #574
Addresses #566

## Verification

- `.venv/bin/pytest tests/ -v` — 436 passed
- shell syntax check for `transcribe_xiaoyuzhou.sh`
- live yt-dlp/OpenCLI subtitle comparison
- live `opencli xueqiu stock NVDA -f yaml` returned structured quote data
