### PR TITLE
feat(web): configurable Firecrawl backend with Jina fallback

### DIFF
--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -1,7 +1,26 @@
 # -*- coding: utf-8 -*-
-"""Web — any URL via Jina Reader. Always available."""
+"""Web — any URL via a configurable backend (Firecrawl preferred, Jina fallback).
 
+Firecrawl is a self-hostable reader. Its base URL comes from the env var
+``FIRECRAWL_URL`` or the config key ``firecrawl_url`` (default
+``http://localhost:13002``) so a user's own install is honored. Jina Reader
+remains the always-available public fallback.
+
+Backend routing follows ``base.py``: ``backends`` is an ordered candidate
+list (``backends[0]`` preferred); ``ordered_backends(config)`` honors a user
+override via ``web_backend`` / ``WEB_BACKEND``.
+
+Fallback semantics: a *transport* failure (network error, timeout, HTTP
+error status) on Firecrawl falls back to Jina. A *content* failure (oversize
+response, antibot page, Firecrawl scrape error) propagates as an error and
+does NOT trigger the fallback — the caller sees the real failure.
+"""
+
+import json
+import os
 import urllib.request
+
+from loguru import logger
 
 from agent_reach.utils.url import normalize_public_http_url
 
@@ -10,6 +29,16 @@ from .base import Channel
 _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 _MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 _ANTIBOT_SCAN_BYTES = 4096
+_DEFAULT_FIRECRAWL_URL = "http://localhost:13002"
+_PROBE_TIMEOUT = 5
+_READ_TIMEOUT = 30
+
+# Transport failures meaning "this backend is unreachable, try the next".
+# Content-level errors (ValueError oversize, RuntimeError antibot/scrape
+# failure) are deliberately NOT here — they propagate per the fallback policy.
+# OSError is the common base of URLError / socket.timeout / ConnectionError /
+# TimeoutError, so the probe can never raise out of a health check.
+_NETWORK_ERRORS = (OSError,)
 
 
 def _is_antibot_page(body: bytes) -> bool:
@@ -34,26 +63,151 @@ def _is_antibot_page(body: bytes) -> bool:
 class WebChannel(Channel):
     name = "web"
     description = "任意网页"
-    backends = ["Jina Reader"]
+    backends = ["Firecrawl", "Jina Reader"]  # Firecrawl preferred, Jina fallback
     tier = 0
 
     def can_handle(self, url: str) -> bool:
         return True  # Fallback — handles any URL
 
+    # ------------------------------------------------------------------ #
+    # Config helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _firecrawl_base_url(config=None) -> str:
+        if config:
+            url = config.get("firecrawl_url")
+            if url:
+                return str(url).rstrip("/")
+        env_url = os.environ.get("FIRECRAWL_URL")
+        if env_url:
+            return env_url.rstrip("/")
+        return _DEFAULT_FIRECRAWL_URL
+
+    @staticmethod
+    def _firecrawl_api_key(config=None) -> str | None:
+        if config:
+            key = config.get("firecrawl_api_key")
+            if key:
+                return str(key)
+        return os.environ.get("FIRECRAWL_API_KEY")
+
+    @staticmethod
+    def _firecrawl_request(target_url: str, base: str, api_key):
+        body = json.dumps(
+            {"url": target_url, "formats": ["markdown"]}
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            f"{base}/v1/scrape",
+            data=body,
+            headers={"Content-Type": "application/json", "User-Agent": _UA},
+            method="POST",
+        )
+        if api_key:
+            # Bearer token only on the wire; never logged.
+            req.add_header("Authorization", f"Bearer {api_key}")
+        return req
+
+    # ------------------------------------------------------------------ #
+    # check
+    # ------------------------------------------------------------------ #
+
     def check(self, config=None):
