### PR TITLE
feat(skill): ship English references for English locales

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -466,26 +466,50 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
+def _is_english_locale(value: str) -> bool:
+    normalized = value.strip().lower()
+    return normalized.startswith("en") or normalized.startswith("english")
+
+
+def _prefers_english() -> bool:
+    """True when any locale variable asks for English skill content."""
+    locale_candidates = (
+        os.environ.get("AGENT_REACH_LANG", ""),
+        os.environ.get("LC_ALL", ""),
+        os.environ.get("LC_MESSAGES", ""),
+        os.environ.get("LANG", ""),
+    )
+    return any(_is_english_locale(candidate) for candidate in locale_candidates)
+
+
+def _skill_resource_name() -> str:
+    """Packaged SKILL markdown matching the requested locale."""
+    return "SKILL_en.md" if _prefers_english() else "SKILL.md"
+
+
+def _skill_references_dirname() -> str:
+    """Package directory holding the locale-matched references."""
+    return "references_en" if _prefers_english() else "references"
+
+
 def _install_skill(force: bool = True):
     """Install Agent Reach as an agent skill for supported agent clients."""
     import importlib.resources
     import os
     import shutil
 
-    def _is_english_locale(value: str) -> bool:
-        normalized = value.strip().lower()
-        return normalized.startswith("en") or normalized.startswith("english")
-
-    def _skill_resource_name() -> str:
-        locale_candidates = (
-            os.environ.get("AGENT_REACH_LANG", ""),
-            os.environ.get("LC_ALL", ""),
-            os.environ.get("LC_MESSAGES", ""),
-            os.environ.get("LANG", ""),
-        )
-        if any(_is_english_locale(candidate) for candidate in locale_candidates):
-            return "SKILL_en.md"
-        return "SKILL.md"
+    def _references_pkg(skill_pkg):
+        """Locale-matched references dir, falling back to the default set."""
+        default = skill_pkg.joinpath("references")
+        if not _prefers_english():
+            return default
+        english = skill_pkg.joinpath(_skill_references_dirname())
+        try:
+            if any(entry.name.endswith(".md") for entry in english.iterdir()):
+                return english
+        except (FileNotFoundError, NotADirectoryError):
+            pass
+        return default
 
     def _read_skill_markdown(skill_pkg):
         resource_name = _skill_resource_name()
@@ -521,8 +545,8 @@ def _install_skill(force: bool = True):
             with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
                 f.write(skill_md)
 
-            # Copy references/ directory
-            refs_pkg = skill_pkg.joinpath("references")
+            # Copy references/ directory (locale-matched source, fixed target name)
+            refs_pkg = _references_pkg(skill_pkg)
             refs_target = os.path.join(target, "references")
             os.makedirs(refs_target, exist_ok=True)
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -42,7 +42,7 @@ these platforms — do not invent your own approach.**
 5. **Watch versions for the user**: after finishing a substantial
    multi-platform task, run `agent-reach check-update` (fast, one API call).
    If a new version exists, append one line to your wrap-up: "Agent Reach
-   vX.Y.Z is available — paste this to me to update: 帮我更新 Agent Reach：
+   vX.Y.Z is available. Paste this back to me to update: Update Agent Reach using
    https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md".
    Never interrupt the current task to update; never nag about the same version twice.
 
@@ -134,7 +134,7 @@ output and `~/.agent-reach/` for persistent data.
 
 Read the matching file when you need specifics (commands above cover the
 common cases; references hold per-backend command groups, caveats, retry
-chains — note: reference docs are written in Chinese, commands are universal):
+chains):
 
 - [Search](references/search.md) — Exa AI search
 - [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)

--- a/agent_reach/skill/references_en/career.md
+++ b/agent_reach/skill/references_en/career.md
@@ -1,0 +1,29 @@
+# Careers and recruiting
+
+LinkedIn.
+
+## LinkedIn
+
+```bash
+# Get a person's profile
+mcporter call linkedin.get_person_profile linkedin_username="username" sections="experience,education"
+
+# Search for people
+mcporter call linkedin.search_people keywords="AI engineer" location="Shanghai"
+
+# Get a company profile
+mcporter call linkedin.get_company_profile company_name="openai" sections="posts,jobs"
+
+# Search jobs
+mcporter call linkedin.search_jobs keywords="software engineer" location="Remote" max_pages=2
+```
+
+> **Login required**: before first use run `uvx mcp-server-linkedin@latest --login` to save a valid session.
+
+### Fallback
+
+If the MCP is unavailable, use Jina Reader:
+
+```bash
+curl -s "https://r.jina.ai/https://linkedin.com/in/username"
+```

