### PR TITLE
test(windows): skip symlink security tests when symlinks unavailable

### DIFF
--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -946,10 +946,13 @@ class TestXiaoHongShuChannel:
             json.dumps({"a1": "do-not-read"}),
             encoding="utf-8",
         )
-        (isolated_home / ".xiaohongshu-cli").symlink_to(
-            victim_dir,
-            target_is_directory=True,
-        )
+        try:
+            (isolated_home / ".xiaohongshu-cli").symlink_to(
+                victim_dir,
+                target_is_directory=True,
+            )
+        except OSError:
+            pytest.skip("symlinks are not supported on this platform")
 
         status, message = XiaoHongShuChannel()._check_xhs_cli()
 
@@ -1426,10 +1429,13 @@ class TestGitHubChannel:
             "github.com:\n  oauth_token: do-not-read\n",
             encoding="utf-8",
         )
-        (isolated_home / ".config").symlink_to(
-            real_config,
-            target_is_directory=True,
-        )
+        try:
+            (isolated_home / ".config").symlink_to(
+                real_config,
+                target_is_directory=True,
+            )
+        except OSError:
+            pytest.skip("symlinks are not supported on this platform")
         monkeypatch.setattr(
             subprocess,
             "run",

--- a/tests/test_reddit_channel.py
+++ b/tests/test_reddit_channel.py
@@ -5,6 +5,8 @@ import json
 import time
 from unittest.mock import Mock, patch
 
+import pytest
+
 from agent_reach.channels.reddit import RedditChannel
 
 
@@ -103,7 +105,10 @@ def test_check_rdt_refuses_symlink_credential(isolated_home):
     victim.write_text('{"secret": "do-not-read"}', encoding="utf-8")
     path = isolated_home / ".config" / "rdt-cli" / "credential.json"
     path.parent.mkdir(parents=True)
-    path.symlink_to(victim)
+    try:
+        path.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
     with patch("shutil.which", return_value="/usr/local/bin/rdt"):
         status, message = RedditChannel()._check_rdt()
 
@@ -119,10 +124,13 @@ def test_check_rdt_refuses_ancestor_symlink(isolated_home):
         '{"cookies": {"reddit_session": "do-not-read"}}',
         encoding="utf-8",
     )
-    (isolated_home / ".config").symlink_to(
-        victim_dir,
-        target_is_directory=True,
-    )
+    try:
+        (isolated_home / ".config").symlink_to(
+            victim_dir,
+            target_is_directory=True,
+        )
+    except OSError:
+        pytest.skip("symlinks are not supported on this platform")
 
     with patch("shutil.which", return_value="/usr/local/bin/rdt"):
         status, message = RedditChannel()._check_rdt()


### PR DESCRIPTION
## Problem

Four symlink-refusal security tests fail on stock Windows with
`OSError: [WinError 1314]` — creating symlinks there requires admin rights or
Developer Mode, so `pytest tests/` is red out of the box on a default Windows
setup (verified on Windows 11, Python 3.11):

- `test_channels.py::TestXiaoHongShuChannel::test_saved_cli_cookie_refuses_ancestor_symlink`
- `test_channels.py::TestGitHubChannel::test_hosts_metadata_refuses_ancestor_symlink`
- `test_reddit_channel.py::test_check_rdt_refuses_symlink_credential`
- `test_reddit_channel.py::test_check_rdt_refuses_ancestor_symlink`

## Fix

Wrap the `symlink_to` setup calls in the try/except-skip guard this suite
already uses in `tests/test_private_file_writes.py` ("symlinks are not
supported on this platform"). A blanket `skipif(win32)` was deliberately NOT
used: on Windows with Developer Mode enabled the tests can and should still run.

No behavior under test changes; only test setup gains the same capability
guard as its sibling file. After this change the full suite is green on stock
Windows: 554 passed, 32 skipped, 0 failed.