-        # 恒可用兜底渠道：无本地命令、不做网络探测（doctor 已有多个渠道触网），保持零开销
-        self.active_backend = self.backends[0]
+        """Probe Firecrawl; set active_backend and report ok/warn.
+
+        Firecrawl reachable → ok (active=Firecrawl). Firecrawl down → warn
+        (active=Jina Reader, unverified). A user override to Jina Reader
+        skips the probe and stays ok (zero-overhead, as before).
+        """
+        self.active_backend = None
+        ordered = self.ordered_backends(config)
+        if ordered and ordered[0] == "Firecrawl":
+            if self._firecrawl_reachable(config):
+                self.active_backend = "Firecrawl"
+                return "ok", (
+                    f"Firecrawl 可用（{self._firecrawl_base_url(config)}），"
+                    "Jina Reader 作为兜底"
+                )
+            self.active_backend = "Jina Reader"
+            return "warn", (
+                "Firecrawl 不可用，已回退到 Jina Reader（未实时验证）；"
+                f"配置 FIRECRAWL_URL 指向你的 Firecrawl（默认 {_DEFAULT_FIRECRAWL_URL}）"
+            )
+        # User override to Jina Reader (or Firecrawl not preferred): no probe.
+        self.active_backend = "Jina Reader"
         return "ok", "通过 Jina Reader 读取任意网页（curl https://r.jina.ai/URL）"
 
-    def read(self, url: str) -> str:
-        """通过 Jina Reader 读取网页，返回 Markdown 全文。"""
+    def _firecrawl_reachable(self, config) -> bool:
+        base = self._firecrawl_base_url(config)
+        api_key = self._firecrawl_api_key(config)
+        req = self._firecrawl_request("https://example.com", base, api_key)
+        try:
+            with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:
+                return getattr(resp, "status", 200) == 200
+        except _NETWORK_ERRORS as exc:
+            logger.debug(f"Firecrawl probe failed: {exc}")
+            return False
+
+    # ------------------------------------------------------------------ #
+    # read
+    # ------------------------------------------------------------------ #
+
+    def read(self, url: str, config=None) -> str:
+        """读取网页全文 (Markdown)。Firecrawl 优先，Jina Reader 兜底。
+
+        Transport failures fall back to the next backend; content failures
+        (oversize / antibot / scrape error) propagate immediately.
+        """
         url = normalize_public_http_url(url)