--- a/agent_reach/skill/references_en/dev.md
+++ b/agent_reach/skill/references_en/dev.md
@@ -1,0 +1,62 @@
+# Developer tools
+
+GitHub CLI
+
+## GitHub (gh CLI)
+
+GitHub's official command line tool, for repos, issues, PRs, Actions, releases and API access.
+
+```bash
+# Auth
+gh auth login
+gh auth status
+
+# Search
+gh search repos "query" --sort stars --limit 10
+gh search code "query" --language python
+
+# Repos
+gh repo view owner/repo
+gh repo clone owner/repo
+gh repo create my-repo --private
+gh repo fork owner/repo
+gh repo fork owner/repo --clone
+gh repo sync owner/repo
+
+# Issues
+gh issue list -R owner/repo --state open
+gh issue view 123 -R owner/repo
+gh issue create -R owner/repo --title "Title" --body "Body"
+
+# Pull Requests
+gh pr list -R owner/repo --state open
+gh pr view 123 -R owner/repo
+gh pr create -R owner/repo --title "Title" --body "Body"
+gh pr checks 123 --repo owner/repo
+
+# Actions / CI
+gh run list --repo owner/repo --limit 10
+gh run view <run-id> --repo owner/repo
+gh run view <run-id> --repo owner/repo --log-failed
+gh workflow list --repo owner/repo
+
+# Releases
+gh release list -R owner/repo
+gh release create v1.0.0
+
+# API
+gh api /user
+gh api repos/owner/repo
+
+# JSON output
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+```
+
+
+## Choosing a tool
+
+| Tool | Source | Use for |
+|-----|------|------|
+| gh CLI | agent-reach | Git operations |
+| zread | my-mcp-tools | Reading repo contents |
+| context7 | my-mcp-tools | Looking up technical docs |

--- a/agent_reach/skill/references_en/finance.md
+++ b/agent_reach/skill/references_en/finance.md
@@ -1,0 +1,47 @@
+# Financial market data
+
+Xueqiu stock quotes, search and trending content. Quotes may be delayed and are not investment advice.
+
+## Check status first
+
+```bash
+agent-reach doctor --json
+```
+
+When `xueqiu.active_backend` has a value, use that backend. A value of `null` only means Doctor
+did not complete live content verification. Xueqiu needs a logged-in session or a minimal cookie,
+so never read an HTTP 400 as proof the stock does not exist.
+
+## OpenCLI (preferred when the desktop Chrome session is already logged in)
+
+```bash
+# Verify the current session
+opencli xueqiu whoami -f yaml
+
+# Stock search and live quotes
+opencli xueqiu search "英伟达" -f yaml
+opencli xueqiu stock NVDA -f yaml
+
+# Trending content and trending stocks
+opencli xueqiu hot -f yaml
+opencli xueqiu hot-stock -f yaml
+
+# See all read-only commands
+opencli xueqiu --help
+```
+
+OpenCLI only reuses a browser session the user already has and explicitly controls. Do not run
+`opencli xueqiu login` automatically. When no session exists, ask the user to log in via Chrome
+first, or explicitly import the minimal cookie Xueqiu needs:
+
+```bash
+agent-reach configure --from-browser chrome --platform xueqiu
+```
+
+That command reads and saves only `xq_a_token`. It does not collect cookies for any other platform.
+
+## Acceptance and failure handling
+
+- Success means a returned stock name, ticker, price, or a non-empty content list. Exit code 0 with empty fields is not success.
+- HTTP 400 is usually a session or cookie problem, not a non-existent ticker.
+- When `whoami` succeeds but `stock`/`hot` fails, report it as an adapter parsing or platform API problem. Do not misdiagnose it as being logged out.

--- a/agent_reach/skill/references_en/search.md
+++ b/agent_reach/skill/references_en/search.md
@@ -1,0 +1,37 @@
+# Search tools
+
+Exa AI search engine.
+
+## Exa AI search
+
+High-quality AI search engine, good for finding technical documentation, official examples and related web pages.
+
+```bash
+mcporter call exa.web_search_exa query="query" numResults=5
+mcporter call exa.web_search_exa query="library API code example" numResults=5
+```
+
+### When to use
+
+| Scenario | Parameters |
+|-----|------|
+| Web search | `web_search_exa(query: "...", numResults: 5)` |
+| Technical / code material | `web_search_exa(query: "framework name API example", numResults: 5)` |
+
+> Exa MCP's `get_code_context_exa` is deprecated and not registered by default. Use
+> `web_search_exa` for code questions too. When you need to search repo contents precisely,
+> use the GitHub search in `dev.md` instead.
+
+### Characteristics
+
+- Strong on English content and technical documentation
+- Query wording can pin down official docs and code examples
+- High result quality
+
+## Compared with other search tools
+
+| Tool | Source | Best for |
+|-----|------|---------|
+| Exa | agent-reach | English / technical / code search |
+| Zhipu search | my-mcp-tools | Chinese-language search |
+| GitHub search | agent-reach (dev.md) | Repo / code search |

