### PR TITLE
fix: pip install update is a silent no-op for pipx installs (#610)

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -2190,14 +2190,49 @@ def _github_get_with_retry(url, timeout=10, retries=3, sleeper=time.sleep):
     return None, "unknown", retries
 
 
+def _detect_install_method() -> str:
+    """Detect how agent-reach was installed: 'pipx', 'venv', or 'pip'.
+
+    Returns 'pipx' when pipx manages the agent-reach app, 'venv' when the
+    running interpreter lives inside a virtual environment, and 'pip'
+    otherwise. Matters for update instructions: `pip install` is a silent
+    no-op for pipx installs (it updates user/system site-packages, not the
+    pipx venv the executable points at) — see issue #610.
+    """
+    import shutil
+    import subprocess
+
+    pipx = shutil.which("pipx")
+    if pipx:
+        try:
+            out = subprocess.run(
+                [pipx, "list"], capture_output=True, text=True, timeout=30
+            ).stdout
+        except Exception:
+            out = ""
+        if "agent-reach" in out:
+            return "pipx"
+
+    if getattr(sys, "base_prefix", None) != getattr(sys, "prefix", None):
+        return "venv"
+    return "pip"
+
+
 #: Full update = package + upstream tools + skill. The one-liner walks an
-#: agent through all three (docs/update.md); bare pip only updates the package.
-_UPDATE_INSTRUCTIONS = (
-    "更新方式（推荐，复制这句话给你的 AI Agent，会完整更新本体+上游工具+skill）：\n"
-    "  帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md\n"
-    "仅更新本体（不含上游工具和 skill）：\n"
-    "  pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip"
-)
+#: agent through all three (docs/update.md); the package command below only
+#: updates the package, tailored to how it was installed.
+def _update_instructions() -> str:
+    """Return update instructions tailored to the install method (see #610)."""
+    if _detect_install_method() == "pipx":
+        pkg_cmd = "pipx upgrade agent-reach"
+    else:
+        pkg_cmd = "pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip"
+    return (
+        "更新方式（推荐，复制这句话给你的 AI Agent，会完整更新本体+上游工具+skill）：\n"
+        "  帮我更新 Agent Reach：https://raw.githubusercontent.com/Panniantong/agent-reach/main/docs/update.md\n"
+        f"仅更新本体（不含上游工具和 skill）：\n"
+        f"  {pkg_cmd}"
+    )
 
 
 def _is_newer_version(remote: str, local: str) -> bool:
@@ -2247,7 +2282,7 @@ def _cmd_check_update():
                 for line in body.strip().split("\n")[:20]:
                     print(f"  {line}")
             print()
-            print(_UPDATE_INSTRUCTIONS)
+            print(_update_instructions())
             return "update_available"
         print("✅ 已是最新版本")
         return "up_to_date"
@@ -2269,7 +2304,7 @@ def _cmd_check_update():
         date = commit.get("commit", {}).get("committer", {}).get("date", "")[:10]
         print(f"最新提交: {sha} ({date}) {msg}")
         print()
-        print(_UPDATE_INSTRUCTIONS)
+        print(_update_instructions())
         return "unknown"
 
     commit_err = _classify_github_response_error(resp2)

--- a/docs/update.md
+++ b/docs/update.md
@@ -36,14 +36,22 @@ If it says "已是最新版本", skip to Step 4 (verify). Otherwise continue.
 
 ### Step 2: Update Agent Reach package
 
+Detect how it was installed first — `pip install` is a **silent no-op** for
+pipx installs (pip updates user/system site-packages, but the `agent-reach`
+executable points at the pipx venv, so the version never changes):
+
 ```bash
-pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip
+if pipx list 2>/dev/null | grep -q agent-reach; then
+  pipx upgrade agent-reach        # pipx reinstalls from its recorded source (main.zip)
+else
+  pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip
+fi
 ```
 
-> If pip complains about `externally-managed-environment` (PEP 668), the user
-> originally installed via pipx or a venv — use the matching command:
-> `pipx install --force https://github.com/Panniantong/agent-reach/archive/main.zip`
-> or activate `~/.agent-reach-venv` first.
+> If pip complains about `externally-managed-environment` (PEP 668), the
+> package lives in a venv — activate it first (e.g.
+> `source ~/.agent-reach-venv/bin/activate`) and re-run the `pip install`
+> command above.
 
 ### Step 3: Refresh upstream tools
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -412,6 +412,44 @@ class TestVersionCompare:
         assert cli._is_newer_version("1.5.0", "1.5.0-dev") is True
 
 
+class TestInstallMethodDetection:
+    """安装方式检测: pipx 装的必须用 `pipx upgrade`, 否则 pip install 静默无效(#610)。"""
+
+    def test_pipx_install_uses_pipx_upgrade(self, monkeypatch):
+        class R:
+            stdout = "package agent-reach, installed using Python 3.13\n"
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/pipx")
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: R())
+        assert cli._detect_install_method() == "pipx"
+
+    def test_pipx_absent_falls_back_to_pip(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        monkeypatch.setattr("agent_reach.cli.sys", type("S", (), {"base_prefix": "/a", "prefix": "/a"})())
+        assert cli._detect_install_method() == "pip"
+
+    def test_venv_install_detected(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        monkeypatch.setattr("agent_reach.cli.sys", type("S", (), {"base_prefix": "/usr", "prefix": "/usr/venv"})())
+        assert cli._detect_install_method() == "venv"
+
+    def test_update_instructions_pipx(self, monkeypatch):
+        class R:
+            stdout = "package agent-reach, installed using Python 3.13\n"
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/pipx")
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: R())
+        text = cli._update_instructions()
+        assert "pipx upgrade agent-reach" in text
+        assert "pip install --upgrade" not in text
+
+    def test_update_instructions_pip(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        monkeypatch.setattr("agent_reach.cli.sys", type("S", (), {"base_prefix": "/a", "prefix": "/a"})())
+        text = cli._update_instructions()
+        assert "pip install --upgrade https://github.com/Panniantong/agent-reach/archive/main.zip" in text
+
+
 class TestWatchVersionCompare:
     def test_watch_does_not_prompt_downgrade(self, monkeypatch, capsys):
         """watch 与 check-update 同语义:本地领先远端 release 时不提示更新。"""


### PR DESCRIPTION
Closes #610

## Problem

\docs/update.md\ Step 2 and the \check-update\ output (\_UPDATE_INSTRUCTIONS\) tell users to run \pip install --upgrade <archive-url>\. For pipx installs (the officially recommended method), this is a **silent no-op**: pip updates user/system site-packages, but the \gent-reach\ executable points at the pipx venv - the version never changes and no error is shown.

## Fix

Detect the install method and emit the matching update command:

- **pipx installs** -> \pipx upgrade agent-reach\ (pipx reinstalls from its recorded main.zip source)
- **pip installs** -> existing \pip install --upgrade <archive-url>\
- **venv installs** -> same pip command, with the PEP 668 note already covering activation

## Changes

- \gent_reach/cli.py\: \_detect_install_method()\ + \_update_instructions()\ replacing the static \_UPDATE_INSTRUCTIONS\ constant (used by \check-update\ and \watch\)
- \docs/update.md\: Step 2 now detects the install method first
- \	ests/test_cli.py\: 5 new tests covering pipx / venv / pip detection and instruction output

## Verification

- \pytest tests/test_cli.py tests/test_p0_cli.py\ -> 81 passed