### PR TITLE
fix(packaging): define MCP optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 [project.optional-dependencies]
 browser = ["playwright>=1.40"]
 cookies = ["browser-cookie3>=0.19"]
+mcp = ["mcp[cli]>=1.0"]
 all = ["playwright>=1.40", "mcp[cli]>=1.0", "browser-cookie3>=0.19"]
 dev = [
     "pytest>=8.0",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,9 +1,34 @@
 """Security boundaries for the optional Agent Reach MCP server."""
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import agent_reach.integrations.mcp_server as mcp_server
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pyproject_declares_mcp_optional_dependency():
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    optional_dependencies = text.split(
+        "[project.optional-dependencies]",
+        1,
+    )[1].split("\n[", 1)[0]
+
+    assert 'mcp = ["mcp[cli]>=1.0"]' in optional_dependencies
+
+
+def test_missing_mcp_exits_with_advertised_extra(monkeypatch, capsys):
+    monkeypatch.setattr(mcp_server, "HAS_MCP", False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mcp_server.create_server()
+
+    assert exc_info.value.code == 1
+    assert "agent-reach[mcp]" in capsys.readouterr().err
 
 
 class _FakeServer:


### PR DESCRIPTION
Closes #608.

## Problem

When MCP is missing, `create_server()` points users at an extra that the package does not define:

```python
# agent_reach/integrations/mcp_server.py
"MCP not installed. Install: python -m pip install "
"'agent-reach[mcp] @ "
"https://github.com/Panniantong/agent-reach/archive/main.zip'",
```

`[project.optional-dependencies]` on `main` declares `browser`, `cookies`, `all`, and `dev` — there is no `mcp` extra. Following the printed command therefore reinstalls Agent Reach without the MCP dependency, and the next run prints the same message:

```console
$ python -m pip install --dry-run ".[mcp]"     # on main
WARNING: agent-reach 1.5.0 does not provide the extra 'mcp'
Would install agent-reach-1.5.0

$ python -m pip install --dry-run ".[mcp]"     # on this branch
Would install ... mcp-2.0.0 mcp-types-2.0.0 ... typer-0.27.1 uvicorn-0.52.3 ...
```

## Change

- `pyproject.toml`: add `mcp = ["mcp[cli]>=1.0"]`, reusing the exact requirement already listed in the `all` extra.
- `tests/test_mcp_server.py`: add two regressions — one asserting the `[project.optional-dependencies]` block declares that extra, one asserting that with `HAS_MCP` false `create_server()` exits with status 1 and names `agent-reach[mcp]` on stderr.

The metadata test reads `pyproject.toml` as UTF-8 text instead of parsing TOML, following the existing precedent in `tests/test_youtube_channel.py`, so it needs no TOML parser on Python 3.10. The missing-dependency test patches `HAS_MCP` and does not require MCP to be uninstalled from the test environment.

## Verification

Run on this branch (Windows, Python 3.14.5, pytest 9.1.1, ruff 0.16.3, mypy 2.3.0):

| Command | Result |
| --- | --- |
| `python -m pytest tests/test_mcp_server.py -v` | 4 passed |
| `python -m ruff check agent_reach tests` | All checks passed |
| `python -m mypy agent_reach` | Success: no issues found in 35 source files |
| `git diff --check` | clean |
| `python -m pytest tests/ -v` | 4 failed, 556 passed, 28 skipped, 16 subtests passed |
| `python -m pip install --dry-run ".[mcp]"` | resolves `mcp-2.0.0` (warns about an unknown extra on `main`) |

The metadata test was confirmed to fail before the `pyproject.toml` edit and to pass after it. MCP is not installed in the environment these tests ran in, so the missing-dependency path is exercised for real.

The 4 failures are pre-existing in this local environment and unrelated to this change: the symlink security tests in `tests/test_channels.py` and `tests/test_reddit_channel.py` raise `OSError: [WinError 1314] A required privilege is not held by the client` because this Windows account cannot create symlinks. They fail identically on `main` before this change (baseline: 4 failed, 554 passed, 28 skipped), and #616 addresses them separately.

## Scope

- No change to `agent_reach/integrations/mcp_server.py`, its tool contract, or its install message.
- MCP stays optional: base dependencies are untouched and the `all` extra is unchanged.
- No version bump, changelog entry, constraints change, or documentation edit.
