### PR TITLE
feat(rss): discover feeds from site root URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## Unreleased
+
+### ✨ Features / 新功能
+
+- **RSS discovery:** `RSSChannel.discover_feeds(root_url)` finds RSS/Atom/JSON feeds from HTML `rel=alternate` links and common paths, validates with feedparser, and dedupes (#322).
+
+---
+
 ## [1.3.1] - 2026-03-27
 
 ### 🐛 Bug Fixes / 修复

--- a/agent_reach/channels/rss.py
+++ b/agent_reach/channels/rss.py
@@ -1,7 +1,223 @@
 # -*- coding: utf-8 -*-
-"""RSS — check if feedparser is available."""
+"""RSS — feedparser availability check + root-URL feed discovery."""
+
+from __future__ import annotations
+
+import logging
+import urllib.error
+import urllib.request
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from agent_reach.utils.text import scrub_url_credentials
+from agent_reach.utils.url import normalize_public_http_url
 
 from .base import Channel
+
+_UA = "agent-reach/1.0"
+_TIMEOUT = 10
+_MAX_RESPONSE_BYTES = 1024 * 1024
+_LOG = logging.getLogger(__name__)
+
+# Common self-hosted / CMS feed paths (issue #322). Kept short so discovery
+# stays bounded for agents that pass an arbitrary site root.
+_COMMON_FEED_PATHS = (
+    "/feed",
+    "/rss",
+    "/atom.xml",
+    "/feed.xml",
+    "/rss.xml",
+    "/index.xml",
+    "/atom",
+    "/.well-known/feed",
+)
+
+_FEED_LINK_TYPES = {
+    "application/rss+xml",
+    "application/atom+xml",
+    "application/feed+json",
+    "application/json",
+    "text/xml",
+    "application/xml",
+}
+
+
+class _AlternateFeedLinkParser(HTMLParser):
+    """Collect ``<link rel=\"alternate\" type=… href=…>`` feed candidates."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.links: list[tuple[str, str, str]] = []  # href, type, title
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "link":
+            return
+        mapping = {k.lower(): (v or "") for k, v in attrs if k}
+        rel = mapping.get("rel", "").lower()
+        if "alternate" not in rel.split():
+            return
+        href = mapping.get("href", "").strip()
+        if not href:
+            return
+        typ = mapping.get("type", "").split(";", 1)[0].strip().lower()
+        title = mapping.get("title", "").strip()
+        # Prefer typed feed links; still keep untyped alternate that looks like a feed path.
+        if typ and typ not in _FEED_LINK_TYPES and "rss" not in typ and "atom" not in typ and "json" not in typ:
+            return
+        if not typ:
+            low = href.lower()
+            if not any(x in low for x in ("/feed", "/rss", "atom", ".xml", "json")):
+                return
+        self.links.append((href, typ, title))
+
+
+def _origin(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+
+
+def _canonical_feed_key(url: str) -> str:
+    parts = urlsplit(url)
+    path = parts.path or "/"
+    if path != "/" and path.endswith("/"):
+        path = path.rstrip("/")
+    return urlunsplit((parts.scheme.lower(), (parts.netloc or "").lower(), path, "", ""))
+
+
+def _fetch_text(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": _UA, "Accept": "text/html,*/*"})
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+        charset = resp.headers.get_content_charset() or "utf-8"
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise ValueError("response exceeds the 1 MiB safety limit")
+    return raw.decode(charset, errors="replace")
+
+
+def _looks_like_feed(parsed: Any) -> bool:
+    version = getattr(parsed, "version", None) or ""
+    entries = list(getattr(parsed, "entries", None) or [])
+    feed = getattr(parsed, "feed", None)
+    has_feed_meta = False
+    if feed is not None:
+        title = getattr(feed, "title", None) or (feed.get("title") if isinstance(feed, dict) else None)
+        link = getattr(feed, "link", None) or (feed.get("link") if isinstance(feed, dict) else None)
+        has_feed_meta = bool(title or link)
+    return bool(version) or bool(entries) or has_feed_meta
+
+
+def _validate_feed(url: str) -> dict[str, str] | None:
+    """Return a feed record if ``url`` parses as RSS/Atom/JSON Feed, else None."""
+    import feedparser
+
+    try:
+        parsed = feedparser.parse(url)
+    except Exception as exc:  # noqa: BLE001
+        _LOG.warning("feed parse raised for %s: %s", scrub_url_credentials(url), scrub_url_credentials(exc))
+        return None
+    if not _looks_like_feed(parsed):
+        bozo = getattr(parsed, "bozo_exception", None)
+        detail = scrub_url_credentials(bozo) if bozo else "not a feed"
+        _LOG.info("rejecting candidate %s (%s)", scrub_url_credentials(url), detail)
+        return None
+    feed = getattr(parsed, "feed", None)
+    title = ""
+    if feed is not None:
+        title = str(
+            getattr(feed, "title", None)
+            or (feed.get("title") if isinstance(feed, dict) else "")
+            or ""
+        )
+    version = str(getattr(parsed, "version", None) or "")
+    feed_type = "rss"
+    low = version.lower()
+    if "atom" in low:
+        feed_type = "atom"
+    elif "json" in low:
+        feed_type = "json"
+    return {
+        "url": url,
+        "title": title,
+        "type": feed_type,
+        "version": version,
+    }
+
+
+def discover_feeds(root_url: str) -> list[dict[str, str]]:
+    """Discover RSS/Atom/JSON feeds reachable from a site root URL.
+
+    Strategy (issue #322 MVP):
+    1. Normalize ``root_url`` with the public-HTTP gate.
+    2. Parse ``<link rel="alternate" …>`` tags from the homepage HTML.
+    3. Probe a small set of common feed paths under the same origin.
+    4. Validate each candidate with feedparser; drop failures (logged).
+    5. Deduplicate by canonical URL.
+
+    Out of scope for this MVP: robots.txt, external registries, and
+    scheduled re-scans (callers can re-invoke on their own schedule).
+    """
+    root = normalize_public_http_url(root_url)
+    origin = _origin(root)
+    candidates: list[tuple[str, str]] = []  # url, source
+    seen_keys: set[str] = set()
+
+    def _add_candidate(raw_href: str, source: str) -> None:
+        abs_url = urljoin(root if root.endswith("/") else root + "/", raw_href)
+        try:
+            normalized = normalize_public_http_url(abs_url)
+        except ValueError as exc:
+            _LOG.info(
+                "skipping unsafe candidate from %s (%s): %s",
+                source,
+                scrub_url_credentials(raw_href),
+                scrub_url_credentials(exc),
+            )
+            return
+        # Stay on the same host — discovery is for one site root, not open redirects.
+        if urlsplit(normalized).netloc.lower() != urlsplit(origin).netloc.lower():
+            _LOG.info(
+                "skipping off-host candidate %s (from %s)",
+                scrub_url_credentials(normalized),
+                source,
+            )
+            return
+        key = _canonical_feed_key(normalized)
+        if key in seen_keys:
+            return
+        seen_keys.add(key)
+        candidates.append((normalized, source))
+
+    try:
+        html = _fetch_text(root)
+        parser = _AlternateFeedLinkParser()
+        parser.feed(html)
+        for href, typ, _title in parser.links:
+            _add_candidate(href, f"html-link:{typ or 'untyped'}")
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        _LOG.warning(
+            "homepage fetch failed for %s: %s",
+            scrub_url_credentials(root),
+            scrub_url_credentials(exc),
+        )
+
+    for path in _COMMON_FEED_PATHS:
+        _add_candidate(urljoin(origin + "/", path.lstrip("/")), f"common-path:{path}")
+
+    results: list[dict[str, str]] = []
+    result_keys: set[str] = set()
+    for url, source in candidates:
+        record = _validate_feed(url)
+        if record is None:
+            _LOG.info("discovery miss (%s): %s", source, scrub_url_credentials(url))
+            continue
+        key = _canonical_feed_key(record["url"])
+        if key in result_keys:
+            continue
+        result_keys.add(key)
+        record["source"] = source
+        results.append(record)
+    return results
 
 
 class RSSChannel(Channel):
@@ -25,3 +241,7 @@ class RSSChannel(Channel):
             return "error", f"feedparser 导入失败：{e}\n修复：pip install --force-reinstall feedparser"
         self.active_backend = self.backends[0]
         return "ok", "可读取 RSS/Atom 源"
+
+    def discover_feeds(self, root_url: str) -> list[dict[str, str]]:
+        """See module-level :func:`discover_feeds`."""
+        return discover_feeds(root_url)

--- a/agent_reach/skill/references/web.md
+++ b/agent_reach/skill/references/web.md
@@ -41,6 +41,17 @@ for e in feedparser.parse('FEED_URL').entries[:5]:
 
 **适用场景**: 订阅博客、新闻源、播客等 RSS feed。
 
+### 从站点根 URL 发现 feed
+
+```python
+from agent_reach.channels.rss import RSSChannel
+
+for feed in RSSChannel().discover_feeds("https://example.com"):
+    print(feed["url"], feed.get("title"), feed.get("type"))
+```
+
+会解析首页的 `<link rel="alternate">`，再探测常见路径（`/feed`、`/rss`、`/atom.xml` 等），用 feedparser 校验后去重返回。不覆盖 robots.txt / 外部 registry / 定时重扫——由调用方按需调度。
+
 ## 选择指南
 
 | 场景 | 推荐工具 |
@@ -48,3 +59,4 @@ for e in feedparser.parse('FEED_URL').entries[:5]:
 | 通用网页 | Jina Reader (`curl r.jina.ai`) |
 | 需要图片/格式控制 | web-reader MCP |
 | RSS 订阅 | feedparser |
+| 从站点根发现 feed | `RSSChannel.discover_feeds` |

--- a/tests/test_rss_discover.py
+++ b/tests/test_rss_discover.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Tests for RSS root-URL feed discovery (#322)."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent_reach.channels import rss as rss_mod
+from agent_reach.channels.rss import RSSChannel, discover_feeds
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes, *, charset: str = "utf-8"):
+        self._body = body
+        self.headers = SimpleNamespace(get_content_charset=lambda: charset)
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            return self._body
+        return self._body[:n]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _install_fake_feedparser(monkeypatch, *, valid_urls: set[str] | None = None):
+    valid = valid_urls or set()
+    mod = types.ModuleType("feedparser")
+
+    def parse(url: str):
+        if url in valid:
+            return SimpleNamespace(
+                version="rss20",
+                entries=[SimpleNamespace(title="t", link=url)],
+                feed=SimpleNamespace(title="Example Feed", link=url),
+                bozo_exception=None,
+            )
+        return SimpleNamespace(
+            version="",
+            entries=[],
+            feed=SimpleNamespace(title="", link=""),
+            bozo_exception=RuntimeError("not a feed"),
+        )
+
+    mod.parse = parse
+    monkeypatch.setitem(sys.modules, "feedparser", mod)
+    return mod
+
+
+def test_discover_from_html_alternate_links(monkeypatch):
+    html = b"""<!doctype html><html><head>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="alternate" type="application/rss+xml" title="Blog" href="/blog/rss.xml">
+    <link rel="alternate" type="application/atom+xml" href="https://example.com/atom.xml">
+    </head><body>hi</body></html>"""
+    valid = {
+        "https://example.com/blog/rss.xml",
+        "https://example.com/atom.xml",
+    }
+    _install_fake_feedparser(monkeypatch, valid_urls=valid)
+
+    def fake_urlopen(req, timeout=0):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if url.rstrip("/") == "https://example.com":
+            return _FakeHTTPResponse(html)
+        raise AssertionError(f"unexpected fetch {url}")
+
+    with patch.object(rss_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+        found = discover_feeds("https://example.com")
+
+    urls = {f["url"] for f in found}
+    assert "https://example.com/blog/rss.xml" in urls
+    assert "https://example.com/atom.xml" in urls
+    assert all("source" in f for f in found)
+
+
+def test_discover_common_paths_and_dedupe(monkeypatch):
+    html = b"""<!doctype html><html><head>
+    <link rel="alternate" type="application/rss+xml" href="/feed">
+    </head></html>"""
+    valid = {"https://news.example.org/feed"}
+    _install_fake_feedparser(monkeypatch, valid_urls=valid)
+
+    def fake_urlopen(req, timeout=0):  # noqa: ARG001
+        return _FakeHTTPResponse(html)
+
+    with patch.object(rss_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+        found = discover_feeds("https://news.example.org/")
+
+    assert len(found) == 1
+    assert found[0]["url"] == "https://news.example.org/feed"
+    assert found[0]["type"] == "rss"
+
+
+def test_discover_rejects_private_and_off_host(monkeypatch):
+    html = b"""<!doctype html><html><head>
+    <link rel="alternate" type="application/rss+xml" href="http://127.0.0.1/feed">
+    <link rel="alternate" type="application/rss+xml" href="https://evil.example/feed">
+    </head></html>"""
+    _install_fake_feedparser(monkeypatch, valid_urls=set())
+
+    def fake_urlopen(req, timeout=0):  # noqa: ARG001
+        return _FakeHTTPResponse(html)
+
+    with patch.object(rss_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+        found = discover_feeds("https://example.com")
+    assert found == []
+
+
+def test_discover_rejects_non_public_root():
+    try:
+        discover_feeds("http://localhost/blog")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for localhost root")
+
+
+def test_channel_method_delegates(monkeypatch):
+    _install_fake_feedparser(monkeypatch, valid_urls={"https://example.com/rss.xml"})
+    html = b'<link rel="alternate" type="application/rss+xml" href="/rss.xml">'
+
+    def fake_urlopen(req, timeout=0):  # noqa: ARG001
+        return _FakeHTTPResponse(html)
+
+    with patch.object(rss_mod.urllib.request, "urlopen", side_effect=fake_urlopen):
+        found = RSSChannel().discover_feeds("example.com")
+    assert found[0]["url"] == "https://example.com/rss.xml"
+
+
+def test_existing_check_still_ok(monkeypatch):
+    monkeypatch.setitem(sys.modules, "feedparser", types.ModuleType("feedparser"))
+    status, message = RSSChannel().check()
+    assert status == "ok"
+    assert "RSS" in message


### PR DESCRIPTION
## Summary

Adds `RSSChannel.discover_feeds(root_url)` so agents can locate RSS/Atom/JSON feeds from a site root without hand-writing feed URLs.

## Changes

- Parse homepage `<link rel="alternate" type="…">` candidates (stdlib `HTMLParser`)
- Probe a short list of common paths (`/feed`, `/rss`, `/atom.xml`, …)
- Validate each candidate with `feedparser`, log misses, same-host + public-HTTP gate
- Deduplicate by canonical URL; document usage in the web skill reference

## Out of scope (follow-ups)

- `robots.txt` / external feed registries
- Built-in scheduled re-scans (callers can re-invoke)

## Test plan

- [x] `tests/test_rss_discover.py` (HTML links, common-path dedupe, SSRF/off-host reject, channel method)
- [x] Existing `RSSChannel.check` still reports ok when feedparser is importable

Fixes #322
