### PR TITLE
feat(cli): add `agent-reach route` for URL to channel/backend/command

### DIFF
--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -55,9 +55,31 @@ def get_all_channels() -> List[Channel]:
     return ALL_CHANNELS
 
 
+def get_channel_for_url(url: str) -> Channel:
+    """Route a URL to the channel that owns it.
+
+    WebChannel.can_handle() is True for every URL, so it is skipped during
+    matching and used as the fallback — otherwise its registry position would
+    decide the answer. A channel whose can_handle() raises is skipped rather
+    than allowed to break routing for every other platform.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("url 不能为空")
+    for ch in ALL_CHANNELS:
+        if ch.name == "web":
+            continue
+        try:
+            if ch.can_handle(url):
+                return ch
+        except Exception:  # noqa: BLE001 — one bad matcher must not break routing
+            continue
+    return get_channel("web")
+
+
 __all__ = [
     "Channel",
     "ALL_CHANNELS",
     "get_channel",
     "get_all_channels",
+    "get_channel_for_url",
 ]

--- a/agent_reach/channels/base.py
+++ b/agent_reach/channels/base.py
@@ -23,7 +23,7 @@ Backend routing semantics:
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 class Channel(ABC):
@@ -36,6 +36,17 @@ class Channel(ABC):
 
     #: Backend currently serving this channel; set by check(), None = unavailable.
     active_backend: Optional[str] = None
+
+    #: Skill reference doc covering this platform, e.g. "social" →
+    #: agent_reach/skill/references/social.md. Used by `agent-reach route`.
+    reference: str = ""
+
+    #: backend name → command template for reading ONE URL, `{url}` substituted.
+    #: Only backends whose upstream CLI documents accepting a URL/ID belong
+    #: here: `route` prints these verbatim for an agent to run, so an invented
+    #: flag would be worse than no entry at all. Backends absent from this map
+    #: still route correctly — the agent is sent to the reference doc instead.
+    url_commands: Dict[str, str] = {}
 
     @abstractmethod
     def can_handle(self, url: str) -> bool:
@@ -57,6 +68,19 @@ class Channel(ABC):
                     candidates.insert(0, candidates.pop(i))
                     break
         return candidates
+
+    def commands_for_url(self, url: str, config=None) -> List[Tuple[str, str]]:
+        """(backend, command) pairs for reading `url`, in probe order.
+
+        Backends without a documented URL-accepting command are skipped, so an
+        empty list means "read the reference doc", never "this URL is
+        unsupported".
+        """
+        return [
+            (backend, self.url_commands[backend].replace("{url}", url))
+            for backend in self.ordered_backends(config)
+            if backend in self.url_commands
+        ]
 
     def check(self, config=None) -> Tuple[str, str]:
         """

--- a/agent_reach/channels/bilibili.py
+++ b/agent_reach/channels/bilibili.py
@@ -37,6 +37,8 @@ class BilibiliChannel(Channel):
     description = "B站视频、字幕和搜索"
     backends = ["bili-cli", "OpenCLI", "B站搜索 API"]
     tier = 1
+    reference = "social"
+    # bili/opencli take a BV id, not a URL — see references/social.md.
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/exa_search.py
+++ b/agent_reach/channels/exa_search.py
@@ -12,6 +12,7 @@ class ExaSearchChannel(Channel):
     description = "全网语义搜索"
     backends = ["Exa via mcporter"]
     tier = 0
+    reference = "search"
 
     def can_handle(self, url: str) -> bool:
         return False  # Search-only channel

--- a/agent_reach/channels/facebook.py
+++ b/agent_reach/channels/facebook.py
@@ -10,4 +10,5 @@ class FacebookChannel(OpenCLISiteChannel):
     site = "facebook"
     domains = ("facebook.com", "fb.com", "fb.watch")
     usage = "opencli facebook search/profile/feed/groups -f yaml"
+    reference = "social"
     login_hint = "facebook.com"

--- a/agent_reach/channels/github.py
+++ b/agent_reach/channels/github.py
@@ -97,6 +97,8 @@ class GitHubChannel(Channel):
     description = "GitHub 仓库和代码"
     backends = ["gh CLI"]
     tier = 0