--- a/agent_reach/skill/references_en/social.md
+++ b/agent_reach/skill/references_en/social.md
@@ -1,0 +1,301 @@
+# Social media and communities
+
+XiaoHongShu, Twitter/X, Bilibili, V2EX, Reddit, Facebook, Instagram.
+
+## XiaoHongShu (multi-backend)
+
+XiaoHongShu has three backends. **Run `agent-reach doctor --json` first to see which `active_backend` xiaohongshu is on**, then use the matching command group.
+
+### Backend A: OpenCLI (preferred on desktop)
+
+```bash
+# Search notes
+opencli xiaohongshu search "query" -f yaml
+
+# Read a note's body and engagement data (use the full URL from the search results, including xsec_token)
+opencli xiaohongshu note "NOTE_URL" -f yaml
+
+# Comments (nested replies supported)
+opencli xiaohongshu comments NOTE_ID -f yaml
+
+# Home recommendation feed
+opencli xiaohongshu feed -f yaml
+
+# A user's public notes
+opencli xiaohongshu user USER_ID -f yaml
+```
+
+> Requires Chrome open with the OpenCLI extension installed. OpenCLI only uses a Chrome session the
+> user already has and explicitly controls. Agent Reach does not log in on the user's behalf and does
+> not read browser cookies. `agent-reach configure xhs-cookies` does not inject cookies into OpenCLI.
+> If there is no existing session, do not log in automatically. Switch to backend B or C and configure
+> it through the matching manual Cookie-Editor export flow.
+
+### Backend B: xiaohongshu-mcp (server scenarios)
+
+```bash
+# Before authenticating, have the user export manually with Cookie-Editor, then import explicitly
+agent-reach configure xhs-cookies
+
+# Read-only status check
+mcporter call xiaohongshu.check_login_status --timeout 120000
+
+# Search
+mcporter call xiaohongshu.search_feeds keyword="query" --timeout 120000
+
+# Note detail plus comments (take feed_id and xsec_token from the search results)
+mcporter call xiaohongshu.get_feed_detail feed_id="..." xsec_token="..." --timeout 120000
+```
+
+> The first call downloads roughly 150MB of headless browser, so always pass `--timeout 120000`.
+> Authentication goes only through a manual Cookie-Editor export. After importing, run `check_login_status` first.
+> That explicit command saves and imports the same-origin xiaohongshu.com cookie set the user provided, and the user
+> should confirm its scope. Cookies from domains other than xiaohongshu.com are ignored.
+
+### Backend C: xhs-cli (legacy alternative, upstream stopped updating in March 2026)
+
+```bash
+xhs search "query"          # Search
+xhs read NOTE_ID_OR_URL     # Read a note (must use the URL/ID from search results, never a bare note_id)
+xhs comments NOTE_ID_OR_URL # Comments
+xhs hot                     # Trending
+xhs feed                    # Recommendations
+```
+
+> Known to be unstable: `xhs user` / `xhs user-posts` / `xhs favorites` can return API errors (upstream is unmaintained). New users should go straight to backend A or B.
+
+### General notes
+
+> **Authentication boundary**: Agent Reach must not perform a XiaoHongShu login on the user's behalf and must not
+> read browser cookies. OpenCLI may only use a Chrome session the user already has and explicitly controls.
+> xiaohongshu-mcp and the legacy tools use a manual Cookie-Editor export.
+>
+> **xsec_token constraint**: XiaoHongShu enforces an xsec_token mechanism, so **a bare note_id cannot be read directly**. The correct flow is to search or pull the feed first, then read using the full URL/ID from those results. This applies to all three backends.
+>
+> **Rate control**: high-frequency requests (bulk searches, deep comment paging) trigger a captcha. This platform limit cannot be worked around. Leave 2 to 3 seconds between operations.
+>
+> **Write operations (posting, commenting, liking)**: read-only is recommended. xhs-cli v0.6.x write operations can return 406 because of signature problems.
+
+## Twitter/X (twitter-cli)
+
+### Authentication prerequisites
+
+The cookie saved by `agent-reach configure twitter-cookies` through hidden input is only used by
+`agent-reach doctor` to check whether the explicit credentials are complete. `doctor` does not run
+upstream's `twitter status`, and it does not set up your current shell. Before running any `twitter`
+command below, you must explicitly provide these in the same shell or subprocess environment:
+
+```bash
+export TWITTER_AUTH_TOKEN="..."
+export TWITTER_CT0="..."
+```
+
+### Stable commands
+
+```bash
+# Home timeline (most stable)
+twitter feed -n 20
+
+# Read a single tweet (with replies)
+twitter tweet URL_OR_ID
+
+# Read a long-form post / X Article
+twitter article URL_OR_ID
+
+# A user's timeline
+twitter user-posts @username -n 20
+
+# A user's profile
+twitter user @username
+```
+
+### Commands that may be unstable
+
+```bash
+# Tweet search (Twitter changes GraphQL endpoints often, so this can 404)
+twitter search "query" -n 10
+
+# likes (since 2024 you can only see your own, a platform limit)
+twitter likes
+```
+
+### Retry chain when search fails (run in order, stop on success)
+
+1. Simply retry once (intermittent failures are common): `twitter search "query" -n 10`
+2. Upgrade and retry: `pipx upgrade twitter-cli && twitter search "query" -n 10`
+3. Switch to the OpenCLI alternative (desktop, reuses the browser session): `opencli twitter search "query" -f yaml`
+4. If none of that works, route around it with stable commands such as `twitter feed` or `twitter user-posts @somebody`
+
+### Important notes
+
+> **Install**: `pipx install twitter-cli` (make sure it is v0.8.5+)
+>
+> **Auth**: use a manual Cookie-Editor export only, then set the environment variables
+> `TWITTER_AUTH_TOKEN` and `TWITTER_CT0` explicitly. Do not rely on automatic browser reading.
+>
+> **IP risk controls**: do not call frequently from a VPS or datacentre IP, especially followers/following, as it risks a ban. Use a residential proxy or a local environment.
+>
+> **OpenCLI alternative**: if OpenCLI is installed on the desktop, the full set `opencli twitter search/article/user-posts -f yaml` is available (browser session, no cookie environment variables needed).
+>
+> **Output format**: prefer `--yaml` or `--json` for structured output, which is friendlier for an AI agent.
+
+## Bilibili
+
+> ⚠️ **Do not use yt-dlp for Bilibili** (anti-abuse blocks it with 412 across the board, no known workaround). Use bili-cli or OpenCLI.
+
+```bash
+# Search / trending / video details (bili-cli, read-only, no login needed)
+bili search "query" --type video -n 5
+bili hot -n 10
+bili video BVxxx
+
+# Subtitles (OpenCLI, needs desktop Chrome)
+opencli bilibili subtitle BVxxx
+```
+
+> For the detailed commands (audio transcription, direct API fallback) see [references/video.md](video.md).
+
+## V2EX (public API)
+
+No authentication needed, call the public API directly.
+
+### Hot topics
+
+```bash
+curl -s "https://www.v2ex.com/api/topics/hot.json" -H "User-Agent: agent-reach/1.0"
+```
+
+### Node topics
+
+```bash
+# node_name examples: python, tech, jobs, qna, programmers
+curl -s "https://www.v2ex.com/api/topics/show.json?node_name=python&page=1" -H "User-Agent: agent-reach/1.0"
+```
+
+### Topic detail
+
+```bash
+# topic_id comes from the URL, e.g. https://www.v2ex.com/t/1234567
+curl -s "https://www.v2ex.com/api/topics/show.json?id=TOPIC_ID" -H "User-Agent: agent-reach/1.0"
+```
+
+### Topic replies
+
+```bash
+curl -s "https://www.v2ex.com/api/replies/show.json?topic_id=TOPIC_ID&page=1" -H "User-Agent: agent-reach/1.0"
+```
+
+### User info
+
+```bash
+curl -s "https://www.v2ex.com/api/members/show.json?username=USERNAME" -H "User-Agent: agent-reach/1.0"
+```
+
+### Python usage example
+
+```python
+from agent_reach.channels.v2ex import V2EXChannel
+
+ch = V2EXChannel()
+
+# Get hot topics
+topics = ch.get_hot_topics(limit=10)
+for t in topics:
+    print(f"[{t['node_title']}] {t['title']} ({t['replies']} 回复)")
+
+# Get topics from a node
+node_topics = ch.get_node_topics("python", limit=5)
+
+# Get topic detail plus replies
+topic = ch.get_topic(1234567)
+print(topic["title"], "—", topic["author"])
+
+# Get user info
+user = ch.get_user("Livid")
+```
+
+> **Node list**: https://www.v2ex.com/planes
+
+## Reddit (multi-backend, session required)
+
+**Reddit has no zero-config path**: the anonymous `.json` endpoints are blocked (403), and official API access has been effectively unobtainable through manual review since November 2025. Both backends rely on a logged-in session, so run `agent-reach doctor --json` first to see reddit's `active_backend`. Access from mainland China needs a proxy.
+
+### Backend A: OpenCLI (preferred on desktop, reuses the browser session)
+
+```bash
+# Search posts
+opencli reddit search "query" -f yaml
+
+# Read a full post plus comments
+opencli reddit read POST_ID -f yaml
+
+# Browse a subreddit / hot / popular
+opencli reddit subreddit LocalLLaMA -f yaml
+opencli reddit hot -f yaml
+opencli reddit popular -f yaml
+
+# Subreddit metadata (subscriber count, description)
+opencli reddit subreddit-info LocalLLaMA -f yaml
+```
+
+> Requires Chrome open and logged into reddit.com in the browser.
+
+### Backend B: rdt-cli (legacy / server alternative, upstream stopped updating in March 2026)
+
+```bash
+rdt search "query" --limit 10   # Search posts
+rdt read POST_ID                # Read a full post plus comments
+rdt sub python --limit 20       # Browse a subreddit
+rdt popular --limit 10          # Browse popular
+rdt all --limit 10              # Browse /r/all
+```
+
+> **Install**: `pipx install 'git+https://github.com/public-clis/rdt-cli.git'` (the PyPI version lags, so install v0.4.2+ from GitHub). Run `rdt login` before searching and reading (on a server with no browser, write the cookie manually as the doctor output describes).
+> Prefer `--yaml` output, which is friendlier for an AI agent.
+
+### Advanced option: official API plus PRAW (only for users who already have credentials)
+
+Users who registered a Reddit script app before November 2025 (holding a client_id/client_secret) can use PRAW against the official API (100 QPM free). New applications need manual review and personal projects are essentially never approved, so **do not recommend this path to new users**.
+
+## Facebook (OpenCLI, session required)
+
+Facebook goes through OpenCLI, reusing the facebook.com session in the user's Chrome. Run `agent-reach doctor --json` first to check facebook's `active_backend`, which should read `OpenCLI`. Do not recommend Jina, Exa or the Graph API as the default path.
+
+```bash
+# Search users / pages / posts
+opencli facebook search "query" -f yaml
+
+# User or page info
+opencli facebook profile zuck -f yaml
+
+# The current account's news feed
+opencli facebook feed --limit 10 -f yaml
+
+# Groups visible to the current account, and recent activity
+opencli facebook groups --limit 20 -f yaml
+```
+
+> Requires Chrome open with the OpenCLI extension installed and logged into facebook.com. Facebook Groups currently only promises the group list and recent activity visible to the current account. It does not promise an API for arbitrary group posts and comments.
+
+## Instagram (OpenCLI, session required)
+
+Instagram goes through OpenCLI, reusing the instagram.com session in the user's Chrome. Run `agent-reach doctor --json` first to check instagram's `active_backend`, which should read `OpenCLI`. Do not fall back to instaloader by default, as it has historically been unstable with cookies, 401s and 429s.
+
+```bash
+# Search users (not a site-wide keyword search over posts)
+opencli instagram search "query" -f yaml
+
+# User profile
+opencli instagram profile nasa -f yaml
+
+# A user's recent posts
+opencli instagram user nasa --limit 12 -f yaml
+
+# Explore / Discover
+opencli instagram explore --limit 20 -f yaml
+
+# The current account's saved posts
+opencli instagram saved --limit 20 -f yaml
+```
+
+> Requires Chrome open with the OpenCLI extension installed and logged into instagram.com. `instagram search` searches users, so to read posts you must first establish a username, then use `instagram user USERNAME`. If you hit 429 or login required, ask the user to log in again in Chrome and reduce the request rate.

