### PR TITLE
fix: avoid wildcard reference token in Skill prose

### DIFF
--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -17,7 +17,7 @@ description: >
   NOT for: 写报告/数据分析/翻译等内容加工（本 skill 只负责从互联网获取内容）；
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
-  【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
+  【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references 文件。
   分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
 metadata:
   homepage: https://github.com/Panniantong/Agent-Reach


### PR DESCRIPTION
## Summary
- Replace the prose token `references/*.md` with wording that does not resemble a support-file glob.
- Keep the seven explicit Markdown links to real reference files unchanged.

## Context
Closes #584. Hermes Skill installation recursively extracts `references/`-shaped tokens from `SKILL.md`; the prose wildcard was interpreted as a file path, causing bundle installation to fail.

## Validation
- `git diff --check`
- `ruff check agent_reach tests`
- `mypy agent_reach`
- `pytest -q` — 586 passed, 16 subtests passed