### PR TITLE
perf(doctor): run channel checks concurrently (12.4s -> 5.2s)

### DIFF
--- a/agent_reach/doctor.py
+++ b/agent_reach/doctor.py
@@ -4,45 +4,70 @@
 Each channel knows how to check itself. Doctor just collects the results.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
 
 from rich.markup import escape
 
-from agent_reach.channels import get_all_channels
+from agent_reach.channels import Channel, get_all_channels
 from agent_reach.config import Config
 from agent_reach.utils.text import scrub_url_credentials
+
+#: Upper bound on concurrent channel checks. Each check is IO-bound (it waits
+#: on an upstream subprocess), so the cap exists to avoid spawning a dozen
+#: browsers/node processes at once on small machines, not for CPU reasons.
+MAX_CHECK_WORKERS = 8
+
+
+def _check_one(ch: Channel, config: Config) -> dict:
+    """Run one channel's check and normalize it into a result dict.
+
+    A single misbehaving channel must never take the whole report down,
+    so per-channel exceptions degrade to status="error".
+    """
+    try:
+        status, message = ch.check(config)
+        active = getattr(ch, "active_backend", None)
+    except Exception as e:  # noqa: BLE001 — doctor must survive any channel
+        # Channels are registry singletons: a stale active_backend from a
+        # previous check must not leak into an errored result.
+        status = "error"
+        message = f"体检异常：{e}"
+        active = None
+    # Doctor is the final output boundary for both expected channel
+    # messages and unexpected exceptions. Upstream probe output can echo a
+    # configured URL, so scrub every path before JSON/text rendering.
+    return {
+        "status": status,
+        "name": ch.description,
+        "message": scrub_url_credentials(message),
+        "tier": ch.tier,
+        "backends": ch.backends,
+        "active_backend": active,
+    }
 
 
 def check_all(config: Config) -> Dict[str, dict]:
     """Check all channels and return status dict.
 
-    A single misbehaving channel must never take the whole report down,
-    so per-channel exceptions degrade to status="error".
+    Checks run concurrently. Every channel probes its upstream CLI with a
+    multi-second timeout, so a serial sweep costs the SUM of all probes — one
+    slow or timing-out backend delays every channel behind it. Each channel is
+    still visited exactly once by exactly one worker, so `check()` keeps its
+    single-threaded contract with respect to its own `active_backend`.
+
+    Result order follows the registry, not completion order, so the report
+    stays stable between runs.
     """
-    results = {}
-    for ch in get_all_channels():
-        try:
-            status, message = ch.check(config)
-            active = getattr(ch, "active_backend", None)
-        except Exception as e:  # noqa: BLE001 — doctor must survive any channel
-            # Channels are registry singletons: a stale active_backend from a
-            # previous check must not leak into an errored result.
-            status = "error"
-            message = f"体检异常：{e}"
-            active = None
-        # Doctor is the final output boundary for both expected channel
-        # messages and unexpected exceptions. Upstream probe output can echo a
-        # configured URL, so scrub every path before JSON/text rendering.
-        message = scrub_url_credentials(message)
-        results[ch.name] = {
-            "status": status,
-            "name": ch.description,
-            "message": message,
-            "tier": ch.tier,
-            "backends": ch.backends,
-            "active_backend": active,
-        }
-    return results
+    channels = get_all_channels()
+    if not channels:
+        return {}
+
+    workers = min(len(channels), MAX_CHECK_WORKERS)
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="doctor") as pool:
+        outcomes = list(pool.map(lambda ch: _check_one(ch, config), channels))
+
+    return {ch.name: outcome for ch, outcome in zip(channels, outcomes)}
 
 
 def _name_msg(r: dict, escape) -> str:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -114,6 +114,120 @@ class TestDoctor:
         assert "可选渠道可以解锁" in plain
 
 