--- a/agent_reach/skill/references_en/video.md
+++ b/agent_reach/skill/references_en/video.md
@@ -1,0 +1,149 @@
+# Video / podcasts
+
+Subtitles and transcripts for YouTube, Bilibili and Xiaoyuzhou podcasts.
+
+## YouTube (yt-dlp)
+
+### Get video metadata
+
+```bash
+yt-dlp --dump-json "URL"
+```
+
+### Download subtitles
+
+```bash
+# Download subtitles only (no video)
+yt-dlp --write-sub --write-auto-sub --sub-lang "zh-Hans,zh,en" --skip-download -o "/tmp/%(id)s" "URL"
+
+# Then read the .vtt file
+cat /tmp/VIDEO_ID.*.vtt
+```
+
+### Get comments
+
+```bash
+# Extract comments (best-effort, completeness not guaranteed)
+yt-dlp --write-comments --skip-download --write-info-json \
+  --extractor-args "youtube:max_comments=20" \
+  -o "/tmp/%(id)s" "URL"
+# Comments land in the comments field of the .info.json
+```
+
+### Search videos
+
+```bash
+yt-dlp --dump-json "ytsearch5:query"
+```
+
+> **Subtitle note**: manually uploaded subtitles extract reliably. Auto-generated subtitles can contain repeated lines and need post-processing.
+> **Comment note**: `--write-comments` is based on page scraping, not the YouTube Data API, so some comments may be missing.
+
+### Retry chain when subtitles fail (run in order, stop as soon as you have real content)
+
+`doctor` only confirms that yt-dlp itself and the JS runtime can run. It does not request a
+specific video, so `active_backend: yt-dlp` does NOT mean the target video's subtitles have been
+verified live.
+
+1. Start with the `yt-dlp --write-sub --write-auto-sub` command above.
+2. If you hit a bot check, an empty subtitle response, or no subtitle file is produced, and OpenCLI is connected:
+   `opencli youtube transcript "URL" -f yaml`.
+3. If OpenCLI returns `Caption URL returned empty response`, retry up to 3 times. These subtitle URLs carry an
+   expiry and fail intermittently, so an empty response is not proof the video has no subtitles.
+4. Still failing, or the video genuinely has no subtitles: `agent-reach transcribe "URL"` downloads the audio and transcribes it.
+
+The success criterion is actually holding non-empty subtitle or transcript content, not the command's exit code or `doctor`'s version probe.
+
+### No-subtitle fallback: Whisper audio transcription
+
+```bash
+# Fallback when a video has no subtitles: download the audio and transcribe with Whisper (a free Groq key is enough)
+agent-reach transcribe "https://www.youtube.com/watch?v=VIDEO_ID"
+agent-reach transcribe ./local_audio.mp3 -o /tmp/transcript.txt
+```
+
+> `agent-reach transcribe` accepts only a public http(s) URL or a local audio file. When searching with `ytsearch5:`, pick a specific video URL out of the yt-dlp results first, then transcribe.
+> Configure a key first: `agent-reach configure groq-key` (hidden input; free, console.groq.com)
+> or `agent-reach configure openai-key`. The default auto mode uses only the first configured provider
+> (Groq if present, otherwise OpenAI) and stops on failure. It will not silently send your audio to the other one.
+> `--allow-provider-fallback` explicitly authorises cross-provider fallback. The same audio may then be processed by both Groq and
+> OpenAI and may incur OpenAI charges, so use it only once you have confirmed the content can be shared with both.
+
+## Bilibili (bili-cli primary, OpenCLI for subtitles)
+
+> ⚠️ **Do not use yt-dlp for Bilibili**: Bilibili's anti-abuse now blocks yt-dlp with 412 across the board (tested on the latest version, direct, proxied and with cookies, all fail). Use yt-dlp for YouTube only.
+
+### Video details / search / trending / rankings (bili-cli, read-only, no login needed)
+
+```bash
+# Video details (title, uploader, duration, play and engagement stats, subtitle availability)
+bili video BVxxx
+
+# Search videos
+bili search "query" --type video -n 5
+
+# Trending videos / leaderboard
+bili hot -n 10
+bili rank -n 10
+
+# Download audio and split into ASR-ready WAV (pair with agent-reach transcribe when there are no subtitles)
+bili audio BVxxx
+```
+
+### Subtitles (OpenCLI, needs desktop Chrome)
+
+```bash
+# Subtitles line by line with timestamps
+opencli bilibili subtitle BVxxx
+
+# OpenCLI can also search and read video metadata (alternative)
+opencli bilibili search "query" -f yaml
+opencli bilibili video BVxxx -f yaml
+```
+
+### Zero-config fallback: direct search API
+
+```bash
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+curl -s -c /tmp/bili_ck.txt -o /dev/null -A "$UA" "https://www.bilibili.com/"
+curl -s -b /tmp/bili_ck.txt -A "$UA" -e "https://www.bilibili.com/" \
+  "https://api.bilibili.com/x/web-interface/search/all/v2?keyword=QUERY&page=1"
+```
+
+> **Installing bili-cli**: `pipx install bilibili-cli` (upstream stopped updating in March 2026 but tests healthy; read-only use needs no login, and `bili login` with a QR scan unlocks personal features such as your feed and favourites).
+
+## Xiaoyuzhou Podcast
+
+### Transcribe a single episode (optional --polish improves punctuation)
+
+```bash
+# Writes a Markdown file to /tmp/. --polish has Llama 3.3 70B add Chinese punctuation and sensible paragraph breaks
+~/.agent-reach/tools/xiaoyuzhou/transcribe.sh --polish "https://www.xiaoyuzhoufm.com/episode/EPISODE_ID"
+```
+
+> The transcription prompt already asks Whisper for Chinese punctuation. If punctuation still reads poorly, add `--polish` to use the free Llama 3.3 70B on Groq for punctuation and paragraphing (roughly 7 extra seconds on a 9-minute podcast). Each transcription then costs one extra LLM call, so use it as needed.
+
+### Prerequisites
+
+1. **ffmpeg**: `brew install ffmpeg`
+2. **Groq API key** (free): https://console.groq.com/keys
+3. **Configure the key**: `agent-reach configure groq-key` (hidden input)
+4. **First run**: `agent-reach install --env=auto --system --channels=xiaoyuzhou` (needs explicit user authorisation)
+
+### Check status
+
+```bash
+agent-reach doctor
+```
+
+> Output Markdown files are saved to `/tmp/` by default.
+
+## Choosing a tool
+
+| Scenario | Recommended tool |
+|-----|---------|
+| YouTube subtitles | yt-dlp; on failure OpenCLI (up to 3 tries), then agent-reach transcribe |
+| Bilibili video details / search | bili-cli |
+| Bilibili subtitles | opencli bilibili subtitle |
+| Podcast transcription | Xiaoyuzhou transcribe.sh |
+| Audio or video without subtitles | agent-reach transcribe (for Bilibili, run `bili audio` first) |

