### PR TITLE
fix(cli): use resolved mcporter path as subprocess argv0 (fixes #590)

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -1904,7 +1904,8 @@ def _cmd_uninstall(args):
                     print(f"  Could not remove {skill_path}: {e}")
 
     # ── 3. mcporter MCP entries ──
-    if shutil.which("mcporter"):
+    mcporter_cmd = shutil.which("mcporter")
+    if mcporter_cmd:
         from agent_reach.channels.mcporter import (
             McporterConfigError,
             configured_server_names,
@@ -1913,7 +1914,7 @@ def _cmd_uninstall(args):
         try:
             result = subprocess.run(
                 [
-                    "mcporter",
+                    mcporter_cmd,
                     "config",
                     "list",
                     "--json",
@@ -2006,7 +2007,8 @@ def _cmd_setup():
     print("【推荐】全网搜索 — Exa（通过 mcporter）")
     print("  免费，无需 API Key")
 
-    if not shutil.which("mcporter"):
+    mcporter_cmd = shutil.which("mcporter")
+    if not mcporter_cmd:
         print("  当前状态: -- mcporter 未安装")
         print("  安装：npm install -g mcporter")
         print("  然后：mcporter config add exa https://mcp.exa.ai/mcp --scope home")
@@ -2019,7 +2021,7 @@ def _cmd_setup():
             )
 
             r = subprocess.run(
-                ["mcporter", "config", "list", "--json"],
+                [mcporter_cmd, "config", "list", "--json"],
                 capture_output=True,
                 encoding="utf-8",
                 errors="replace",
@@ -2035,7 +2037,7 @@ def _cmd_setup():
                 if setup_now in ("", "y", "yes"):
                     add_r = subprocess.run(
                         [
-                            "mcporter",
+                            mcporter_cmd,
                             "config",
                             "add",
                             "exa",

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -1357,3 +1357,62 @@ def test_uninstall_preserves_mcporter_entries_without_agent_reach_provenance(
     output = capsys.readouterr().out
     assert not any("remove" in call for call in calls)
     assert "来源无法证明" in output
+
+
+def test_uninstall_mcporter_cleanup_uses_resolved_command(
+    isolated_home, monkeypatch, capsys
+):
+    """Windows npm installs mcporter.cmd; argv0 must be the resolved path."""
+    calls = []
+    resolved = "/fake/bin/mcporter"
+
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: resolved if name == "mcporter" else None,
+    )
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _docker_result(args, stdout=json.dumps({"servers": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._cmd_uninstall(Namespace(dry_run=False, keep_config=True))
+
+    assert calls, "expected a mcporter config query"
+    assert all(call[0] != "mcporter" for call in calls)
+    assert calls[0][0] == resolved
+
+
+def test_setup_exa_uses_resolved_mcporter_command(monkeypatch, capsys):
+    """Both the Exa config check and config add must use the resolved path."""
+    import getpass
+    import shutil as shutil_module
+
+    import agent_reach.config as config_module
+
+    resolved = "/fake/bin/mcporter"
+    calls = []
+    config = _MemoryConfig()
+    config.config_path = Path("/tmp/agent-reach-test-config.yaml")
+
+    monkeypatch.setattr(config_module, "Config", lambda: config)
+    monkeypatch.setattr(
+        shutil_module,
+        "which",
+        lambda name: resolved if name == "mcporter" else None,
+    )
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: "")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _docker_result(args, stdout=json.dumps({"servers": []}))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cli._cmd_setup()
+
+    assert calls, "expected mcporter subprocess calls"
+    assert all(call[0] != "mcporter" for call in calls)
+    assert any(call[0] == resolved for call in calls)

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -1413,6 +1413,10 @@ def test_setup_exa_uses_resolved_mcporter_command(monkeypatch, capsys):
 
     cli._cmd_setup()
 
-    assert calls, "expected mcporter subprocess calls"
-    assert all(call[0] != "mcporter" for call in calls)
-    assert any(call[0] == resolved for call in calls)
+    # The docstring's claim is per-call: check both the config query and the
+    # config add, not just that the resolved path appears somewhere.
+    config_calls = [call for call in calls if len(call) > 1 and call[1] == "config"]
+    assert [call[2] for call in config_calls] == ["list", "add"], (
+        f"expected an Exa config query then a config add, got {config_calls}"
+    )
+    assert all(call[0] == resolved for call in config_calls)


### PR DESCRIPTION
## Problem

Three subprocess calls pass the bare string `"mcporter"` as argv0: the uninstall
mcporter-cleanup query, the setup Exa config check, and the setup Exa `config add`.
On Windows, npm installs `mcporter.cmd` / `mcporter.ps1` — `CreateProcess` cannot
find the `.cmd` shim without shell resolution, so these calls raise
`FileNotFoundError` even when mcporter is installed and on PATH. This is #590.

## Fix

Capture `shutil.which("mcporter")` (already called as a guard at each site, result
previously discarded) and pass the resolved path as argv0 — the same pattern #591
established for the other call sites (`mcporter_cmd` / `npm_cmd`).

## Tests

Two regressions: uninstall cleanup and setup Exa flow each assert no subprocess
call uses bare `"mcporter"` as argv0. Verified on Windows 11 + Python 3.11:
full suite passes with no new failures.
