### PR TITLE
fix(cli): preserve existing SKILL.md by default, add skill --force

### DIFF
--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -496,10 +496,45 @@ def _install_skill(force: bool = False):
         except FileNotFoundError:
             return skill_pkg.joinpath("SKILL.md").read_text(encoding="utf-8")
 
+    def _resolve_skill_pkg():
+        """Locate the packaged skill directory (fallback for editable installs)."""
+        try:
+            skill_pkg = importlib.resources.files("agent_reach").joinpath("skill")
+            _read_skill_markdown(skill_pkg)
+            return skill_pkg
+        except Exception:
+            from pathlib import Path
+            return Path(__file__).resolve().parent / "skill"
+
+    def _write_references(skill_pkg, target: str) -> None:
+        """Replace target/references/ with the packaged reference docs.
+
+        Rewritten from scratch so docs dropped upstream do not linger.
+        """
+        refs_pkg = skill_pkg.joinpath("references")
+        refs_target = os.path.join(target, "references")
+        if os.path.islink(refs_target):
+            os.unlink(refs_target)
+        elif os.path.isdir(refs_target):
+            shutil.rmtree(refs_target)
+        os.makedirs(refs_target, exist_ok=True)
+
+        for ref_file in refs_pkg.iterdir():
+            name = ref_file.name if hasattr(ref_file, 'name') else str(ref_file).split('/')[-1]
+            if name.endswith(".md"):
+                content = ref_file.read_text(encoding="utf-8") if hasattr(ref_file, 'read_text') else ref_file.read_text()
+                with open(os.path.join(refs_target, name), "w", encoding="utf-8") as f:
+                    f.write(content)
+
     def _copy_skill_dir(target: str) -> str | None:
         """Copy entire skill directory (locale-specific SKILL.md + references/)."""
         try:
+            skill_pkg = _resolve_skill_pkg()
+
+            # A customized SKILL.md is the user's; the reference docs are ours,
+            # so they still track the installed version.
             if not force and os.path.exists(os.path.join(target, "SKILL.md")):
+                _write_references(skill_pkg, target)
                 return "preserved"
 
             # Clear existing installation. A symlinked skill dir (dotfiles
@@ -510,30 +545,11 @@ def _install_skill(force: bool = False):
                 shutil.rmtree(target)
             os.makedirs(target, exist_ok=True)
 
-            # Get skill directory from package (with fallback for editable installs)
-            try:
-                skill_pkg = importlib.resources.files("agent_reach").joinpath("skill")
-                skill_md = _read_skill_markdown(skill_pkg)
-            except Exception:
-                from pathlib import Path
-                skill_pkg = Path(__file__).resolve().parent / "skill"
-                skill_md = _read_skill_markdown(skill_pkg)
-
             # Copy SKILL.md using the selected locale file
             with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
-                f.write(skill_md)
+                f.write(_read_skill_markdown(skill_pkg))
 
-            # Copy references/ directory
-            refs_pkg = skill_pkg.joinpath("references")
-            refs_target = os.path.join(target, "references")
-            os.makedirs(refs_target, exist_ok=True)
-
-            for ref_file in refs_pkg.iterdir():
-                name = ref_file.name if hasattr(ref_file, 'name') else str(ref_file).split('/')[-1]
-                if name.endswith(".md"):
-                    content = ref_file.read_text(encoding="utf-8") if hasattr(ref_file, 'read_text') else ref_file.read_text()
-                    with open(os.path.join(refs_target, name), "w", encoding="utf-8") as f:
-                        f.write(content)
+            _write_references(skill_pkg, target)
 
             return "installed"
         except Exception as e:
@@ -563,7 +579,10 @@ def _install_skill(force: bool = False):
             status = _copy_skill_dir(target)
             if status:
                 if status == "preserved":
-                    print(f"Skill already installed for {platform_name}, preserving existing files: {target}")
+                    print(
+                        f"Skill already installed for {platform_name}: kept your SKILL.md, "
+                        f"refreshed references/ (agent-reach skill --force overwrites): {target}"
+                    )
                 else:
                     print(f"Skill installed for {platform_name}: {target}")
                 installed = True
@@ -574,7 +593,11 @@ def _install_skill(force: bool = False):
         os.makedirs(os.path.dirname(target), exist_ok=True)
         status = _copy_skill_dir(target)
         if status == "preserved":