--- a/agent_reach/skill/references_en/web.md
+++ b/agent_reach/skill/references_en/web.md
@@ -1,0 +1,50 @@
+# Web reading
+
+General web pages, RSS.
+
+## General web pages (Jina Reader)
+
+```bash
+# Read the contents of any web page
+curl -s "https://r.jina.ai/URL"
+
+# Example
+curl -s "https://r.jina.ai/https://example.com/article"
+```
+
+**When to use**: most web pages can be read directly with Jina Reader.
+
+## Web Reader (MCP)
+
+```bash
+# Read page content (Markdown format)
+mcporter call web-reader.webReader url="https://example.com"
+
+# Keep images
+mcporter call web-reader.webReader url="https://example.com" retain_images=true
+
+# Plain text format
+mcporter call web-reader.webReader url="https://example.com" return_format="text"
+```
+
+**When to use**: when you need finer control over the output format.
+
+## RSS (feedparser)
+
+```python
+python3 -c "
+import feedparser
+for e in feedparser.parse('FEED_URL').entries[:5]:
+    print(f'{e.title} — {e.link}')
+"
+```
+
+**When to use**: subscribing to blogs, news sources, podcasts and other RSS feeds.
+
+## Choosing a tool
+
+| Scenario | Recommended tool |
+|-----|---------|
+| General web page | Jina Reader (`curl r.jina.ai`) |
+| Need images / format control | web-reader MCP |
+| RSS subscription | feedparser |

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -10,7 +10,13 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
-from agent_reach.cli import _cmd_skill, _install_skill, _uninstall_skill
+from agent_reach.cli import (
+    _cmd_skill,
+    _install_skill,
+    _skill_references_dirname,
+    _skill_resource_name,
+    _uninstall_skill,
+)
 
 
 class TestSkillCommand(unittest.TestCase):
