### PR TITLE
fix(deps): add missing mcp optional-dependency extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 [project.optional-dependencies]
 browser = ["playwright>=1.40"]
 cookies = ["browser-cookie3>=0.19"]
+mcp = ["mcp[cli]>=1.0"]
 all = ["playwright>=1.40", "mcp[cli]>=1.0", "browser-cookie3>=0.19"]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
## Summary
- `agent_reach/integrations/mcp_server.py` tells users to install `agent-reach[mcp]` when the `mcp` package is missing, but `pyproject.toml` never defined an `mcp` extra (only `browser`, `cookies`, `all`, `dev` exist). The suggested fix command was a dead end.
- Added `mcp = ["mcp[cli]>=1.0"]` to `[project.optional-dependencies]` so the guided install command actually works.

Closes #608

## Test plan
- [x] `python -m pytest tests/ -v` — same 11 pre-existing failures as on `main` (Windows symlink-privilege issues + one missing test module), unrelated to this change; no new failures introduced.