-            print(f"Skill already installed, preserving existing files: {target}")
+            print(
+                "Skill already installed: kept your SKILL.md, refreshed references/ "
+                f"(agent-reach skill --force overwrites): {target}"
+            )
+            installed = True
         elif status == "installed":
             print(f"Skill installed: {target}")
             installed = True

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -146,6 +146,8 @@ def main():
                                help="Install SKILL.md to agent skill directories")
     p_skill_group.add_argument("--uninstall", action="store_true",
                                help="Remove SKILL.md from agent skill directories")
+    p_skill.add_argument("--force", action="store_true",
+                         help="Overwrite an existing SKILL.md (default: preserve user-modified files)")
 
     # ── format ──
     p_format = sub.add_parser("format", help="Clean and format platform API output")
@@ -466,7 +468,7 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
-def _install_skill(force: bool = True):
+def _install_skill(force: bool = False):
     """Install Agent Reach as an agent skill for supported agent clients."""
     import importlib.resources
     import os
@@ -625,7 +627,7 @@ def _uninstall_skill():
 def _cmd_skill(args):
     """Manage agent skill registration."""
     if args.install:
-        if not _install_skill():
+        if not _install_skill(force=args.force):
             raise SystemExit(1)
     elif args.uninstall:
         _uninstall_skill()

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for 'agent-reach skill' command and _install_skill / _uninstall_skill."""
 
+import contextlib
 import importlib.resources
+import io
 import os
 import re
 import tempfile
@@ -11,6 +13,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 from agent_reach.cli import _cmd_skill, _install_skill, _uninstall_skill
+
+CUSTOM_SKILL_MD = "# my customized skill\n"
 
 
 class TestSkillCommand(unittest.TestCase):
@@ -193,27 +197,66 @@ class TestSkillCommand(unittest.TestCase):
                 content = f.read()
             self.assertIn("Agent Reach", content)
 
+    def _install_over_customized_skill(self, tmpdir):
+        """Plant a customized SKILL.md plus a stale reference doc, then re-install.
+
+        Returns (target_dir, stdout).
+        """
+        skill_parent = os.path.join(tmpdir, ".openclaw", "skills")
+        target = os.path.join(skill_parent, "agent-reach")
+        os.makedirs(os.path.join(target, "references"))
+        with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
+            f.write(CUSTOM_SKILL_MD)
+        with open(
+            os.path.join(target, "references", "retired.md"), "w", encoding="utf-8"
+        ) as f:
+            f.write("# doc dropped upstream\n")
+
+        stdout = io.StringIO()
+        with patch(
+            "agent_reach.cli.os.path.expanduser",
+            side_effect=lambda p: p.replace("~", tmpdir),
+        ):
+            env = os.environ.copy()
+            env.pop("OPENCLAW_HOME", None)
+            with patch.dict(os.environ, env, clear=True):
+                with contextlib.redirect_stdout(stdout):
+                    _install_skill()
+
+        return target, stdout.getvalue()
+
     def test_install_preserves_existing_skill_md_by_default(self):
         """A user-customized SKILL.md must survive a re-install."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            skill_parent = os.path.join(tmpdir, ".openclaw", "skills")
-            target = os.path.join(skill_parent, "agent-reach")
-            os.makedirs(target)
-            custom = "# my customized skill\n"
-            with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
-                f.write(custom)
-
-            with patch(
-                "agent_reach.cli.os.path.expanduser",
-                side_effect=lambda p: p.replace("~", tmpdir),
-            ):
-                env = os.environ.copy()
-                env.pop("OPENCLAW_HOME", None)
-                with patch.dict(os.environ, env, clear=True):
-                    _install_skill()
+            target, _ = self._install_over_customized_skill(tmpdir)
 
             with open(os.path.join(target, "SKILL.md"), encoding="utf-8") as f:
-                self.assertEqual(f.read(), custom)
+                self.assertEqual(f.read(), CUSTOM_SKILL_MD)
+
+    def test_install_refreshes_references_while_preserving_skill_md(self):
+        """Preserve keeps the user's SKILL.md but still ships current reference docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target, _ = self._install_over_customized_skill(tmpdir)
+            refs = os.path.join(target, "references")
+
+            # Docs dropped upstream must not linger in a preserved install.
+            self.assertFalse(os.path.exists(os.path.join(refs, "retired.md")))
+            self.assertTrue(os.path.exists(os.path.join(refs, "search.md")))
+            packaged = (
+                importlib.resources.files("agent_reach")
+                .joinpath("skill", "references", "search.md")
+                .read_text(encoding="utf-8")
+            )
+            with open(os.path.join(refs, "search.md"), encoding="utf-8") as f:
+                self.assertEqual(f.read(), packaged)
+
+    def test_preserved_install_tells_user_how_to_overwrite(self):
+        """Silent preservation strands users on a stale SKILL.md — name --force."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, output = self._install_over_customized_skill(tmpdir)
+
+            self.assertIn("--force", output)
+            self.assertIn("SKILL.md", output)
 
     def test_install_force_overwrites_existing_skill_md(self):
         """--force restores the packaged SKILL.md."""

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -119,7 +119,7 @@ class TestSkillCommand(unittest.TestCase):
     def test_skill_install_command_exits_nonzero_when_install_fails(self):
         with patch("agent_reach.cli._install_skill", return_value=False):
             with self.assertRaises(SystemExit) as raised:
-                _cmd_skill(Namespace(install=True, uninstall=False))
+                _cmd_skill(Namespace(install=True, uninstall=False, force=False))
 
         self.assertEqual(raised.exception.code, 1)
 
@@ -192,6 +192,49 @@ class TestSkillCommand(unittest.TestCase):
             with open(target, encoding="utf-8") as f:
                 content = f.read()
             self.assertIn("Agent Reach", content)
+
+    def test_install_preserves_existing_skill_md_by_default(self):
+        """A user-customized SKILL.md must survive a re-install."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_parent = os.path.join(tmpdir, ".openclaw", "skills")
+            target = os.path.join(skill_parent, "agent-reach")
+            os.makedirs(target)
+            custom = "# my customized skill\n"
+            with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
+                f.write(custom)
+
+            with patch(
+                "agent_reach.cli.os.path.expanduser",
+                side_effect=lambda p: p.replace("~", tmpdir),
+            ):
+                env = os.environ.copy()
+                env.pop("OPENCLAW_HOME", None)
+                with patch.dict(os.environ, env, clear=True):
+                    _install_skill()
+
+            with open(os.path.join(target, "SKILL.md"), encoding="utf-8") as f:
+                self.assertEqual(f.read(), custom)
+
+    def test_install_force_overwrites_existing_skill_md(self):
+        """--force restores the packaged SKILL.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_parent = os.path.join(tmpdir, ".openclaw", "skills")
+            target = os.path.join(skill_parent, "agent-reach")
+            os.makedirs(target)
+            with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8") as f:
+                f.write("# my customized skill\n")
+
+            with patch(
+                "agent_reach.cli.os.path.expanduser",
+                side_effect=lambda p: p.replace("~", tmpdir),
+            ):
+                env = os.environ.copy()
+                env.pop("OPENCLAW_HOME", None)
+                with patch.dict(os.environ, env, clear=True):
+                    _install_skill(force=True)
+
+            with open(os.path.join(target, "SKILL.md"), encoding="utf-8") as f:
+                self.assertIn("Agent Reach", f.read())
 
     def test_install_uses_english_skill_for_english_locale(self):
         """_install_skill should install the English skill file for English locales."""


### PR DESCRIPTION
## Problem

`_install_skill()` defaults to `force=True`, and both callers (the `install`
flow and `agent-reach skill --install`) call it bare. Every install run
therefore silently overwrites `~/.claude/skills/agent-reach/SKILL.md` (and the
other agent skill roots), destroying any user customization — scoped
descriptions, trimmed tool lists, local routing notes.

The preserve path already exists: `_copy_skill_dir` returns `"preserved"` when
`not force` and a SKILL.md is present, and both callers already print a
"preserving existing files" message for it — it's just unreachable from the CLI.

## Fix

- Default flips to `force=False`: installs preserve an existing SKILL.md and
  say so.
- New `agent-reach skill --install --force` opts into overwrite (e.g. to pick
  up a new packaged skill after upgrading).

## Tests

Two new tests: re-install preserves a customized SKILL.md; `--force` restores
the packaged one. Full suite passes with no new failures (Windows 11,
Python 3.11); manually verified that `skill --install` now prints
"preserving existing files" and leaves a customized SKILL.md byte-identical.