@@ -25,6 +31,95 @@ class TestSkillCommand(unittest.TestCase):
 
         self.assertTrue(default_skill.strip())
         self.assertTrue(english_skill.strip())
+
+    def test_english_references_mirror_default_file_set(self):
+        """references_en/ must cover exactly the same files as references/."""
+        skill_dir = importlib.resources.files("agent_reach").joinpath("skill")
+
+        default_names = sorted(
+            entry.name
+            for entry in skill_dir.joinpath("references").iterdir()
+            if entry.name.endswith(".md")
+        )
+        english_names = sorted(
+            entry.name
+            for entry in skill_dir.joinpath("references_en").iterdir()
+            if entry.name.endswith(".md")
+        )
+
+        self.assertEqual(default_names, english_names)
+
+    def test_english_references_carry_identical_commands(self):
+        """Translation must never alter an executable command line."""
+        skill_dir = importlib.resources.files("agent_reach").joinpath("skill")
+
+        def executable_lines(text: str) -> list[str]:
+            lines, inside = [], False
+            for raw in text.splitlines():
+                if raw.strip().startswith("```"):
+                    inside = not inside
+                    continue
+                if not inside:
+                    continue
+                stripped = raw.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                # Drop a trailing inline comment, but only outside quoted text.
+                if "#" in stripped and stripped.count('"') % 2 == 0:
+                    stripped = stripped.split("#")[0].strip()
+                if stripped:
+                    lines.append(stripped)
+            return lines
+
+        for entry in skill_dir.joinpath("references").iterdir():
+            if not entry.name.endswith(".md"):
+                continue
+            english = skill_dir.joinpath("references_en", entry.name)
+            with self.subTest(reference=entry.name):
+                self.assertEqual(
+                    executable_lines(entry.read_text(encoding="utf-8")),
+                    executable_lines(english.read_text(encoding="utf-8")),
+                )
+
+    def test_english_skill_surface_is_free_of_han_characters(self):
+        """The English skill must not fall back to Chinese prose."""
+        skill_dir = importlib.resources.files("agent_reach").joinpath("skill")
+        han = re.compile(r"[\u4e00-\u9fff]")
+
+        english_skill = skill_dir.joinpath("SKILL_en.md").read_text(encoding="utf-8")
+        self.assertFalse(han.findall(english_skill))
+
+        for entry in skill_dir.joinpath("references_en").iterdir():
+            if not entry.name.endswith(".md"):
+                continue
+            prose = [
+                line
+                for line in entry.read_text(encoding="utf-8").splitlines()
+                # Sample queries and printed labels inside code stay as-is.
+                if han.search(line) and not line.strip().startswith(("opencli", "print("))
+            ]
+            with self.subTest(reference=entry.name):
+                self.assertEqual(prose, [])
+
+    def test_locale_selects_matching_references_dir(self):
+        """Locale variables must steer which packaged references dir is used."""
+        cases = [
+            ({"AGENT_REACH_LANG": "en"}, "references_en"),
+            ({"AGENT_REACH_LANG": "en_GB.UTF-8"}, "references_en"),
+            ({"AGENT_REACH_LANG": "", "LANG": "English_United States"}, "references_en"),
+            ({"AGENT_REACH_LANG": "", "LC_ALL": "zh_CN.UTF-8"}, "references"),
+            ({"AGENT_REACH_LANG": "", "LANG": "", "LC_ALL": "", "LC_MESSAGES": ""}, "references"),
+        ]
+        for overrides, expected in cases:
+            env = {"AGENT_REACH_LANG": "", "LC_ALL": "", "LC_MESSAGES": "", "LANG": ""}
+            env.update(overrides)
+            with self.subTest(env=overrides):
+                with patch.dict(os.environ, env, clear=False):
+                    self.assertEqual(_skill_references_dirname(), expected)
+                    self.assertEqual(
+                        _skill_resource_name(),
+                        "SKILL_en.md" if expected == "references_en" else "SKILL.md",
+                    )
 
     def test_exa_reference_uses_default_registered_tools_only(self):
         """Agent instructions must not call Exa tools disabled by default."""


