### PR TITLE
fix(cli): pass resolved mcporter path to subprocess on Windows

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1904,7 +1904,8 @@ def _cmd_uninstall(args):
                     print(f"  Could not remove {skill_path}: {e}")
 
     # ── 3. mcporter MCP entries ──
-    if shutil.which("mcporter"):
+    mcporter_cmd = shutil.which("mcporter")
+    if mcporter_cmd:
         from agent_reach.channels.mcporter import (
             McporterConfigError,
             configured_server_names,
@@ -1913,7 +1914,7 @@ def _cmd_uninstall(args):
         try:
             result = subprocess.run(
                 [
-                    "mcporter",
+                    mcporter_cmd,
                     "config",
                     "list",
                     "--json",
@@ -2006,7 +2007,8 @@ def _cmd_setup():
     print("【推荐】全网搜索 — Exa（通过 mcporter）")
     print("  免费，无需 API Key")
 
-    if not shutil.which("mcporter"):
+    mcporter_cmd = shutil.which("mcporter")
+    if not mcporter_cmd:
         print("  当前状态: -- mcporter 未安装")
         print("  安装：npm install -g mcporter")
         print("  然后：mcporter config add exa https://mcp.exa.ai/mcp --scope home")
@@ -2019,7 +2021,7 @@ def _cmd_setup():
             )
 
             r = subprocess.run(
-                ["mcporter", "config", "list", "--json"],
+                [mcporter_cmd, "config", "list", "--json"],
                 capture_output=True,
                 encoding="utf-8",
                 errors="replace",
@@ -2035,7 +2037,7 @@ def _cmd_setup():
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
                         [
-                            "mcporter",
+                            mcporter_cmd,
                             "config",
                             "add",
                             "exa",


### PR DESCRIPTION
Fixes the three call sites reported in #590.

## Why

`subprocess.run(["mcporter", ...])` cannot work on Windows. `CreateProcess` does not consult `PATHEXT`, so a bare extensionless name raises `FileNotFoundError [WinError 2]`. `shutil.which()` *does* apply `PATHEXT` and resolves to `mcporter.CMD`.

All three sites **guarded** with `shutil.which("mcporter")` and then **invoked** the bare name — so the guard passed, the call failed, and the enclosing `except` presented it as a normal degraded state rather than a platform failure:

| Site | Effect on Windows before this PR |
|---|---|
| `_cmd_uninstall()` | `OSError` caught at 1929 → `mcporter_cleanup_skipped = True`. **`agent-reach uninstall` never removed the `exa`/`xiaohongshu` MCP entries — unconditionally**, while reporting it as a cautious "could not verify the source" case. |
| `_cmd_setup()` (list) | Caught by the bare `except Exception` → **always printed `无法检查 Exa 配置`, even when Exa was configured correctly.** |
| `_cmd_setup()` (add) | Unreachable; the call above raised first inside the same `try`. |

## What changed

Capture `shutil.which("mcporter")` once, pass the resolved path. This is the idiom `_install_mcporter()` (line 1206) and `probe.py` already use — the migration just missed these three.

+7 −5, no behavior change on Linux/macOS, where `shutil.which()` returns the same path the bare name would have resolved to.

`systemd-detect-virt` at line 1327 has the same shape but is Linux-only and correctly best-effort, so it is deliberately left alone.

## Verification

On Windows 11 / Python 3.12.10 / Node 24.18.0:

```python
subprocess.run(["mcporter", "--version"])                -> FileNotFoundError [WinError 2]
subprocess.run([shutil.which("mcporter"), "--version"])  -> returncode 0
```

Against `pip install -c constraints.txt -e ".[dev]"`:

- `ruff check agent_reach` — **All checks passed**
- `pytest -q` — **554 passed, 28 skipped, 4 failed**

The 4 failures are `test_channels.py` / `test_reddit_channel.py` symlink-security tests failing with `OSError [WinError 1314]` (creating a symlink needs a privilege the client does not hold unless Developer Mode or an elevated shell is used). They are **pre-existing and unrelated** — I re-ran exactly those 4 against an unmodified checkout of this branch's base and they fail identically. Neither file is touched by this PR. CI runs its Windows job on `windows-latest`, where symlink creation is permitted, so this should be green there.

`mypy` could not run in my environment (application-control policy blocked loading its `aststrip` DLL), so that check is unverified on my side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