+    reference = "dev"
+    url_commands = {"gh CLI": 'gh repo view "{url}"'}
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/instagram.py
+++ b/agent_reach/channels/instagram.py
@@ -10,4 +10,5 @@ class InstagramChannel(OpenCLISiteChannel):
     site = "instagram"
     domains = ("instagram.com", "instagr.am")
     usage = "opencli instagram search/profile/user/explore -f yaml"
+    reference = "social"
     login_hint = "instagram.com"

--- a/agent_reach/channels/linkedin.py
+++ b/agent_reach/channels/linkedin.py
@@ -25,6 +25,8 @@ class LinkedInChannel(Channel):
     description = "LinkedIn 职业社交"
     backends = ["mcp-server-linkedin", "Jina Reader"]
     tier = 2
+    reference = "career"
+    url_commands = {"Jina Reader": 'curl -s "https://r.jina.ai/{url}"'}
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/reddit.py
+++ b/agent_reach/channels/reddit.py
@@ -32,6 +32,8 @@ class RedditChannel(Channel):
     description = "Reddit 帖子和评论"
     backends = ["OpenCLI", "rdt-cli"]
     tier = 1  # no zero-config path exists — see module docstring
+    reference = "social"
+    # Both backends read by POST_ID, not URL — see references/social.md.
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/rss.py
+++ b/agent_reach/channels/rss.py
@@ -9,6 +9,14 @@ class RSSChannel(Channel):
     description = "RSS/Atom 订阅源"
     backends = ["feedparser"]
     tier = 0
+    reference = "web"
+    url_commands = {
+        "feedparser": (
+            'python -c "import feedparser,sys;'
+            '[print(e.title, e.link) for e in feedparser.parse(sys.argv[1]).entries[:10]]"'
+            ' "{url}"'
+        )
+    }
 
     def can_handle(self, url: str) -> bool:
         return any(x in url.lower() for x in ["/feed", "/rss", ".xml", "atom"])

--- a/agent_reach/channels/twitter.py
+++ b/agent_reach/channels/twitter.py
@@ -36,6 +36,10 @@ class TwitterChannel(Channel):
     description = "Twitter/X 推文"
     backends = ["twitter-cli", "OpenCLI", "bird CLI (legacy)"]
     tier = 1
+    reference = "social"
+    # twitter-cli documents `tweet URL_OR_ID`; the other two backends have no
+    # documented single-URL read, so they are intentionally absent.
+    url_commands = {"twitter-cli": 'twitter tweet "{url}"'}
 
     def can_handle(self, url: str) -> bool:
         return host_matches(url, "x.com", "twitter.com")

--- a/agent_reach/channels/v2ex.py
+++ b/agent_reach/channels/v2ex.py
@@ -142,6 +142,8 @@ class V2EXChannel(Channel):
     description = "V2EX 节点、主题与回复"
     backends = ["V2EX API (public)"]
     tier = 0
+    reference = "social"
+    # The API keys off a topic id (/t/<id>), not the URL — see social.md.
 
     # ------------------------------------------------------------------ #
     # URL routing

--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -36,6 +36,8 @@ class WebChannel(Channel):
     description = "任意网页"
     backends = ["Jina Reader"]
     tier = 0
+    reference = "web"
+    url_commands = {"Jina Reader": 'curl -s "https://r.jina.ai/{url}"'}
 
     def can_handle(self, url: str) -> bool:
         return True  # Fallback — handles any URL

--- a/agent_reach/channels/xiaohongshu.py
+++ b/agent_reach/channels/xiaohongshu.py
@@ -162,6 +162,11 @@ class XiaoHongShuChannel(Channel):
     description = "小红书笔记"
     backends = ["OpenCLI", "xiaohongshu-mcp", "xhs-cli (xiaohongshu-cli)"]
     tier = 1