### PR DESCRIPTION
## Problem

`SKILL_en.md` already gives English-locale users an English skill descriptor, but `references/` has only one language. An English-locale install therefore lands seven Chinese reference files next to an English `SKILL.md`.

Those references are not decoration: they hold the per-backend command groups, the authentication boundaries (the XiaoHongShu "never log in for the user" rule, the Twitter cookie rule), the rate-limit warnings and the retry chains. That is exactly the content an operator wants to read before letting an agent act on their logged-in accounts.

`SKILL_en.md` also acknowledged the gap in a line reading "reference docs are written in Chinese, commands are universal", and its update prompt asked English users to paste a Chinese phrase back to their agent.

## Change

- Add `agent_reach/skill/references_en/` with all seven files translated.
- Select the references directory by locale, mirroring the existing `_skill_resource_name()`, and fall back to `references/` when `references_en/` is missing, so older packages and partial installs keep working.
- Promote `_is_english_locale`, `_prefers_english`, `_skill_resource_name` and the new `_skill_references_dirname` to module level so the selection is unit-testable. The install targets are hardcoded `~` paths, so an end-to-end install test would overwrite a developer's real skill directory.
- Fix the two Chinese strings in `SKILL_en.md` described above.

The installed directory is still named `references/` regardless of source, so every existing `[references/x.md](references/x.md)` link in `SKILL_en.md` keeps working. Hatchling packages the whole `agent_reach` directory, so no packaging change is needed.

