### PR TITLE
feat(channels): add TikTok via OpenCLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Project
-Agent Reach — Python CLI + library that gives AI agents read/search access to 13 internet platforms.
+Agent Reach — Python CLI + library that gives AI agents read/search access to 16 internet platforms.
 Positioning: installer + doctor + config tool. NOT a wrapper — after install, agents call upstream tools directly.
 Repo: github.com/Panniantong/Agent-Reach | License: MIT | Version: 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📖 **Reddit** | —（没有零配置路径：匿名接口已被封） | 搜索 + 读帖子和评论 | 桌面装 OpenCLI 用浏览器登录态；或 rdt-cli + Cookie |
 | 📘 **Facebook** | — | 搜索、主页、Feed、群组列表 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
+| 🎵 **TikTok** | — | 用户、搜索、公开视频、当前账号创作者指标 | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📕 **小红书** | — | 搜索、阅读、评论 | OpenCLI 只用用户已有 Chrome 会话；MCP/存量工具用 Cookie-Editor |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
@@ -167,7 +168,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 3. **按授权安装与配置** — 仅在显式传入 `--system` 时安装依赖并通过 MCP 接入 Exa
 4. **检测环境** — 判断是本地电脑还是服务器，给出对应的配置建议
 5. **按授权注册 SKILL.md** — 仅在显式 `--system` 时写入 Agent 的 skills 目录；默认检查不改文件
-6. **问你要不要更多** — 默认只激活 6 个零配置渠道；小红书、Twitter、Reddit、Facebook、Instagram 这些需要登录态的，Agent 会列菜单问你要哪些，点名才装
+6. **问你要不要更多** — 默认只激活 6 个零配置渠道；小红书、Twitter、Reddit、Facebook、Instagram、TikTok 这些需要登录态的，Agent 会列菜单问你要哪些，点名才装
 
 安装完之后，`agent-reach doctor` 一条命令告诉你每个渠道的状态、当前走哪条路。
 </details>
@@ -185,7 +186,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 - "全网搜一下 LLM 框架对比" → Exa 语义搜索
 - "订阅这个 RSS" → `feedparser` 解析
 
-**不需要记命令。** Agent 读了 SKILL.md 之后自己知道该调什么。需要登录的平台（小红书、Twitter、Reddit、Facebook、Instagram），告诉 Agent「帮我配 XXX」即可解锁。
+**不需要记命令。** Agent 读了 SKILL.md 之后自己知道该调什么。需要登录的平台（小红书、Twitter、Reddit、Facebook、Instagram、TikTok），告诉 Agent「帮我配 XXX」即可解锁。
 
 ---
 
@@ -211,6 +212,7 @@ channels/
 ├── reddit.py       → OpenCLI ▸ rdt-cli（无零配置路径，必须登录态）
 ├── facebook.py     → OpenCLI（桌面浏览器登录态）
 ├── instagram.py    → OpenCLI（桌面浏览器登录态）
+├── tiktok.py       → OpenCLI（桌面浏览器登录态）
 ├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── linkedin.py     → mcp-server-linkedin ▸ Jina Reader
 ├── rss.py          → feedparser