+    reference = "social"
+    url_commands = {
+        "OpenCLI": 'opencli xiaohongshu note "{url}" -f yaml',
+        "xhs-cli (xiaohongshu-cli)": 'xhs read "{url}"',
+    }
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/xiaoyuzhou.py
+++ b/agent_reach/channels/xiaoyuzhou.py
@@ -14,6 +14,8 @@ class XiaoyuzhouChannel(Channel):
     description = "小宇宙播客转文字"
     backends = ["groq-whisper", "ffmpeg"]
     tier = 1
+    reference = "video"
+    url_commands = {"groq-whisper": 'agent-reach transcribe "{url}"'}
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/channels/xueqiu.py
+++ b/agent_reach/channels/xueqiu.py
@@ -116,6 +116,7 @@ class XueqiuChannel(Channel):
     description = "雪球股票行情与社区动态"
     backends = ["Xueqiu API (需要登录 Cookie)"]
     tier = 1
+    reference = "finance"
 
     # ------------------------------------------------------------------ #
     # URL routing

--- a/agent_reach/channels/youtube.py
+++ b/agent_reach/channels/youtube.py
@@ -41,6 +41,13 @@ class YouTubeChannel(Channel):
     description = "YouTube 视频和字幕"
     backends = ["yt-dlp"]
     tier = 0
+    reference = "video"
+    url_commands = {
+        "yt-dlp": (
+            'yt-dlp --write-sub --write-auto-sub --skip-download '
+            '-o "/tmp/%(id)s" "{url}"'
+        )
+    }
 
     def can_handle(self, url: str) -> bool:
         from agent_reach.utils.url import host_matches

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -132,6 +132,13 @@ def main():
     p_doctor.add_argument("--json", action="store_true",
                           help="Output machine-readable JSON instead of the text report")
 
+    # ── route ──
+    p_route = sub.add_parser(
+        "route", help="Show which channel and command handle a URL")
+    p_route.add_argument("url", help="The URL to route")
+    p_route.add_argument("--json", action="store_true",
+                         help="Output machine-readable JSON instead of the text report")
+
     # ── uninstall ──
     p_uninstall = sub.add_parser("uninstall", help="Remove all Agent Reach config, tokens, and skill files")
     p_uninstall.add_argument("--dry-run", action="store_true",
@@ -228,6 +235,8 @@ def main():
 
     if args.command == "doctor":
         _cmd_doctor(args)
+    elif args.command == "route":
+        _cmd_route(args)
     elif args.command == "check-update":
         _cmd_check_update()
     elif args.command == "watch":
@@ -1986,6 +1995,65 @@ def _cmd_doctor(args=None):
         print(report)
     else:
         rich_print(report)
+
+
+def _cmd_route(args):
+    """Answer 'I have this URL — which platform, which command?' in one call.
+
+    Pure metadata: no upstream process is spawned and no config is written, so
+    this stays fast enough for an agent to call per URL. Run `doctor` when the
+    question is which backend is live right now.
+    """
+    from agent_reach.channels import get_channel_for_url
+    from agent_reach.config import Config
+
+    try:
+        channel = get_channel_for_url(args.url)
+    except ValueError as exc:
+        print(f"[X] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    config = Config(read_only=True)
+    commands = channel.commands_for_url(args.url, config)
+    reference = (
+        f"agent_reach/skill/references/{channel.reference}.md"
+        if channel.reference else ""
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "url": args.url,
+            "channel": channel.name,
+            "description": channel.description,
+            "tier": channel.tier,
+            "backends": channel.ordered_backends(config),
+            "commands": [
+                {"backend": backend, "command": command}
+                for backend, command in commands
+            ],
+            "usage": getattr(channel, "usage", ""),
+            "reference": reference,
+        }, ensure_ascii=False, indent=2))
+        return
+
+    print(f"URL      : {args.url}")
+    print(f"渠道     : {channel.name} — {channel.description}")
+    print(f"后端顺序 : {'、'.join(channel.ordered_backends(config)) or '内置'}")
+    if commands:
+        print("命令     :")
+        for backend, command in commands:
+            print(f"  [{backend}] {command}")
+    else:
+        # Every backend here reads by id/keyword rather than URL; sending the
+        # agent to the reference doc beats printing a command that won't run.
+        usage = getattr(channel, "usage", "")
+        if usage:
+            print(f"命令     : {usage}")
+        else:
+            print("命令     : 该渠道按 id/关键词读取，不接受整条 URL")
+    if reference:
+        print(f"参考文档 : {reference}")
+    print("提示     : 运行 `agent-reach doctor --json` 查看当前实际生效的后端")
 
 
 def _cmd_setup():

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -110,7 +110,14 @@ opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
 ```bash
 # 检查可用 channel 与每个平台当前激活的后端
 agent-reach doctor --json
+
+# 拿到一条 URL 但不确定归哪个平台/该跑什么命令时（纯元数据，不触网、不写盘）
+agent-reach route --json "URL"
 ```