## Translation safety

Commands were treated as untouchable. `test_english_references_carry_identical_commands` extracts every line inside a code fence, drops inline comments, and asserts the executable text is identical between `references/` and `references_en/`. All 135 command lines match; only prose and comments differ.

Deliberately left in Chinese, because they are example data rather than prose: the Xueqiu search term `"英伟达"` (a Chinese stock platform where a Chinese query is the realistic example) and the `回复` label inside the V2EX Python sample. `test_english_skill_surface_is_free_of_han_characters` allows exactly those two line shapes and fails on any other Han characters.

## Tests

Four added to `tests/test_skill_command.py`:

| Test | Guards |
|---|---|
| `test_locale_selects_matching_references_dir` | five locale permutations pick the right dir, and agree with the `SKILL.md` choice |
| `test_english_references_mirror_default_file_set` | the two dirs never drift apart in file coverage |
| `test_english_references_carry_identical_commands` | translation never alters a command |
| `test_english_skill_surface_is_free_of_han_characters` | no Chinese prose leaks back into the English surface |

Each was mutation-checked: forcing the selector to ignore locale fails the first, and altering one character of a `curl` command in `references_en/web.md` fails the third.

`ruff check` and `mypy` are clean. The full suite goes from 580 to 584 passed with an unchanged failure set (6 failures reproduce identically on unmodified `main` in my environment, all in `test_transcribe.py` / `test_xiaoyuzhou_install.py`, and appear to come from a real `GROQ_API_KEY` in the environment leaking into those tests, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)