### PR TITLE
docs(readme): document HOME-over-USERPROFILE resolution on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Agent Reach 在设计上重视安全：
 | 兼容安全参数 | `agent-reach install --env=auto --safe` | 与默认行为相同 |
 | 仅预览 | `agent-reach install --env=auto --dry-run` | 先看看会做什么 |
 
+> **Windows 用户注意：** Agent Reach 解析主目录时优先使用 `HOME` 环境变量，其次才是 `USERPROFILE`（与 Git Bash / MSYS 工具链保持一致）。如果你的机器把 `HOME` 设置到了其他位置，配置、Cookie 和 skill 文件会写入该位置，而不是 `C:\Users\<用户名>`。
+
 ### 🗑️ 卸载
 
 ```bash

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -180,6 +180,8 @@ After the Skill is installed, the Agent will auto-detect whether `agent-reach` C
 
 ---
 
+> **Windows note:** Agent Reach resolves your home directory from the `HOME` environment variable first, falling back to `USERPROFILE` (keeping paths consistent with Git Bash / MSYS tooling). If `HOME` points somewhere custom, config, cookies, and skill files are written there instead of `C:\Users\<you>`.
+
 ## Works Out of the Box
 
 No configuration needed — just tell your Agent:


### PR DESCRIPTION
`agent_reach/utils/paths.py::home_dir()` prefers the `HOME` environment
variable over `USERPROFILE` on Windows. That's the right call for Git Bash /
MSYS interop, but it surprises Windows users who have a stray `HOME` set:
config, cookies, and skill installs silently land outside `C:\Users\<name>`.
This adds one note to the README (zh + en) stating the resolution order and
its implication. No code change.