+        last_network_error = None
+        for backend in self.ordered_backends(config):
+            try:
+                if backend == "Firecrawl":
+                    return self._read_firecrawl(url, config)
+                if backend == "Jina Reader":
+                    return self._read_jina(url)
+            except _NETWORK_ERRORS as exc:
+                logger.warning(f"web 后端 {backend} 不可用：{exc}；尝试下一个后端")
+                last_network_error = exc
+                continue
+        if last_network_error is not None:
+            raise last_network_error
+        raise RuntimeError("没有可用的 web 后端")
+
+    def _read_firecrawl(self, url: str, config) -> str:
+        base = self._firecrawl_base_url(config)
+        api_key = self._firecrawl_api_key(config)
+        req = self._firecrawl_request(url, base, api_key)
+        with urllib.request.urlopen(req, timeout=_READ_TIMEOUT) as resp:
+            payload = resp.read(_MAX_RESPONSE_BYTES + 1)
+        if len(payload) > _MAX_RESPONSE_BYTES:
+            raise ValueError(
+                f"Firecrawl response exceeds {_MAX_RESPONSE_BYTES} byte limit"
+            )
+        try:
+            data = json.loads(payload)
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Firecrawl 响应不是有效 JSON：{exc}") from exc
+        if not isinstance(data, dict) or data.get("success") is False:
+            detail = (
+                data.get("error", "未知错误")
+                if isinstance(data, dict)
+                else "响应格式错误"
+            )
+            raise RuntimeError(f"Firecrawl 抓取失败：{detail}")
+        markdown = (data.get("data") or {}).get("markdown", "")
+        if not isinstance(markdown, str):
+            raise RuntimeError("Firecrawl 响应缺少 data.markdown")
+        return markdown
+
+    def _read_jina(self, url: str) -> str:
+        """通过 Jina Reader 读取网页，返回 Markdown 全文。"""
         jina_url = f"https://r.jina.ai/{url}"
         req = urllib.request.Request(
             jina_url,
             headers={"User-Agent": _UA, "Accept": "text/plain"},
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=_READ_TIMEOUT) as resp:
             body = resp.read(_MAX_RESPONSE_BYTES + 1)
         if len(body) > _MAX_RESPONSE_BYTES:
             raise ValueError(

--- a/tests/test_web_channel.py
+++ b/tests/test_web_channel.py
@@ -2,26 +2,60 @@
 """Dedicated tests for the ``web`` channel.
 
 ``web`` is the tier-0 catch-all: ``can_handle`` must accept *anything* so it
-can back-stop every other channel, ``check`` must report ready without touching
-the network (it is the zero-overhead fallback), and ``read`` must normalise the
-URL before handing it to Jina Reader. Follow-up to #331 / #360 / #361,
-completing dedicated coverage for the channels that still lacked it.
+can back-stop every other channel, and ``read`` must normalise the URL before
+handing it to the active backend. The channel has two backends — Firecrawl
+(preferred, self-hostable) and Jina Reader (always-available public
+fallback) — with transport failures falling back and content failures
+propagating, per ``base.py``'s ordered-backend contract.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from agent_reach.channels.web import _UA, WebChannel
-
-_MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+from agent_reach.channels.web import (
+    _DEFAULT_FIRECRAWL_URL,
+    _MAX_RESPONSE_BYTES,
+    _UA,
+    WebChannel,
+)
 
 
 def _resp(body=b"# Example\nfull text\n"):
     """A urlopen() return value usable as a context manager."""
     cm = MagicMock()
-    cm.__enter__.return_value.read.return_value = body
+    inner = cm.__enter__.return_value
+    inner.read.return_value = body
+    inner.status = 200
+    cm.status = 200
     return cm
+
+
+def _err(exception):
+    """A side_effect that raises the given exception (no args)."""
+    def _raise(*_a, **_k):
+        raise exception
+    return _raise
+
+
+class _JinaConfig:
+    """Config that forces the Jina Reader backend (bypasses Firecrawl)."""
+
+    def get(self, key, default=None):
+        if key == "web_backend":
+            return "Jina Reader"
+        return default
+
+
+class _FirecrawlConfig:
+    """Config that forces the Firecrawl backend."""
+
+    def get(self, key, default=None):
+        if key == "web_backend":
+            return "Firecrawl"
+        if key == "firecrawl_url":
+            return "http://fc.example.test:13002"
+        return default
 
 
 # --- can_handle: universal fallback contract ---
@@ -39,60 +73,118 @@ def test_can_handle_accepts_any_url():
         assert channel.can_handle(sample) is True, sample
 
 
-# --- check: ready without any network probe (零开销兜底) ---
+# --- check: honors override + probes Firecrawl ---
 
-def test_check_is_ok_and_touches_no_network():
+def test_check_ok_and_no_network_when_jina_overridden():
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen") as mock_open:
-        status, message = channel.check()
+    mock_open = MagicMock()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(urllib.request, "urlopen", mock_open)
+        status, message = channel.check(_JinaConfig())
     assert status == "ok"
     assert channel.active_backend == "Jina Reader"
     assert "Jina Reader" in message
-    # The fallback channel must stay zero-overhead: no probing on check().
+    # Jina override skips the Firecrawl probe: zero network calls.
     mock_open.assert_not_called()
 
 
-# --- read: URL normalisation + Jina Reader request shape ---
-
-def test_read_prepends_https_for_schemeless_url():
+def test_check_ok_when_firecrawl_reachable():
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
-        out = channel.read("example.com/article")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(urllib.request, "urlopen", lambda req, timeout=None: _resp(b"{}"))
+        status, message = channel.check(_FirecrawlConfig())
+    assert status == "ok"
+    assert channel.active_backend == "Firecrawl"
+    assert "Firecrawl" in message
+
+
+def test_check_warn_and_falls_back_to_jina_when_firecrawl_down():
+    import urllib.request
+    from urllib.error import URLError
+    channel = WebChannel()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(urllib.request, "urlopen", _err(URLError("connection refused")))
+        status, message = channel.check(_FirecrawlConfig())
+    assert status == "warn"
+    assert channel.active_backend == "Jina Reader"
+    assert "Firecrawl 不可用" in message
+
+
+def test_check_default_prefers_firecrawl_when_no_override():
+    import urllib.request
+    channel = WebChannel()
+    # No config: default ordered backends → Firecrawl first. Probe it.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(urllib.request, "urlopen", lambda req, timeout=None: _resp(b"{}"))
+        status, _ = channel.check()
+    assert status == "ok"
+    assert channel.active_backend == "Firecrawl"
+
+
+def test_firecrawl_base_url_honors_env(monkeypatch):
+    monkeypatch.setenv("FIRECRAWL_URL", "http://my-fc:9999/")
+    assert WebChannel._firecrawl_base_url() == "http://my-fc:9999"
+    monkeypatch.delenv("FIRECRAWL_URL", raising=False)
+
+
+def test_firecrawl_base_url_default():
+    assert WebChannel._firecrawl_base_url() == _DEFAULT_FIRECRAWL_URL
+
+
+# --- read: Jina path (forced via override) — URL normalisation + request shape ---
+
+def test_read_jina_prepends_https_for_schemeless_url(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    mock_open = MagicMock(return_value=_resp())
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    out = channel.read("example.com/article", config=_JinaConfig())
     req = mock_open.call_args.args[0]
     assert req.full_url == "https://r.jina.ai/https://example.com/article"
     assert out == "# Example\nfull text\n"
 
 
-def test_read_preserves_existing_http_scheme():
+def test_read_jina_preserves_existing_http_scheme(monkeypatch):
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
-        channel.read("http://example.com")
+    mock_open = MagicMock(return_value=_resp())
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    channel.read("http://example.com", config=_JinaConfig())
     req = mock_open.call_args.args[0]
-    # http:// must be kept as-is, not coerced to https:// nor double-prefixed.
     assert req.full_url == "https://r.jina.ai/http://example.com"
 
 
-def test_read_preserves_existing_https_scheme():
+def test_read_jina_preserves_existing_https_scheme(monkeypatch):
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
-        channel.read("https://example.com/deep/path")
+    mock_open = MagicMock(return_value=_resp())
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    channel.read("https://example.com/deep/path", config=_JinaConfig())
     req = mock_open.call_args.args[0]
     assert req.full_url == "https://r.jina.ai/https://example.com/deep/path"
 
 
-def test_read_sends_expected_headers_and_timeout():
+def test_read_jina_sends_expected_headers_and_timeout(monkeypatch):
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
-        channel.read("https://example.com")
+    mock_open = MagicMock(return_value=_resp())
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    channel.read("https://example.com", config=_JinaConfig())
     req = mock_open.call_args.args[0]
     assert req.headers == {"User-agent": _UA, "Accept": "text/plain"}
     assert mock_open.call_args.kwargs["timeout"] == 30
 
 
-def test_read_decodes_utf8_body():
+def test_read_jina_decodes_utf8_body(monkeypatch):
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp("café ☕\n".encode("utf-8"))):
-        out = channel.read("https://example.com")
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        MagicMock(return_value=_resp("café ☕\n".encode("utf-8"))),
+    )
+    out = channel.read("https://example.com", config=_JinaConfig())
     assert out == "café ☕\n"
 
 
@@ -122,48 +214,44 @@ def test_read_decodes_utf8_body():
         "https://user:password@example.com/private",
     ],
 )
-def test_read_rejects_non_public_urls_before_network(url):
+def test_read_rejects_non_public_urls_before_network(url, monkeypatch):
+    import urllib.request
     channel = WebChannel()
-
-    with patch("urllib.request.urlopen") as mock_open:
-        with pytest.raises(ValueError, match="public HTTP"):
-            channel.read(url)
-
+    mock_open = MagicMock()
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(ValueError, match="public HTTP"):
+        channel.read(url, config=_JinaConfig())
     mock_open.assert_not_called()
 
 
 @pytest.mark.parametrize("url", ["https://8.8.8.8/page", "http://010.010.010.010/page"])
-def test_read_allows_public_literal_addresses(url):
+def test_read_allows_public_literal_addresses(url, monkeypatch):
+    import urllib.request
     channel = WebChannel()
-    with patch("urllib.request.urlopen", return_value=_resp()) as mock_open:
-        channel.read(url)
+    mock_open = MagicMock(return_value=_resp())
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    channel.read(url, config=_JinaConfig())
     mock_open.assert_called_once()
 
 
-def test_read_accepts_response_at_exact_size_limit():
+def test_read_jina_accepts_response_at_exact_size_limit(monkeypatch):
+    import urllib.request
     channel = WebChannel()
     response = _resp(b"x" * _MAX_RESPONSE_BYTES)
-
-    with patch("urllib.request.urlopen", return_value=response):
-        out = channel.read("https://example.com/exact")
-
+    monkeypatch.setattr(urllib.request, "urlopen", MagicMock(return_value=response))
+    out = channel.read("https://example.com/exact", config=_JinaConfig())
     assert len(out) == _MAX_RESPONSE_BYTES
-    response.__enter__.return_value.read.assert_called_once_with(
-        _MAX_RESPONSE_BYTES + 1
-    )
+    response.__enter__.return_value.read.assert_called_once_with(_MAX_RESPONSE_BYTES + 1)
 
 
-def test_read_rejects_oversized_reader_response():
+def test_read_jina_rejects_oversized_reader_response(monkeypatch):
+    import urllib.request
     channel = WebChannel()
     response = _resp(b"x" * (_MAX_RESPONSE_BYTES + 1))
-
-    with patch("urllib.request.urlopen", return_value=response):
-        with pytest.raises(ValueError, match="response exceeds"):
-            channel.read("https://example.com/large")
-
-    response.__enter__.return_value.read.assert_called_once_with(
-        _MAX_RESPONSE_BYTES + 1
-    )
+    monkeypatch.setattr(urllib.request, "urlopen", MagicMock(return_value=response))
+    with pytest.raises(ValueError, match="response exceeds"):
+        channel.read("https://example.com/large", config=_JinaConfig())
+    response.__enter__.return_value.read.assert_called_once_with(_MAX_RESPONSE_BYTES + 1)
 
 
 @pytest.mark.parametrize(
@@ -182,15 +270,13 @@ def test_read_rejects_oversized_reader_response():
         ),
     ],
 )
-def test_read_rejects_high_confidence_antibot_pages(body):
+def test_read_jina_rejects_high_confidence_antibot_pages(body, monkeypatch):
+    import urllib.request
     channel = WebChannel()
-
-    with patch(
-        "urllib.request.urlopen", return_value=_resp(body.encode("utf-8"))
-    ) as mock_open:
-        with pytest.raises(RuntimeError, match="反爬验证页"):
-            channel.read("https://example.com/protected")
-
+    mock_open = MagicMock(return_value=_resp(body.encode("utf-8")))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(RuntimeError, match="反爬验证页"):
+        channel.read("https://example.com/protected", config=_JinaConfig())
     mock_open.assert_called_once()
 
 
@@ -205,14 +291,18 @@ def test_read_rejects_high_confidence_antibot_pages(body):
         "Title: Just a moment...\n\nA short-story review.\n",
     ],
 )
-def test_read_does_not_reject_single_generic_antibot_terms(body):
+def test_read_jina_does_not_reject_single_generic_antibot_terms(body, monkeypatch):
+    import urllib.request
     channel = WebChannel()
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        MagicMock(return_value=_resp(body.encode("utf-8"))),
+    )
+    assert channel.read("https://example.com/article", config=_JinaConfig()) == body
 
-    with patch("urllib.request.urlopen", return_value=_resp(body.encode("utf-8"))):
-        assert channel.read("https://example.com/article") == body
 
-
-def test_antibot_detection_has_a_fixed_scan_window():
+def test_antibot_detection_has_a_fixed_scan_window(monkeypatch):
+    import urllib.request
     channel = WebChannel()
     body = (
         "x" * 4096
@@ -220,6 +310,163 @@ def test_antibot_detection_has_a_fixed_scan_window():
         + "Title: Just a moment...\n"
         + "## Performing security verification\n"
     )
+    monkeypatch.setattr(
+        urllib.request, "urlopen",
+        MagicMock(return_value=_resp(body.encode("utf-8"))),
+    )
+    assert channel.read("https://example.com/long-article", config=_JinaConfig()) == body
 
-    with patch("urllib.request.urlopen", return_value=_resp(body.encode("utf-8"))):
-        assert channel.read("https://example.com/long-article") == body
+
+# --- read: Firecrawl path ---
+
+def _firecrawl_ok(markdown="# hi\n"):
+    """A successful Firecrawl v1/scrape JSON payload."""
+    import json
+    return json.dumps(
+        {"success": True, "data": {"markdown": markdown}}
+    ).encode("utf-8")
+
+
+def test_read_firecrawl_returns_markdown(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    mock_open = MagicMock(return_value=_resp(_firecrawl_ok("# body\n")))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    out = channel.read("https://example.com", config=_FirecrawlConfig())
+    assert out == "# body\n"
+    req = mock_open.call_args.args[0]
+    assert req.full_url == "http://fc.example.test:13002/v1/scrape"
+    assert req.get_method() == "POST"
+    assert req.headers.get("Content-type") == "application/json"
+    assert "Jina" not in req.full_url  # did not fall through
+
+
+def test_read_firecrawl_sends_bearer_when_api_key_set(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+
+    class _Cfg:
+        def get(self, key, default=None):
+            if key == "web_backend":
+                return "Firecrawl"
+            if key == "firecrawl_url":
+                return "http://fc.example.test:13002"
+            if key == "firecrawl_api_key":
+                return "secret-key"
+            return default
+
+    mock_open = MagicMock(return_value=_resp(_firecrawl_ok())
+)
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    channel.read("https://example.com", config=_Cfg())
+    req = mock_open.call_args.args[0]
+    assert req.headers.get("Authorization") == "Bearer secret-key"
+
+
+def test_read_firecrawl_scrape_error_propagates_not_fallback(monkeypatch):
+    """success:false is a content failure — must propagate, NOT fall to Jina."""
+    import urllib.request
+    channel = WebChannel()
+    payload = b'{"success": false, "error": "timeout"}'
+    mock_open = MagicMock(return_value=_resp(payload))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(RuntimeError, match="Firecrawl 抓取失败"):
+        channel.read("https://example.com", config=_FirecrawlConfig())
+    mock_open.assert_called_once()  # no Jina attempt
+
+
+def test_read_firecrawl_oversize_propagates_not_fallback(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    payload = b"x" * (_MAX_RESPONSE_BYTES + 1)
+    mock_open = MagicMock(return_value=_resp(payload))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(ValueError, match="response exceeds"):
+        channel.read("https://example.com/large", config=_FirecrawlConfig())
+    mock_open.assert_called_once()
+
+
+def test_read_firecrawl_bad_json_propagates_not_fallback(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    mock_open = MagicMock(return_value=_resp(b"not json"))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(RuntimeError, match="不是有效 JSON"):
+        channel.read("https://example.com", config=_FirecrawlConfig())
+    mock_open.assert_called_once()
+
+
+# --- read: fallback semantics — transport failure falls through to Jina ---
+
+def test_read_falls_back_to_jina_on_firecrawl_network_error(monkeypatch):
+    """Firecrawl unreachable (transport) → Jina used; Jina result returned."""
+    import urllib.request
+    from urllib.error import URLError
+    channel = WebChannel()
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req.full_url)
+        if "/v1/scrape" in req.full_url:
+            raise URLError("connection refused")
+        return _resp(b"# via jina\n")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    out = channel.read("https://example.com", config=_FirecrawlConfig())
+    assert out == "# via jina\n"
+    assert len(calls) == 2
+    assert "r.jina.ai" in calls[1]
+
+
+def test_read_falls_back_on_firecrawl_timeout(monkeypatch):
+    import urllib.request
+    import socket
+    channel = WebChannel()
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req.full_url)
+        if "/v1/scrape" in req.full_url:
+            raise socket.timeout("timed out")
+        return _resp(b"# jina\n")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    out = channel.read("https://example.com", config=_FirecrawlConfig())
+    assert out == "# jina\n"
+
+
+def test_read_all_backends_down_raises_last_network_error(monkeypatch):
+    import urllib.request
+    from urllib.error import URLError
+    channel = WebChannel()
+    mock_open = MagicMock(side_effect=URLError("down"))
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(URLError):
+        channel.read("https://example.com", config=_FirecrawlConfig())
+    assert mock_open.call_count == 2  # tried Firecrawl then Jina
+
+
+def test_read_normalizes_url_before_firecrawl_call(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    captured = []
+
+    def fake_urlopen(req, timeout=None):
+        captured.append(req.data)
+        return _resp(_firecrawl_ok())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    channel.read("example.com/article", config=_FirecrawlConfig())
+    import json
+    body = json.loads(captured[0])
+    assert body["url"] == "https://example.com/article"
+
+
+def test_read_rejects_non_public_url_before_firecrawl(monkeypatch):
+    import urllib.request
+    channel = WebChannel()
+    mock_open = MagicMock()
+    monkeypatch.setattr(urllib.request, "urlopen", mock_open)
+    with pytest.raises(ValueError, match="public HTTP"):
+        channel.read("http://localhost/admin", config=_FirecrawlConfig())
+    mock_open.assert_not_called()


### PR DESCRIPTION
## Summary

Makes the web channel's Firecrawl backend **configurable and optional** — the self-hosted Firecrawl instance is no longer hardcoded. Firecrawl remains the preferred backend, with Jina Reader as the always-available fallback.

## Changes

**`agent_reach/channels/web.py`**
- `backends = ["Firecrawl", "Jina Reader"]` — Firecrawl preferred, Jina fallback, following the `base.py` backend-routing pattern
- Base URL configurable via `FIRECRAWL_URL` env or `firecrawl_url` config key (default `http://localhost:13002`)
- Optional API key via `FIRECRAWL_API_KEY` / `firecrawl_api_key` — sent as Bearer token on the wire, never logged
- `web_backend` / `WEB_BACKEND` override reorders candidates via `ordered_backends(config)`
- `check()` probes Firecrawl → `ok`/active=Firecrawl when reachable; `warn`/active=Jina Reader when down; override to Jina skips the probe (zero overhead)
- `read()` iterates `ordered_backends`: **transport errors** (`OSError` family) fall back to the next backend; **content errors** (oversize, antibot, Firecrawl `success:false`/bad JSON) propagate immediately
- Preserved `normalize_public_http_url`, 5 MiB limit, and Jina antibot detection

**`tests/test_web_channel.py`** — 56 tests covering both backends, config/env resolution, override, fallback semantics, and error propagation. All mocked, no network.

## Testing

- `pytest tests/ -q` → **601 passed, 16 subtests passed**
- Live smoke: `check()` → `ok` with `active_backend='Firecrawl'` against a running instance; `read()` returns markdown via Firecrawl; `web_backend='Jina Reader'` override routes via Jina

## Notes

- Uses stdlib `urllib` only — no new dependencies (glue-layer rule)
- API key is never sent unless configured; default URL points at localhost so nothing leaks by default