+
+`route` 返回该 URL 的 channel、按优先级排好的 backends、以及可直接执行的命令；
+某些平台按 id/关键词读取（B站/Reddit/V2EX），此时 `commands` 为空，按返回的
+`reference` 去读对应文档。
 
 ## OpenCLI 适配器发现
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -116,7 +116,15 @@ opencli instagram user USERNAME -f yaml        # recent posts from one user
 ```bash
 # Channel availability + which backend serves each platform
 agent-reach doctor --json
+
+# Given a URL, which platform is it and what should I run?
+# Pure metadata: no network calls, no subprocesses, no writes.
+agent-reach route --json "URL"
 ```
+
+`route` returns the channel, its backends in priority order, and ready-to-run
+commands. Some platforms read by id/keyword rather than URL (Bilibili, Reddit,
+V2EX); there `commands` is empty — follow the returned `reference` doc.
 
 ## Discovering OpenCLI adapters
 

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""Tests for URL routing and the `agent-reach route` command."""
+
+import json
+from argparse import Namespace
+
+import pytest
+
+from agent_reach import cli
+from agent_reach.channels import (
+    ALL_CHANNELS,
+    Channel,
+    get_all_channels,
+    get_channel,
+    get_channel_for_url,
+)
+
+
+class TestRouting:
+    @pytest.mark.parametrize("url,expected", [
+        ("https://github.com/Panniantong/Agent-Reach", "github"),
+        ("https://x.com/user/status/123", "twitter"),
+        ("https://twitter.com/user/status/123", "twitter"),
+        ("https://www.youtube.com/watch?v=abc", "youtube"),
+        ("https://youtu.be/abc", "youtube"),
+        ("https://www.reddit.com/r/LocalLLaMA/comments/abc", "reddit"),
+        ("https://redd.it/abc", "reddit"),
+        ("https://www.facebook.com/zuck", "facebook"),
+        ("https://www.instagram.com/nasa", "instagram"),
+        ("https://www.bilibili.com/video/BV1xx", "bilibili"),
+        ("https://b23.tv/abc", "bilibili"),
+        ("https://www.xiaohongshu.com/explore/abc", "xiaohongshu"),
+        ("https://xhslink.com/abc", "xiaohongshu"),
+        ("https://www.linkedin.com/in/someone", "linkedin"),
+        ("https://www.xiaoyuzhoufm.com/episode/abc", "xiaoyuzhou"),
+        ("https://www.v2ex.com/t/123", "v2ex"),
+        ("https://xueqiu.com/S/SH601138", "xueqiu"),
+        ("https://example.com/feed.xml", "rss"),
+        ("https://example.com/article", "web"),
+    ])
+    def test_url_routes_to_expected_channel(self, url, expected):
+        assert get_channel_for_url(url).name == expected
+
+    def test_web_is_the_fallback_not_the_first_match(self):
+        # WebChannel.can_handle() is True for everything; a specific channel wins
+        # regardless of registry order.
+        assert get_channel_for_url("https://github.com/a/b").name == "github"
+
+    @pytest.mark.parametrize("bad", ["", "   ", None, 123])
+    def test_empty_or_non_string_url_is_rejected(self, bad):
+        with pytest.raises(ValueError):
+            get_channel_for_url(bad)
+
+    def test_a_raising_matcher_does_not_break_routing(self, monkeypatch):
+        class _Exploding(Channel):
+            name = "exploding"
+            description = "爆炸渠道"
+
+            def can_handle(self, url):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            "agent_reach.channels.ALL_CHANNELS",
+            [_Exploding(), *ALL_CHANNELS],
+        )
+        assert get_channel_for_url("https://github.com/a/b").name == "github"
+
+
+class TestChannelMetadata:
+    def test_every_channel_declares_a_reference_doc(self):
+        for ch in get_all_channels():
+            assert ch.reference, f"{ch.name} has no reference doc"
+
+    def test_reference_docs_exist_on_disk(self):
+        from pathlib import Path
+
+        import agent_reach
+
+        refs = Path(agent_reach.__file__).parent / "skill" / "references"
+        for ch in get_all_channels():
+            assert (refs / f"{ch.reference}.md").is_file(), (
+                f"{ch.name} points at a missing reference: {ch.reference}.md"
+            )
+
+    def test_url_commands_only_name_declared_backends(self):
+        # A template keyed by a backend that is not a candidate would silently
+        # never be emitted.
+        for ch in get_all_channels():
+            unknown = set(ch.url_commands) - set(ch.backends)
+            assert not unknown, f"{ch.name} has url_commands for {unknown}"
+
+    def test_url_command_templates_carry_the_placeholder(self):
+        for ch in get_all_channels():
+            for backend, template in ch.url_commands.items():
+                assert "{url}" in template, f"{ch.name}/{backend} lacks {{url}}"
+
+
+class TestCommandsForUrl:
+    def test_substitutes_the_url(self):
+        commands = get_channel("youtube").commands_for_url("https://youtu.be/abc")
+        assert commands
+        for _, command in commands:
+            assert "https://youtu.be/abc" in command
+            assert "{url}" not in command
+
+    def test_follows_backend_order(self):
+        commands = get_channel("xiaohongshu").commands_for_url("https://xhslink.com/a")
+        assert [backend for backend, _ in commands] == [
+            "OpenCLI",
+            "xhs-cli (xiaohongshu-cli)",
+        ]
+
+    def test_honours_a_backend_override(self, tmp_path):
+        from agent_reach.config import Config
+
+        config = Config(config_path=tmp_path / "config.yaml")
+        config.set("xiaohongshu_backend", "xhs-cli (xiaohongshu-cli)")
+
+        commands = get_channel("xiaohongshu").commands_for_url(
+            "https://xhslink.com/a", config
+        )
+
+        assert commands[0][0] == "xhs-cli (xiaohongshu-cli)"
+
+    def test_backends_without_a_url_command_are_skipped(self):
+        # bilibili reads by BV id — no backend may claim to take a URL.
+        assert get_channel("bilibili").commands_for_url("https://b23.tv/a") == []
+
+
+class TestRouteCommand:
+    def test_text_output(self, capsys):
+        cli._cmd_route(Namespace(url="https://youtu.be/abc", json=False))
+        out = capsys.readouterr().out
+        assert "youtube" in out
+        assert "yt-dlp" in out
+        assert "https://youtu.be/abc" in out
+        assert "video.md" in out
+
+    def test_json_output(self, capsys):
+        cli._cmd_route(Namespace(url="https://github.com/a/b", json=True))
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["channel"] == "github"
+        assert payload["backends"] == ["gh CLI"]
+        assert payload["commands"][0]["backend"] == "gh CLI"
+        assert "https://github.com/a/b" in payload["commands"][0]["command"]
+
+    def test_id_based_channel_explains_itself_instead_of_faking_a_command(self, capsys):
+        cli._cmd_route(Namespace(url="https://www.bilibili.com/video/BV1xx", json=False))
+        out = capsys.readouterr().out
+        assert "不接受整条 URL" in out
+        assert "social.md" in out
+
+    def test_opencli_channel_falls_back_to_its_usage_line(self, capsys):
+        cli._cmd_route(Namespace(url="https://www.facebook.com/zuck", json=False))
+        assert "opencli facebook" in capsys.readouterr().out
+
+    def test_unknown_host_falls_back_to_web(self, capsys):
+        cli._cmd_route(Namespace(url="https://example.com/post", json=True))
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["channel"] == "web"
+        assert "r.jina.ai" in payload["commands"][0]["command"]
+
+    def test_empty_url_exits_1(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cli._cmd_route(Namespace(url="   ", json=False))
+        assert exc.value.code == 1
+        assert capsys.readouterr().err.strip()
+
+    def test_route_never_spawns_a_subprocess(self, monkeypatch, capsys):
+        import subprocess
+
+        def explode(*args, **kwargs):
+            raise AssertionError("route must stay probe-free")
+
+        monkeypatch.setattr(subprocess, "run", explode)
+        monkeypatch.setattr(subprocess, "Popen", explode)
+
+        cli._cmd_route(Namespace(url="https://x.com/u/status/1", json=True))
+
+        assert json.loads(capsys.readouterr().out)["channel"] == "twitter"
+
+    def test_route_writes_nothing_to_disk(self, tmp_path, monkeypatch, capsys):
+        from agent_reach.config import Config
+
+        target = tmp_path / "never" / "config.yaml"
+        monkeypatch.setattr(Config, "CONFIG_DIR", target.parent)
+        monkeypatch.setattr(Config, "CONFIG_FILE", target)
+
+        cli._cmd_route(Namespace(url="https://youtu.be/abc", json=True))
+
+        assert not target.parent.exists()


### PR DESCRIPTION
Follow-up to #613, separate branch so you can take them independently.

While I was in the channels code for the doctor change I hit something else. When my agent has a URL in hand, there's no way for it to ask which platform owns it and what to run. That mapping only exists as prose in SKILL.md plus the reference docs, so the agent has to read the skill and work it out. `doctor --json` tells it what's healthy, never what handles this particular link.

So, `agent-reach route <url>`, with `--json` for the agent:

```
$ agent-reach route https://www.xiaohongshu.com/explore/abc
URL      : https://www.xiaohongshu.com/explore/abc
渠道     : xiaohongshu — 小红书笔记
后端顺序 : OpenCLI、xiaohongshu-mcp、xhs-cli (xiaohongshu-cli)
命令     :
  [OpenCLI] opencli xiaohongshu note "https://www.xiaohongshu.com/explore/abc" -f yaml
  [xhs-cli (xiaohongshu-cli)] xhs read "https://www.xiaohongshu.com/explore/abc"
参考文档 : agent_reach/skill/references/social.md
提示     : 运行 `agent-reach doctor --json` 查看当前实际生效的后端
```

The part I'd most want your opinion on is where the commands come from. I did not want this thing guessing CLI flags, so there's a per-channel `url_commands` map and I only filled in backends where your own references show the tool taking a URL or ID: twitter-cli `tweet URL_OR_ID`, `opencli xiaohongshu note NOTE_URL`, `xhs read NOTE_ID_OR_URL`, yt-dlp, Jina Reader, feedparser. Bilibili, Reddit and V2EX read by id or keyword, so they print no command at all and send the agent to the reference doc. Printing something that looks right but doesn't run seemed worse than printing nothing.

Rest of it:

- `WebChannel.can_handle()` is True for everything, so routing skips it while matching and only falls back to it. Otherwise where it sits in the registry would decide every answer.
- if a channel's `can_handle` throws, it gets skipped rather than breaking routing for everything else. Same thing doctor already does with `check()`.
- no subprocess, no network, no writes, `Config(read_only=True)`. It's meant to be cheap enough to call per URL. Two tests hold that line: one makes `subprocess.run` and `Popen` raise, one asserts the config dir never gets created.
- goes through the existing `ordered_backends()`, so a `<channel>_backend` override moves the command to the front too and route agrees with doctor.

Also gave every channel a `reference` field so the routing table has a machine-readable pointer to the doc the agent should read next. There's a test that opens each one, so it fails if a reference doc gets renamed.

Documented in both SKILL.md and SKILL_en.md under the environment check section, since that's where an agent is already looking.

571 existing tests still pass, 41 new ones in `tests/test_route.py`: routing for all 15 channels, the fallback, bad input, `{url}` substitution and ordering, the override, plus consistency checks that no `url_commands` key names a backend that isn't declared and every template actually contains the placeholder.