+class TestConcurrentChecks:
+    """check_all fans channels out; slow backends must not serialize."""
+
+    def test_checks_run_concurrently(self, tmp_config, monkeypatch):
+        import threading
+
+        started = threading.Barrier(3, timeout=10)
+
+        class _BarrierChannel(_StubChannel):
+            def check(self, config=None):
+                # Deadlocks (and fails the test) unless all three run at once.
+                started.wait()
+                return self._status, self._message
+
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [
+                _BarrierChannel(f"ch{i}", f"渠道{i}", 0, "ok", "可用", ["b"])
+                for i in range(3)
+            ],
+        )
+
+        results = doctor.check_all(tmp_config)
+
+        assert [r["status"] for r in results.values()] == ["ok"] * 3
+
+    def test_result_order_follows_registry_not_completion(self, tmp_config, monkeypatch):
+        import time
+
+        class _SlowChannel(_StubChannel):
+            def check(self, config=None):
+                time.sleep(0.05)  # finishes last, must still be reported first
+                return self._status, self._message
+
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [
+                _SlowChannel("slow", "慢渠道", 0, "ok", "可用", ["b"]),
+                _StubChannel("fast", "快渠道", 0, "ok", "可用", ["b"]),
+            ],
+        )
+
+        assert list(doctor.check_all(tmp_config)) == ["slow", "fast"]
+
+    def test_each_channel_is_checked_exactly_once(self, tmp_config, monkeypatch):
+        calls = []
+
+        class _CountingChannel(_StubChannel):
+            def check(self, config=None):
+                calls.append(self.name)
+                return self._status, self._message
+
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [
+                _CountingChannel(f"ch{i}", f"渠道{i}", 0, "ok", "可用", ["b"])
+                for i in range(5)
+            ],
+        )
+
+        doctor.check_all(tmp_config)
+
+        assert sorted(calls) == [f"ch{i}" for i in range(5)]
+
+    def test_one_crashing_channel_does_not_abort_the_others(self, tmp_config, monkeypatch):
+        class _ExplodingChannel(_StubChannel):
+            def check(self, config=None):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [
+                _ExplodingChannel("boom", "爆炸渠道", 0, "ok", "", ["b"]),
+                _StubChannel("web", "网页", 0, "ok", "可用", ["b"]),
+            ],
+        )
+
+        results = doctor.check_all(tmp_config)
+
+        assert results["boom"]["status"] == "error"
+        assert results["web"]["status"] == "ok"
+
+    def test_empty_registry_returns_empty_dict(self, tmp_config, monkeypatch):
+        # ThreadPoolExecutor(max_workers=0) raises; the empty case short-circuits.
+        monkeypatch.setattr(doctor, "get_all_channels", lambda: [])
+        assert doctor.check_all(tmp_config) == {}
+
+    def test_worker_count_is_capped(self, tmp_config, monkeypatch):
+        seen = {}
+        real_pool = doctor.ThreadPoolExecutor
+
+        def spy(*args, **kwargs):
+            seen["workers"] = kwargs.get("max_workers")
+            return real_pool(*args, **kwargs)
+
+        monkeypatch.setattr(doctor, "ThreadPoolExecutor", spy)
+        monkeypatch.setattr(
+            doctor,
+            "get_all_channels",
+            lambda: [
+                _StubChannel(f"ch{i}", f"渠道{i}", 0, "ok", "可用", ["b"])
+                for i in range(50)
+            ],
+        )
+
+        doctor.check_all(tmp_config)
+
+        assert seen["workers"] == doctor.MAX_CHECK_WORKERS
+
+
 def test_stale_active_backend_does_not_leak_into_errored_result(monkeypatch):
     """渠道单例上一轮的 active_backend 不得泄漏进本轮异常结果(Codex review 发现)。"""
     from agent_reach import doctor


### PR DESCRIPTION
Been using this for a while and finally sat down to read the code properly. Really nice project, honestly impressed by the multi-backend routing idea 👍

One thing I kept noticing: `doctor` is slow, and it's the command SKILL.md tells the agent to run before doing anything. Turns out `check_all` walks the registry one channel at a time, and almost every channel shells out to its upstream CLI with a 10s timeout (some with retries). So the total is the sum of every probe, and one slow backend holds up the 14 behind it.

Switched it to a thread pool. The work is all waiting on subprocesses, so I capped it at 8 workers just to avoid spawning a pile of node/browser processes at once on a small box, not for CPU reasons.

On my machine, same env, back to back:

```
before: 12.45s
after:   5.24s
```

Side effect: the test suite went from 109s to 50s, since a lot of it runs real checks.

Things I was careful about:

- every channel is still touched by exactly one worker, so `check()` keeps its single-threaded relationship with its own `active_backend`. I didn't introduce any shared state between channels.
- results get reordered back to registry order before returning, so the report and the JSON key order don't shuffle between runs.
- the exception isolation, the stale `active_backend` guard and `scrub_url_credentials` all moved into `_check_one` untouched.
- empty registry returns early, `ThreadPoolExecutor(max_workers=0)` throws.

All 571 existing tests still pass, including the zero-write doctor audit test. Added 6 for the concurrency itself. The first one uses a `threading.Barrier`, so if anyone ever puts the loop back to serial that test deadlocks and fails instead of silently passing.
