### PR TITLE
fix(skill): drop quotes from gh search repos example

### DIFF
--- a/agent_reach/skill/references/dev.md
+++ b/agent_reach/skill/references/dev.md
@@ -12,8 +12,10 @@ gh auth login
 gh auth status
 
 # 搜索
-gh search repos "query" --sort stars --limit 10
-gh search code "query" --language python
+# repos 搜索不要加引号：引号是精确短语匹配，多词查询会静默返回 0 条结果
+gh search repos query terms --sort stars --limit 10
+# code 搜索的引号是有意义的，匹配连续的精确字符串（如函数签名）
+gh search code "def transcribe_audio" --language python
 
 # 仓库
 gh repo view owner/repo


### PR DESCRIPTION
## Problem

`references/dev.md` documents the GitHub search command as:

```bash
gh search repos "query" --sort stars --limit 10
```

The quotes make GitHub treat the string as an **exact phrase match** against name/description/readme. Any multi-word query therefore returns **zero results, with exit code 0 and no error message**.

This fails in the worst possible way for an agent: the command "succeeds", so the agent reports *"no results found"* and moves on instead of retrying with different syntax. Meanwhile `doctor` keeps showing the GitHub channel as ✅, because `gh auth status` is fine — the channel is healthy, only the documented invocation is wrong.

## Reproduction

Verified on gh 2.x, authenticated, Windows 11:

```
gh search repos "arxiv api python client"          -> 0 results
gh search repos "RePEc OR NBER working papers api" -> 0 results
gh search repos arxiv api python --sort stars      -> 3 results
```

## Fix

Drop the quotes from the `repos` example.

The quotes are **kept** for `gh search code`, where matching an exact contiguous string is the intended semantics and the quoted form is correct:

```
gh search code "def transcribe_audio" --language python  -> 3 matches
gh search code "arxiv feedparser client"                 -> 0 results
```

The code example is changed from `"query"` to a real function signature so the difference between the two lines reads as deliberate rather than as an inconsistency.

## Notes

- Docs-only change; no test asserts on `references/dev.md`.
- Found while exercising the zero-config channels of a fresh v1.5.0 install. Distinct from #566, which does not cover this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