@@ -229,6 +231,7 @@ channels/
 | Reddit | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | [rdt-cli](https://github.com/public-clis/rdt-cli) | 匿名接口已被封、官方 API 审批制——只剩登录态路线 |
 | Facebook | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | — | Graph API/Groups API 权限收紧；浏览器登录态是当前最实用路径 |
 | Instagram | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | 官方 Graph API（Business/Creator + 审批） | instaloader 类路径不稳定；OpenCLI 复用真实浏览器会话 |
+| TikTok | [OpenCLI](https://github.com/jackwener/opencli)（桌面） | — | 复用现有 Chrome 会话，提供用户、搜索、公开视频和当前账号创作者指标命令 |
 | YouTube 字幕 + 搜索 | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | — | 154K Star，YouTube 仍是最佳（注意：不再用于 B站） |
 | B站 | [bili-cli](https://github.com/public-clis/bilibili-cli) | OpenCLI ▸ 搜索 API | yt-dlp 被 B站风控 412 封死（2026-06 实测），bili-cli 无登录可搜可读 |
 | 搜全网 | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI 语义搜索，MCP 接入免 Key |
@@ -257,7 +260,7 @@ Agent Reach 在设计上重视安全：
 
 > ⚠️ **封号风险提醒：** 使用 Cookie 登录的平台（Twitter、小红书等），通过脚本/API 调用**存在被平台检测并封号的风险**。请务必使用**专用小号**，不要用你的主账号。
 
-需要 Cookie 或登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram 等）建议使用**专用小号**，不要用主账号。原因有二：
+需要 Cookie 或登录态的平台（Twitter、小红书、Reddit、Facebook、Instagram、TikTok 等）建议使用**专用小号**，不要用主账号。原因有二：
 1. **封号风险** — 平台可能检测到非正常浏览器的 API 调用行为，导致账号被限制或封禁
 2. **安全风险** — Cookie 等同于完整登录权限，用小号可以在凭据泄露时限制影响范围
 

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -15,6 +15,7 @@ from .instagram import InstagramChannel
 from .linkedin import LinkedInChannel
 from .reddit import RedditChannel
 from .rss import RSSChannel
+from .tiktok import TikTokChannel
 from .twitter import TwitterChannel
 from .v2ex import V2EXChannel
 from .web import WebChannel
@@ -30,6 +31,7 @@ ALL_CHANNELS: List[Channel] = [
     RedditChannel(),
     FacebookChannel(),
     InstagramChannel(),
+    TikTokChannel(),
     BilibiliChannel(),
     XiaoHongShuChannel(),
     LinkedInChannel(),

--- a/agent_reach/channels/tiktok.py
+++ b/agent_reach/channels/tiktok.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""TikTok — OpenCLI backend using the user's logged-in Chrome session."""
+
+from ._opencli_site import OpenCLISiteChannel
+
+
+class TikTokChannel(OpenCLISiteChannel):
+    name = "tiktok"
+    description = "TikTok 用户、公开视频和当前账号创作者指标"
+    site = "tiktok"
+    domains = ("tiktok.com",)
+    usage = "opencli tiktok profile/search/user/explore/creator-videos -f yaml"
+    login_hint = "tiktok.com"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -93,7 +93,7 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,tiktok,bilibili,linkedin,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -269,6 +269,7 @@ def _cmd_install(args):
         "reddit":      _install_reddit_deps,
         "facebook":    _install_opencli_deps,
         "instagram":   _install_opencli_deps,
+        "tiktok":      _install_opencli_deps,
         "bilibili":    _install_bili_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
@@ -313,7 +314,7 @@ def _cmd_install(args):
         tools_dir = os.path.expanduser("~/.agent-reach/tools")
         os.makedirs(tools_dir, exist_ok=True)
 
-    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
+    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram", "tiktok"}
     COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "xiaohongshu"}
 
     # Auto-detect environment
@@ -451,7 +452,7 @@ def _cmd_install(args):
                 # First install — hint about optional channels
                 print()
                 print("More channels available! Use --channels to install:")
-                print("   agent-reach install --system --channels=twitter,xiaohongshu,reddit,facebook,instagram,...")
+                print("   agent-reach install --system --channels=twitter,xiaohongshu,reddit,facebook,instagram,tiktok,...")
                 print("   agent-reach install --system --channels=all  (install everything)")
 
             # Star reminder

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
+  Instagram, TikTok/tiktok, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
   雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,18 +18,18 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/TikTok) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
 metadata:
   homepage: https://github.com/Panniantong/Agent-Reach
 ---
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
-1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram）先跑
+1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram/TikTok）先跑
    `agent-reach doctor --json`。`active_backend` 有值时按它选命令组；`active_backend: null`
    表示 Doctor 为避免触发浏览器 Cookie 读取或远端写入而没有做实时验证，不代表后端不存在。
    只有用户任务明确需要该平台时，才按对应 reference 的只读命令手动验证。
@@ -47,7 +47,7 @@ metadata:
 | 用户意图 | 分类 | 详细文档 |
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
-| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
+| 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram/TikTok | social | [references/social.md](references/social.md) |
 | 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
@@ -98,11 +98,13 @@ rdt search "query" --limit 10            # 存量/服务器
 # 小红书（桌面首选 OpenCLI）
 opencli xiaohongshu search "query" -f yaml
 
-# Facebook / Instagram（桌面 OpenCLI，复用浏览器登录态）
+# Facebook / Instagram / TikTok（桌面 OpenCLI，复用浏览器登录态）
 opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # 搜用户
 opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
+opencli tiktok search "query" -f yaml
+opencli tiktok user USERNAME -f yaml            # 读指定用户最近视频
 ```
 
 ## 环境检查
@@ -127,7 +129,7 @@ agent-reach doctor --json
 根据用户需求，阅读对应的详细文档：
 
 - [搜索工具](references/search.md) — Exa AI 搜索
-- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
+- [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram, TikTok（多后端/登录态命令组）
 - [职场招聘](references/career.md) — LinkedIn
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -6,10 +6,10 @@ description: >
   web for X", "see what people say about X", "look this up".
 
   Also MUST USE when user mentions any platform or shares any URL/link:
-  Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
+  Twitter/X, Reddit, Facebook, Instagram, TikTok, YouTube, GitHub, Bilibili, XiaoHongShu,
   Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -22,13 +22,13 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)
 
 1. **Health-check before acting**: for multi-backend/login-backed platforms (XiaoHongShu /
-   Reddit / Bilibili / Twitter / Facebook / Instagram), run `agent-reach doctor --json` first.
+   Reddit / Bilibili / Twitter / Facebook / Instagram / TikTok), run `agent-reach doctor --json` first.
    Use a populated `active_backend`; `active_backend: null` means Doctor deliberately skipped a
    live probe to avoid browser-cookie reads or remote writes, not that no backend exists. Only when
    the user's task requires that platform, run the reference's read-only command to verify it.
@@ -51,7 +51,7 @@ these platforms — do not invent your own approach.**
 | User intent | Category | Details |
 |---------|------|---------|
 | Web / code search | search | [references/search.md](references/search.md) |
-| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram | social | [references/social.md](references/social.md) |
+| XiaoHongShu / Twitter / Bilibili / V2EX / Reddit / Facebook / Instagram / TikTok | social | [references/social.md](references/social.md) |
 | Jobs / LinkedIn | career | [references/career.md](references/career.md) |
 | GitHub / code | dev | [references/dev.md](references/dev.md) |
 | Web pages / articles / RSS | web | [references/web.md](references/web.md) |
@@ -104,11 +104,13 @@ rdt search "query" --limit 10            # legacy/server
 # XiaoHongShu (desktop prefers OpenCLI)
 opencli xiaohongshu search "query" -f yaml
 
-# Facebook / Instagram (desktop OpenCLI, browser session)
+# Facebook / Instagram / TikTok (desktop OpenCLI, browser session)
 opencli facebook search "query" -f yaml
 opencli facebook groups -f yaml
 opencli instagram search "query" -f yaml       # user search
 opencli instagram user USERNAME -f yaml        # recent posts from one user
+opencli tiktok search "query" -f yaml
+opencli tiktok user USERNAME -f yaml            # recent videos from one user
 ```
 
 ## Environment check
@@ -137,7 +139,7 @@ common cases; references hold per-backend command groups, caveats, retry
 chains — note: reference docs are written in Chinese, commands are universal):
 
 - [Search](references/search.md) — Exa AI search
-- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram (multi-backend/login-backed groups)
+- [Social](references/social.md) — XiaoHongShu, Twitter, Bilibili, V2EX, Reddit, Facebook, Instagram, TikTok (multi-backend/login-backed groups)
 - [Career](references/career.md) — LinkedIn
 - [Dev](references/dev.md) — GitHub CLI
 - [Web](references/web.md) — Jina Reader, RSS

--- a/agent_reach/skill/references/social.md
+++ b/agent_reach/skill/references/social.md
@@ -1,6 +1,6 @@
 # 社交媒体 & 社区
 
-小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram。
+小红书、Twitter/X、B站、V2EX、Reddit、Facebook、Instagram、TikTok。
 
 ## 小红书 / XiaoHongShu（多后端）
 
@@ -299,3 +299,31 @@ opencli instagram saved --limit 20 -f yaml
 ```
 
 > 要求 Chrome 打开且装了 OpenCLI 扩展，并已登录 instagram.com。`instagram search` 是用户搜索；读帖子需要先确定 username，再用 `instagram user USERNAME`。若出现 429 / login required，先让用户在 Chrome 里重新登录并降低频率。
+
+## TikTok（OpenCLI，必须桌面 Chrome）
+
+TikTok 走 OpenCLI，复用用户 Chrome 里的 tiktok.com 会话。先跑
+`agent-reach doctor --json` 确认 `tiktok` channel 已注册；Doctor 不执行平台命令，
+因此即使 OpenCLI 桥接已连接也会保持 `active_backend: null`。只有任务确实需要
+TikTok 时，才执行下面的只读命令并以非空结果验收。
+
+```bash
+# 搜索公开视频
+opencli tiktok search "query" --limit 10 -f yaml
+
+# 用户 Profile
+opencli tiktok profile --username USERNAME -f yaml
+
+# 指定用户最近公开视频
+opencli tiktok user USERNAME --limit 20 -f yaml
+
+# Explore 公开视频
+opencli tiktok explore --limit 20 -f yaml
+
+# 当前登录账号自己的 TikTok Studio 视频和指标
+opencli tiktok creator-videos --limit 20 -f yaml
+```
+
+> 要求 Chrome 打开、安装 OpenCLI 扩展，并由用户自己登录 tiktok.com。
+> `creator-videos` 读取的是当前登录账号自己的 TikTok Studio 数据，不是任意创作者的
+> 私有指标。此 skill 只使用只读命令；不要调用 `comment`、`follow`、`like` 等写操作。

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -103,6 +103,7 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 | 📕 **XiaoHongShu** | Read · Search · Comments | OpenCLI / MCP | OpenCLI uses only an existing user-controlled Chrome session; MCP/legacy tools use a manual Cookie-Editor export |
 | 📘 **Facebook** | Search · Profiles · Feed · Groups list | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 📷 **Instagram** | User search · Profiles · Recent posts · Explore | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
+| 🎵 **TikTok** | Users · Search · Public videos · Own creator metrics | OpenCLI | Desktop only: [OpenCLI](https://github.com/jackwener/opencli) reuses your logged-in Chrome session |
 | 💼 **LinkedIn** | Jina Reader (public pages) | Full profiles, companies, job search | Tell your Agent "help me set up LinkedIn" |
 | 💻 **V2EX** | Hot topics · Node topics · Topic detail + replies · User profile | Zero config | Public JSON API, no auth required. Great for tech community content |
 | 📈 **Xueqiu (雪球)** | Stock quotes · Search · Hot posts · Hot stocks | Browser cookie | Tell your Agent "help me set up Xueqiu" |
@@ -268,6 +269,7 @@ channels/
 ├── reddit.py       → OpenCLI ▸ rdt-cli (no zero-config path, login required)
 ├── facebook.py     → OpenCLI (desktop browser session)
 ├── instagram.py    → OpenCLI (desktop browser session)
+├── tiktok.py       → OpenCLI (desktop browser session)
 ├── xiaohongshu.py  → OpenCLI ▸ xiaohongshu-mcp ▸ xhs-cli
 ├── linkedin.py     → linkedin-mcp ▸ Jina Reader
 ├── rss.py          → feedparser
@@ -286,6 +288,7 @@ Each channel file **actually probes** its candidate backends in order (not just 
 | Reddit | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | [rdt-cli](https://github.com/public-clis/rdt-cli) | Anonymous endpoints blocked, official API gated — logged-in sessions are the only route left |
 | Facebook | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | — | Graph/Groups API access is heavily restricted; browser sessions are the practical route |
 | Instagram | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | Official Graph API (Business/Creator + review) | Instaloader-style paths are unstable; OpenCLI reuses the real browser session |
+| TikTok | [OpenCLI](https://github.com/jackwener/opencli) (desktop) | — | Reuses an existing Chrome session for user, search, public-video, and signed-in creator-metrics commands |
 | YouTube subtitles + search | [yt-dlp](https://github.com/yt-dlp/yt-dlp) | — | 154K stars, still the best for YouTube (no longer used for Bilibili) |
 | Bilibili | [bili-cli](https://github.com/public-clis/bilibili-cli) | OpenCLI ▸ search API | yt-dlp is 412-blocked by Bilibili (verified June 2026); bili-cli searches and reads without login |
 | Search the web | [Exa](https://exa.ai) via [mcporter](https://github.com/nicobailon/mcporter) | — | AI semantic search, MCP integration, no API key |

--- a/docs/install.md
+++ b/docs/install.md
@@ -102,7 +102,7 @@ After installing the basics, **ask the user** which additional channels they nee
 >
 > 还有这些可选渠道，你需要哪些？
 >
-> - 🌟 **OpenCLI**（桌面推荐）— 一次安装即可提供 Reddit/Facebook/Instagram/B站字幕/Twitter 备选，并作为小红书桌面后端；小红书只使用用户已有且明确控制的 Chrome 会话
+> - 🌟 **OpenCLI**（桌面推荐）— 一次安装即可提供 Reddit/Facebook/Instagram/TikTok/B站字幕/Twitter 备选，并作为小红书桌面后端；小红书只使用用户已有且明确控制的 Chrome 会话
 > - 🐦 **Twitter/X** — 搜推文、看时间线（需要登录 Cookie）
 > - 📈 **雪球** — 股票行情、热门帖子（需要登录 Cookie）
 > - 🎙️ **小宇宙播客** — 音频转文字（需要免费 Groq Key）
@@ -110,6 +110,7 @@ After installing the basics, **ask the user** which additional channels they nee
 > - 📖 **Reddit** — 搜索和阅读帖子（必须登录态：桌面 OpenCLI 或 rdt-cli + Cookie）
 > - 📘 **Facebook** — 搜索、主页、Feed、群组列表（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📷 **Instagram** — 用户搜索、Profile、用户最近帖子、Explore（桌面走 OpenCLI，复用 Chrome 登录态）
+> - 🎵 **TikTok** — 用户、搜索、公开视频、当前账号创作者指标（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📺 **B站完整版** — 热门、排行、搜索、视频详情（bili-cli，无需登录）
 > - 💼 **LinkedIn** — Profile、职位搜索
 >
@@ -119,11 +120,11 @@ Based on the user's choice, run:
 
 ```bash
 agent-reach install --env=auto --system --channels=opencli,xiaohongshu   # Desktop user chose XHS
-agent-reach install --env=auto --system --channels=facebook,instagram    # Desktop Meta channels
+agent-reach install --env=auto --system --channels=facebook,instagram,tiktok  # Desktop OpenCLI channels
 agent-reach install --env=auto --system --channels=all                   # User approved everything
 ```
 
-Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `bilibili`, `linkedin`, `all`
+Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `tiktok`, `bilibili`, `linkedin`, `all`
 
 ### Step 3: Fix what's broken
 
@@ -137,7 +138,7 @@ Only ask the user when you genuinely need their input (credentials, permissions,
 
 Some channels need credentials only the user can provide. Based on the doctor output, ask for what's missing:
 
-> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
+> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram, TikTok), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
 > 1. **Account ban** — platforms may detect non-browser API calls and restrict or ban the account
 > 2. **Credential exposure** — cookies grant full account access; using a secondary account limits the blast radius if credentials are ever compromised
 
@@ -255,6 +256,28 @@ agent-reach install --system --channels facebook,instagram
 >
 > Facebook Groups 当前只承诺读取用户登录后可见的群组列表/最近动态，不承诺任意群帖子和评论 API。Instagram 的 search 是用户搜索，不是全站帖子关键词搜索；若提示 429/登录错误，先让用户在 Chrome 里重新登录并降低频率。
 
+**TikTok（桌面 OpenCLI）:**
+> TikTok 走 OpenCLI，复用用户自己的 Chrome 登录态。服务器/无桌面环境不推荐支持。
+
+```bash
+agent-reach install --system --channels tiktok
+```
+
+> 装完后：
+> 1. 确认 Chrome 已安装 OpenCLI 扩展并通过 `opencli doctor`
+> 2. 由用户自己在 Chrome 里登录 tiktok.com
+> 3. Agent 只调用只读命令：
+>    ```bash
+>    opencli tiktok search "query" --limit 10 -f yaml
+>    opencli tiktok profile --username USERNAME -f yaml
+>    opencli tiktok user USERNAME --limit 20 -f yaml
+>    opencli tiktok explore --limit 20 -f yaml
+>    opencli tiktok creator-videos --limit 20 -f yaml
+>    ```
+>
+> `creator-videos` 只读取当前登录账号自己的 TikTok Studio 视频和指标。不要调用
+> `comment`、`follow`、`like` 等写操作。
+
 **雪球 / Xueqiu (股票行情 + 热门帖子):**
 > "雪球需要登录后的 Cookie。请先在 Chrome 里登录 xueqiu.com，然后运行："
 
@@ -364,6 +387,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | Reddit | `opencli`（备选 `rdt`） | `opencli reddit search "query" -f yaml` / `rdt read POST_ID` |
 | Facebook | `opencli` | `opencli facebook search "query" -f yaml` |
 | Instagram | `opencli` | `opencli instagram user nasa -f yaml` |
+| TikTok | `opencli` | `opencli tiktok search "query" -f yaml` |
 | GitHub | `gh` | `gh search repos "query"` |
 | Web | `curl` + Jina | `curl -s "https://r.jina.ai/URL"` |
 | Exa Search | `mcporter` | `mcporter call exa.web_search_exa query="..." numResults=5` |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Agent Reach
 
-> Give your AI agent eyes to see the internet. Agent Reach installs, routes, and health-checks upstream tools for 15 platforms — Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Xiaoyuzhou Podcast, RSS, web search, and any web page. One install, zero API fees.
+> Give your AI agent eyes to see the internet. Agent Reach installs, routes, and health-checks upstream tools for 16 platforms — Twitter/X, Reddit, Facebook, Instagram, TikTok, YouTube, GitHub, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Xiaoyuzhou Podcast, RSS, web search, and any web page. One install, zero API fees.
 
 ## Quick Start
 
@@ -14,11 +14,11 @@
 
 ## Key Features
 
-- Read any URL: tweets, Reddit posts, Facebook pages/feed/groups, Instagram profiles/posts, YouTube videos (transcripts), GitHub repos, articles, XiaoHongShu notes, Bilibili videos, RSS feeds
-- Search/discover across platforms: Twitter/X, Reddit, Facebook, Instagram user search, GitHub, YouTube, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Web (via Exa)
+- Read any URL: tweets, Reddit posts, Facebook pages/feed/groups, Instagram profiles/posts, TikTok profiles/public videos, YouTube videos (transcripts), GitHub repos, articles, XiaoHongShu notes, Bilibili videos, RSS feeds
+- Search/discover across platforms: Twitter/X, Reddit, Facebook, Instagram user search, TikTok, GitHub, YouTube, Bilibili, XiaoHongShu, LinkedIn, V2EX, Xueqiu, Web (via Exa)
 - Self-diagnosis: `agent-reach doctor` checks what works and what needs setup
 - Auto-installs dependencies: `agent-reach install --env=auto`
-- Browser-session / cookie auth for platforms that require login (Twitter, Reddit, Facebook, Instagram, XiaoHongShu, Xueqiu)
+- Browser-session / cookie auth for platforms that require login (Twitter, Reddit, Facebook, Instagram, TikTok, XiaoHongShu, Xueqiu)
 - Proxy support for platforms that block server IPs (Reddit, Twitter)
 - Zero API fees: all backends are free and open-source (OpenCLI, twitter-cli, rdt-cli, bili-cli, yt-dlp, Jina Reader, mcporter/Exa, etc.)
 

--- a/tests/test_channel_contracts.py
+++ b/tests/test_channel_contracts.py
@@ -171,6 +171,7 @@ def test_channel_can_handle_contract():
         "reddit": "https://reddit.com/r/python",
         "facebook": "https://www.facebook.com/zuck",
         "instagram": "https://www.instagram.com/openai/",
+        "tiktok": "https://www.tiktok.com/@openai/video/1234567890",
         "bilibili": "https://www.bilibili.com/video/BV1xx411",
         "xiaohongshu": "https://www.xiaohongshu.com/explore/123",
         "linkedin": "https://www.linkedin.com/in/test",

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -13,6 +13,7 @@ from agent_reach.channels import get_all_channels, get_channel
 from agent_reach.channels.bilibili import BilibiliChannel
 from agent_reach.channels.facebook import FacebookChannel
 from agent_reach.channels.instagram import InstagramChannel
+from agent_reach.channels.tiktok import TikTokChannel
 from agent_reach.channels.v2ex import V2EXChannel
 from agent_reach.channels.xiaohongshu import XiaoHongShuChannel
 from agent_reach.channels.xueqiu import XueqiuChannel
@@ -35,10 +36,19 @@ class TestChannelRegistry:
         assert "twitter" in names
         assert "facebook" in names
         assert "instagram" in names
+        assert "tiktok" in names
         assert "v2ex" in names
 
 
 class TestOpenCLISiteChannels:
+    def test_tiktok_can_handle_common_urls(self):
+        ch = TikTokChannel()
+        assert ch.can_handle("https://www.tiktok.com/@openai/video/1234567890")
+        assert ch.can_handle("https://m.tiktok.com/@openai/video/1234567890")
+        assert ch.can_handle("https://vt.tiktok.com/ZS1234567/")
+        assert not ch.can_handle("https://tiktok.com.evil.example/@openai/video/1234567890")
+        assert not ch.can_handle("https://instagram.com/openai")
+
     def test_facebook_can_handle_common_urls(self):
         ch = FacebookChannel()
         assert ch.can_handle("https://www.facebook.com/zuck")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,7 +256,7 @@ class TestCLI:
             ["C:/Tools/npm.CMD", "install", "-g", backends.OPENCLI_PACKAGE]
         ]
 
-    def test_install_facebook_instagram_routes_to_opencli_once(self, monkeypatch, capsys):
+    def test_install_opencli_site_channels_route_to_opencli_once(self, monkeypatch, capsys):
         calls = []
 
         monkeypatch.setattr(cli, "_detect_environment", lambda: "local")
@@ -286,7 +286,7 @@ class TestCLI:
                 system=True,
                 safe=False,
                 dry_run=False,
-                channels="facebook,instagram,opencli",
+                channels="facebook,instagram,tiktok,opencli",
             )
         )
 
@@ -303,14 +303,14 @@ class TestCLI:
                 system=True,
                 safe=False,
                 dry_run=True,
-                channels="facebook,instagram,opencli,bilibili",
+                channels="facebook,instagram,tiktok,opencli,bilibili",
             )
         )
 
         out = capsys.readouterr().out
-        assert "服务器环境跳过：facebook, instagram, opencli" in out
+        assert "服务器环境跳过：facebook, instagram, opencli, tiktok" in out
         assert "[dry-run] Would install optional channels: bilibili" in out
-        assert "facebook, instagram, opencli, bilibili" not in out
+        assert "facebook, instagram, opencli, tiktok, bilibili" not in out
 
 
 class TestCheckUpdateRetry:


### PR DESCRIPTION
## Summary

- add a TikTok channel backed by the existing OpenCLI browser-session integration
- register TikTok in doctor and add a tiktok installer alias that resolves to OpenCLI
- route TikTok URLs, including www, mobile, and vt short links, with exact host-boundary checks
- document read-only profile, search, user, explore, and signed-in creator-metrics commands in the bundled skills and install guide
- update the platform count and Chinese/English capability docs

## Safety boundaries

- Agent Reach remains an installer, doctor, and router; agents call OpenCLI directly
- doctor does not execute a TikTok platform command or claim a verified login session
- the bundled guidance lists only read-only commands and explicitly excludes comment, follow, and like operations
- creator-videos is documented as data for the currently signed-in TikTok Studio account, not arbitrary creators

## Validation

- ruff check agent_reach tests
- mypy agent_reach
- pytest: 587 passed with the repository constraint set
- focused channel, CLI, and URL tests: 159 passed
- wheel build and smoke inspection: TikTok channel included, no duplicate entries

## Upstream capability source

- OpenCLI v1.8.6 release: https://github.com/jackwener/OpenCLI/releases/tag/v1.8.6
- OpenCLI v1.8.6 TikTok adapter docs: https://github.com/jackwener/OpenCLI/blob/v1.8.6/docs/adapters/browser/tiktok.md