### PR TITLE
fix(test): use relative editable path so test.sh runs on Windows

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -53,7 +53,15 @@ fi
 
 echo "[2/5] Installing this checkout and test dependencies"
 python -m pip install --quiet --upgrade pip
-python -m pip install --quiet -c "$REPO_ROOT/constraints.txt" -e "$REPO_ROOT[dev]"
+# Install the editable target from a subshell cd'd into the repo with a
+# relative ".[dev]". On Windows (Git Bash + native Python), an absolute
+# "$REPO_ROOT[dev]" defeats MSYS path conversion: the trailing [dev] makes
+# the argument look like a non-existent path, so the "/d/..." form is
+# passed through unchanged and native pip rejects it as "not a valid
+# editable requirement". A relative path avoids the conversion. The
+# constraints path is kept absolute on purpose: the file exists, so MSYS
+# converts it cleanly, and test_integration_script pins that exact spelling.
+( cd "$REPO_ROOT" && python -m pip install --quiet -c "$REPO_ROOT/constraints.txt" -e ".[dev]" )
 
 echo "[3/5] Verifying the installed CLI"
 agent-reach version


### PR DESCRIPTION
`test.sh` built the editable install target as `-e "$REPO_ROOT[dev]"`. On Windows with Git Bash + native Python, the trailing `[dev]` defeats MSYS path conversion: the argument no longer looks like an existing path, so the `/d/...` form is passed through unchanged and native pip rejects it as "not a valid editable requirement". The install step therefore aborted at [2/5] before any test could run.

Install from a subshell cd'd into the repo using a relative `.[dev]`, matching what CI already does on windows-latest. The constraints path stays absolute (`$REPO_ROOT/constraints.txt`): the file exists, so MSYS converts it cleanly, and `test_integration_script` pins that exact spelling.