### PR TITLE
feat: add BOSS Zhipin channel (job search + full JD text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### ✨ Features / 新增
+
+#### 🎯 Boss直聘 channel
+
+- 新增 `boss` channel：经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD 全文。
+- `check()` 三层只读探测（boss-agent-cli 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
+- 抓取走公开 API（`search_jobs` + `job_card_browser` + `browser_mode="cdp_required"`）。
+
 ## [1.3.1] - 2026-03-27
 
 ### 🐛 Bug Fixes / 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - 新增 `boss` channel：经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD 全文。
 - `check()` 三层只读探测（boss-agent-cli 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
 - 抓取走公开 API（`search_jobs` + `job_card_browser` + `browser_mode="cdp_required"`）。
+- `agent-reach install --system --channels=boss` 可安装临时锁定 PR #382 提交的后端；
+  上游发布后切回正式版本约束。
+- Skill 与安装指南支持“帮我配 Boss直聘”：Agent 启动仅监听回环地址的专用 Chrome，
+  用户只负责手动登录，最后由 Agent 验证登录态与 CDP 链路。
 
 ## [1.3.1] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project will be documented in this file.
   上游发布后切回正式版本约束。
 - Skill 与安装指南支持“帮我配 Boss直聘”：Agent 启动仅监听回环地址的专用 Chrome，
   用户只负责手动登录，最后由 Agent 验证登录态与 CDP 链路。
+- 固定依赖更新到 PR #382 的 `ba0f125`：已登录 CDP 会话可直接复用，搜索可通过
+  `--browser-mode cdp-required` 禁止 headless 降级。
+- code 37 按原始文案分类：环境异常为 `ENVIRONMENT_RISK` 并立即停止；只有明确
+  token/stoken 过期才允许一次刷新。专用 Chrome profile 应长期复用并降低频率。
 
 ## [1.3.1] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,33 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes / 修复
+
+#### 🔐 Boss直聘 — 登录态误判（双凭据存储）
+
+- **根因：** Boss 有两个互不代表的登录态存储——本地 `~/.boss-agent/auth/session.enc`
+  和专用 Chrome profile 内的浏览器 cookie。`boss status` / `status --live` **只校验前者**
+  （Bridge/httpx 时代的遗留凭据库），而 `cdp-required` 模式下搜索走的是浏览器 cookie。
+  「本地有旧凭据 + 浏览器未登录」时 `boss status` 会报 `logged_in: true`，误导 Agent
+  跳过登录直接搜索，最终撞上 `AUTH_EXPIRED`；旧 runbook 又禁止把 `_security_check`
+  当成未登录，两条规则叠加把 Agent 推向「反爬滑块」的错误分支。
+- **修复：** `check()` 新增第 4 层只读探测 `_cdp_zhipin_login_cookie()`，用纯标准库
+  实现的最小 WebSocket 客户端直接问 CDP 浏览器本体（`Storage.getCookies`）有无 zhipin
+  的 `wt2` cookie，**以浏览器为准**，不引入新依赖、不拉起浏览器、不执行搜索。
+  无 wt2 → 明确报「浏览器未登录，搜索会报 AUTH_EXPIRED」并指向「用户登录 +
+  `login --cdp`」；探测失败 → 报「登录态未知」；安全校验页提示也附带浏览器 cookie 状态。
+- **Runbook 修正：** 删除误导规则「判断登录态只信 `boss status`」，改为以 doctor 的
+  浏览器 cookie 探测为准；拉起专用 Chrome 后**强制暂停让用户肉眼确认**登录状态；
+  `AUTH_EXPIRED` 定为 ground truth（直接走登录流程，禁止往安全校验方向解释），
+  `_security_check` 仅在无 `AUTH_EXPIRED` 时按滑块处理。
+
 ### ✨ Features / 新增
 
 #### 🎯 Boss直聘 channel
 
 - 新增 `boss` channel：经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD 全文。
-- `check()` 三层只读探测（boss-agent-cli 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
+- `check()` 四层只读探测（boss-agent-cli 装没装 → 9222 端口通不通 → 有无 zhipin 页签
+  → 浏览器内有无 `wt2` 登录 cookie）。
 - 抓取走公开 API（`search_jobs` + `job_card_browser` + `browser_mode="cdp_required"`）。
 - `agent-reach install --system --channels=boss` 可安装临时锁定 #403–#407 快照提交的后端；
   上游发布后切回正式版本约束。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ All notable changes to this project will be documented in this file.
 - 新增 `boss` channel：经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD 全文。
 - `check()` 三层只读探测（boss-agent-cli 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
 - 抓取走公开 API（`search_jobs` + `job_card_browser` + `browser_mode="cdp_required"`）。
-- `agent-reach install --system --channels=boss` 可安装临时锁定 PR #382 提交的后端；
+- `agent-reach install --system --channels=boss` 可安装临时锁定 #403–#407 快照提交的后端；
   上游发布后切回正式版本约束。
 - Skill 与安装指南支持“帮我配 Boss直聘”：Agent 启动仅监听回环地址的专用 Chrome，
   用户只负责手动登录，最后由 Agent 验证登录态与 CDP 链路。
-- 固定依赖更新到 PR #382 的 `ba0f125`：已登录 CDP 会话可直接复用，搜索可通过
+- 固定依赖更新到 #403–#407 的 merge 快照 `8ff6bd3`：已登录 CDP 会话可直接复用，搜索可通过
   `--browser-mode cdp-required` 禁止 headless 降级。
 - code 37 按原始文案分类：环境异常为 `ENVIRONMENT_RISK` 并立即停止；只有明确
   token/stoken 过期才允许一次刷新。专用 Chrome profile 应长期复用并降低频率。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📕 **小红书** | — | 搜索、阅读、评论 | OpenCLI 只用用户已有 Chrome 会话；MCP/存量工具用 Cookie-Editor |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
+| 🎯 **Boss直聘** | CDP 链路体检（装没装 / 9222 端口 / 登录态） | 搜索岗位 + JD 全文（CDP 真 Chrome） | 需 boss-agent-cli + 本地 Chrome 9222 登录 zhipin.com |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
 | 📈 **雪球** | 股票行情、搜索股票、热门帖子、热门股票排行 | — | 告诉 Agent「帮我配雪球」 |
 | 🎙️ **小宇宙播客** | — | 播客音频转文字（Whisper 转录，免费 Key） | 告诉 Agent「帮我配小宇宙播客」 |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ AI Agent 已经能帮你写代码、改文档、管项目——但你让它去�
 | 📷 **Instagram** | — | 用户搜索、Profile、用户最近帖子、Explore | 桌面装 OpenCLI（复用 Chrome 登录态） |
 | 📕 **小红书** | — | 搜索、阅读、评论 | OpenCLI 只用用户已有 Chrome 会话；MCP/存量工具用 Cookie-Editor |
 | 💼 **LinkedIn** | Jina Reader 读公开页面 | Profile 详情、公司页面、职位搜索 | 告诉 Agent「帮我配 LinkedIn」 |
-| 🎯 **Boss直聘** | CDP 链路体检（装没装 / 9222 端口 / 登录态） | 搜索岗位 + JD 全文（CDP 真 Chrome） | 需 boss-agent-cli + 本地 Chrome 9222 登录 zhipin.com |
+| 🎯 **Boss直聘** | CDP 链路体检 | 搜索岗位 + JD 全文（专用真 Chrome） | 告诉 Agent「帮我配 Boss直聘」；Agent 打开专用 Chrome，你手动登录 |
 | 💻 **V2EX** | 热门帖子、节点帖子、帖子详情+回复、用户信息 | — | 无需配置 |
 | 📈 **雪球** | 股票行情、搜索股票、热门帖子、热门股票排行 | — | 告诉 Agent「帮我配雪球」 |
 | 🎙️ **小宇宙播客** | — | 播客音频转文字（Whisper 转录，免费 Key） | 告诉 Agent「帮我配小宇宙播客」 |

--- a/agent_reach/channels/__init__.py
+++ b/agent_reach/channels/__init__.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 # Import all channels
 from .base import Channel
 from .bilibili import BilibiliChannel
+from .boss import BossChannel
 from .exa_search import ExaSearchChannel
 from .facebook import FacebookChannel
 from .github import GitHubChannel
@@ -33,6 +34,7 @@ ALL_CHANNELS: List[Channel] = [
     BilibiliChannel(),
     XiaoHongShuChannel(),
     LinkedInChannel(),
+    BossChannel(),
     XiaoyuzhouChannel(),
     V2EXChannel(),
     XueqiuChannel(),

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Boss直聘 — 经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD。
+
+后端是 boss-agent-cli（CDP 调试端口复用已登录的真 Chrome）。headless 是禁区
+（触发 code 36 风控），故 check() 只做三层只读探测，不实例化 BossClient、不拉起浏览器。
+
+抓取走 boss-agent-cli 公开 API（search_jobs + job_card_browser + browser_mode="cdp_required"），
+调用姿势见 skill/references/career.md；check() 只负责「装没装 + CDP 链路就绪」的体检，不搜索。
+"""
+
+import json
+import urllib.request
+
+from agent_reach.probe import probe_command
+from agent_reach.utils.url import host_matches
+
+from .base import Channel
+
+_CDP_URL = "http://localhost:9222"
+_CDP_TIMEOUT = 5
+
+
+def _cdp_json(path: str):
+    """GET 本地 CDP 端点（禁用系统代理），返回解析后的 JSON；失败返回 None。"""
+    req = urllib.request.Request(f"{_CDP_URL}{path}", method="GET")
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(req, timeout=_CDP_TIMEOUT) as resp:
+            return json.loads(resp.read())
+    except Exception:
+        return None
+
+
+def _has_zhipin_page(pages) -> bool:
+    """CDP /json 页签列表里是否存在可复用的 zhipin.com 页签（精确 hostname 校验）。"""
+    for page in pages or []:
+        if page.get("type") == "page" and host_matches(page.get("url", ""), "zhipin.com"):
+            return True
+    return False
+
+
+class BossChannel(Channel):
+    name = "boss"
+    description = "Boss直聘 职位搜索与 JD"
+    backends = ["boss-agent-cli (CDP)"]
+    tier = 2
+
+    def can_handle(self, url: str) -> bool:
+        return host_matches(url, "zhipin.com")
+
+    def check(self, config=None):
+        self.active_backend = None
+
+        # 层 1：boss-agent-cli 装没装
+        probe = probe_command("boss", ["--version"], timeout=10)
+        if probe.status == "missing":
+            return "off", (
+                "boss-agent-cli 未安装。安装：pip install boss-agent-cli\n"
+                "（需本地 Chrome 以 --remote-debugging-port=9222 启动并登录 zhipin.com）"
+            )
+        if probe.status == "broken":
+            return "error", (
+                "boss 命令存在但无法执行——安装已损坏。重装：\n"
+                "  pip install --force-reinstall boss-agent-cli"
+            )
+        if not probe.ok:
+            return "warn", f"boss 命令探测失败（{probe.status}），请检查安装"
+
+        # 层 2：CDP 端口通不通
+        if _cdp_json("/json/version") is None:
+            return "off", (
+                "CDP 调试端口不可达。请先启动调试 Chrome：\n"
+                "  Google Chrome --remote-debugging-port=9222 --user-data-dir=~/.boss-chrome-profile\n"
+                "  然后在该窗口登录 zhipin.com"
+            )
+
+        # 层 3：有无可复用 BOSS 页签
+        pages = _cdp_json("/json")
+        if pages is None:
+            return "warn", "CDP 端口可达但 /json 页签枚举失败"
+        if not _has_zhipin_page(pages):
+            return "warn", (
+                "CDP 可达但未发现现成 zhipin.com 页签（不代表未登录：Cookie 可能仍在，"
+                "boss-agent-cli 会自行新建页签）。建议先在 Chrome 登录 zhipin.com。"
+            )
+
+        return "warn", (
+            "CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签）。"
+            "Doctor 不实际执行搜索、不验证登录态 liveness；"
+            "搜索前先跑 `boss status` 确认 stoken 未过期（code 37 = TOKEN_REFRESH_FAILED）。"
+        )

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -71,6 +71,24 @@ def _has_zhipin_page(pages) -> bool:
     return False
 
 
+_SECURITY_CHECK_MARKERS = ("security-check", "zhipin-security", "_security_check")
+
+
+def _security_check_blocks_all(pages) -> bool:
+    """现有 zhipin 页签是否全部停在反爬安全校验页（不是登录页）。"""
+    zhipin_urls = [
+        page.get("url", "")
+        for page in (pages or [])
+        if page.get("type") == "page" and host_matches(page.get("url", ""), "zhipin.com")
+    ]
+    if not zhipin_urls:
+        return False
+    return all(
+        any(marker in url.lower() for marker in _SECURITY_CHECK_MARKERS)
+        for url in zhipin_urls
+    )
+
+
 class BossChannel(Channel):
     name = "boss"
     description = "Boss直聘 职位搜索与 JD"
@@ -116,6 +134,13 @@ class BossChannel(Channel):
             return "warn", (
                 "CDP 可达但未发现现成 zhipin.com 页签（不代表未登录：Cookie 可能仍在，"
                 "boss-agent-cli 会自行新建页签）。建议先在 Chrome 登录 zhipin.com。"
+            )
+        if _security_check_blocks_all(pages):
+            return "warn", (
+                "CDP 链路就绪，但现有 zhipin 页签都停在安全校验页"
+                "（security-check / zhipin-security）。这是 Boss 反爬挑战，与登录无关"
+                "——已登录也会出现，不代表未登录。先用 `boss status` 判断登录态"
+                "（看 wt2/__zp_stoken__），不要据此要求用户重新登录。"
             )
 
         return "warn", (

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -9,6 +9,7 @@
 """
 
 import json
+import platform
 import urllib.request
 
 from agent_reach.probe import probe_command
@@ -18,6 +19,37 @@ from .base import Channel
 
 _CDP_URL = "http://localhost:9222"
 _CDP_TIMEOUT = 5
+
+
+def _chrome_launch_command(system: str | None = None) -> str:
+    """Return a dedicated-profile Chrome command for the current OS."""
+    system = system or platform.system()
+    common = (
+        "--remote-debugging-address=127.0.0.1 "
+        "--remote-debugging-port=9222 "
+    )
+    url = '"https://www.zhipin.com/web/geek/job"'
+    if system == "Darwin":
+        return (
+            'open -na "Google Chrome" --args '
+            + common
+            + '--user-data-dir="$HOME/.boss-chrome-profile" '
+            + url
+        )
+    if system == "Windows":
+        return (
+            "Start-Process chrome.exe -ArgumentList "
+            "'--remote-debugging-address=127.0.0.1',"
+            "'--remote-debugging-port=9222',"
+            '"--user-data-dir=$env:USERPROFILE\\.boss-chrome-profile",'
+            "'https://www.zhipin.com/web/geek/job'"
+        )
+    return (
+        "google-chrome "
+        + common
+        + '--user-data-dir="$HOME/.boss-chrome-profile" '
+        + url
+    )
 
 
 def _cdp_json(path: str):
@@ -55,13 +87,14 @@ class BossChannel(Channel):
         probe = probe_command("boss", ["--version"], timeout=10)
         if probe.status == "missing":
             return "off", (
-                "boss-agent-cli 未安装。安装：pip install boss-agent-cli\n"
-                "（需本地 Chrome 以 --remote-debugging-port=9222 启动并登录 zhipin.com）"
+                "boss-agent-cli 未安装。请先获得用户授权，再运行：\n"
+                "  agent-reach install --system --channels=boss\n"
+                "安装后由用户在专用 Chrome 中手动登录 zhipin.com。"
             )
         if probe.status == "broken":
             return "error", (
                 "boss 命令存在但无法执行——安装已损坏。重装：\n"
-                "  pip install --force-reinstall boss-agent-cli"
+                "  agent-reach install --system --channels=boss"
             )
         if not probe.ok:
             return "warn", f"boss 命令探测失败（{probe.status}），请检查安装"
@@ -70,8 +103,9 @@ class BossChannel(Channel):
         if _cdp_json("/json/version") is None:
             return "off", (
                 "CDP 调试端口不可达。请先启动调试 Chrome：\n"
-                "  Google Chrome --remote-debugging-port=9222 --user-data-dir=~/.boss-chrome-profile\n"
-                "  然后在该窗口登录 zhipin.com"
+                f"  {_chrome_launch_command()}\n"
+                "  然后由用户在该窗口手动登录 zhipin.com。\n"
+                "仅绑定 127.0.0.1；任何能访问 9222 的进程都可完全控制这个 Chrome。"
             )
 
         # 层 3：有无可复用 BOSS 页签
@@ -86,6 +120,6 @@ class BossChannel(Channel):
 
         return "warn", (
             "CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签）。"
-            "Doctor 不实际执行搜索、不验证登录态 liveness；"
+            "Doctor 不实际执行搜索、不验证登录态 liveness 或 PR #382 API；"
             "搜索前先跑 `boss status` 确认 stoken 未过期（code 37 = TOKEN_REFRESH_FAILED）。"
         )

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -121,5 +121,7 @@ class BossChannel(Channel):
         return "warn", (
             "CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签）。"
             "Doctor 不实际执行搜索、不验证登录态 liveness 或 PR #382 API；"
-            "搜索前先跑 `boss status` 确认 stoken 未过期（code 37 = TOKEN_REFRESH_FAILED）。"
+            "先运行 `boss --cdp-url http://localhost:9222 login --cdp` 同步现有登录态；"
+            "搜索时使用 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`，"
+            "确保 CDP 不可用时立即停止而不是降级 headless。"
         )

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -2,15 +2,27 @@
 """Boss直聘 — 经 boss-agent-cli + CDP 真 Chrome 搜岗位、取 JD。
 
 后端是 boss-agent-cli（CDP 调试端口复用已登录的真 Chrome）。headless 是禁区
-（触发 code 36 风控），故 check() 只做三层只读探测，不实例化 BossClient、不拉起浏览器。
+（触发 code 36 风控），故 check() 只做四层只读探测，不实例化 BossClient、不拉起浏览器。
 
 抓取走 boss-agent-cli 公开 API（search_jobs + job_card_browser + browser_mode="cdp_required"），
-调用姿势见 skill/references/career.md；check() 只负责「装没装 + CDP 链路就绪」的体检，不搜索。
+调用姿势见 skill/references/career.md；check() 只负责「装没装 + CDP 链路就绪 +
+浏览器内有无登录 cookie」的体检，不搜索。
+
+双登录态存储（体检必须区分，历史教训）：
+- `boss status` / `status --live` 只校验本地 `~/.boss-agent/auth/session.enc`；
+- CDP 模式搜索走的是专用 Chrome profile 内的浏览器 cookie——两个存储互不代表。
+  所以第 4 层直接问 CDP 浏览器本体（Storage.getCookies），以浏览器为准。
 """
 
+import base64
+import hashlib
 import json
+import os
 import platform
+import socket
+import struct
 import urllib.request
+from urllib.parse import urlparse
 
 from agent_reach.probe import probe_command
 from agent_reach.utils.url import host_matches
@@ -89,6 +101,134 @@ def _security_check_blocks_all(pages) -> bool:
     )
 
 
+_WS_ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = b""
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            break
+        chunks += chunk
+    return chunks
+
+
+def _read_ws_text_frame(sock: socket.socket, initial: bytes = b""):
+    """读下一个文本帧的 payload；收到 close 帧或连接断开返回 None。忽略 ping/pong。"""
+    buf = initial
+    while True:
+        while len(buf) < 2:
+            chunk = sock.recv(4096)
+            if not chunk:
+                return None
+            buf += chunk
+        opcode = buf[0] & 0x0F
+        length = buf[1] & 0x7F
+        header_len = 2
+        if length == 126:
+            while len(buf) < header_len + 2:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    return None
+                buf += chunk
+            length = struct.unpack(">H", buf[header_len:header_len + 2])[0]
+            header_len += 2
+        elif length == 127:
+            while len(buf) < header_len + 8:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    return None
+                buf += chunk
+            length = struct.unpack(">Q", buf[header_len:header_len + 8])[0]
+            header_len += 8
+        while len(buf) < header_len + length:
+            chunk = sock.recv(4096)
+            if not chunk:
+                return None
+            buf += chunk
+        payload = buf[header_len:header_len + length]
+        buf = buf[header_len + length:]
+        if opcode == 0x8:  # close
+            return None
+        if opcode in (0x1, 0x2, 0x0):  # text / binary / continuation
+            return payload
+        # ping(0x9)/pong(0xA) 等：忽略，继续读下一帧
+
+
+def _send_ws_text(sock: socket.socket, text: str) -> None:
+    payload = text.encode("utf-8")
+    mask = os.urandom(4)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    header = bytes([0x81])  # FIN + text
+    n = len(payload)
+    if n < 126:
+        header += bytes([0x80 | n])
+    elif n < 65536:
+        header += bytes([0x80 | 126]) + struct.pack(">H", n)
+    else:
+        header += bytes([0x80 | 127]) + struct.pack(">Q", n)
+    sock.sendall(header + mask + masked)
+
+
+def _cdp_zhipin_login_cookie() -> bool | None:
+    """只读探测专用 Chrome 浏览器内的 zhipin.com 登录 cookie（wt2）。
+
+    True=有；False=没有（浏览器未登录，CDP 搜索会报 AUTH_EXPIRED）；
+    None=探测失败（CDP WebSocket 不可达等），登录态未知。
+    只证明浏览器 profile 登录过，不验证 cookie 的服务端有效性。
+    """
+    version = _cdp_json("/json/version")
+    ws_url = (version or {}).get("webSocketDebuggerUrl")
+    if not ws_url:
+        return None
+    parsed = urlparse(ws_url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 80
+    path = parsed.path or "/"
+    try:
+        with socket.create_connection((host, port), timeout=_CDP_TIMEOUT) as sock:
+            sock.settimeout(_CDP_TIMEOUT)
+            key = base64.b64encode(os.urandom(16)).decode()
+            handshake = (
+                f"GET {path} HTTP/1.1\r\n"
+                f"Host: {host}:{port}\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Key: {key}\r\n"
+                "Sec-WebSocket-Version: 13\r\n"
+                "\r\n"
+            )
+            sock.sendall(handshake.encode())
+            response = b""
+            while b"\r\n\r\n" not in response:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    return None
+                response += chunk
+            head, _, rest = response.partition(b"\r\n\r\n")
+            if b" 101 " not in head.split(b"\r\n", 1)[0]:
+                return None
+            accept = base64.b64encode(
+                hashlib.sha1((key + _WS_ACCEPT_GUID).encode()).digest()
+            ).decode()
+            if accept not in head.decode("latin-1"):
+                return None
+            _send_ws_text(sock, json.dumps({"id": 1, "method": "Storage.getCookies"}))
+            payload = _read_ws_text_frame(sock, initial=rest)
+            if payload is None:
+                return None
+            data = json.loads(payload.decode("utf-8"))
+            if data.get("id") != 1 or "result" not in data:
+                return None
+            for cookie in data["result"].get("cookies", []):
+                if cookie.get("name") == "wt2" and "zhipin" in cookie.get("domain", ""):
+                    return True
+            return False
+    except Exception:
+        return None
+
+
 class BossChannel(Channel):
     name = "boss"
     description = "Boss直聘 职位搜索与 JD"
@@ -135,18 +275,39 @@ class BossChannel(Channel):
                 "CDP 可达但未发现现成 zhipin.com 页签（不代表未登录：Cookie 可能仍在，"
                 "boss-agent-cli 会自行新建页签）。建议先在 Chrome 登录 zhipin.com。"
             )
+
+        # 层 4：浏览器内登录 cookie（wt2）。以浏览器为准——`boss status` 只校验
+        # 本地 session.enc，与浏览器登录态互不代表。
+        browser_cookie = _cdp_zhipin_login_cookie()
+        if browser_cookie is False:
+            return "warn", (
+                "CDP 链路就绪，但专用 Chrome 浏览器内没有 zhipin.com 登录 cookie（wt2）"
+                "——浏览器未登录，搜索会报 AUTH_EXPIRED。注意 `boss status` 报的 logged_in "
+                "只代表本地 session.enc 凭据，不代表浏览器已登录。请让用户在该 Chrome 窗口"
+                "肉眼确认并登录 zhipin.com（拉起 CDP Chrome 后应先做这一步），然后运行 "
+                "`boss --cdp-url http://localhost:9222 login --cdp` 同步登录态。"
+            )
+
+        cookie_note = (
+            "浏览器内有登录 cookie（wt2）" if browser_cookie else "浏览器登录 cookie 探测失败，登录态未知"
+        )
+
         if _security_check_blocks_all(pages):
             return "warn", (
-                "CDP 链路就绪，但现有 zhipin 页签都停在安全校验页"
+                f"CDP 链路就绪，但现有 zhipin 页签都停在安全校验页"
                 "（security-check / zhipin-security）。这是 Boss 反爬挑战，与登录无关"
-                "——已登录也会出现，不代表未登录。先用 `boss status` 判断登录态"
-                "（看 wt2/__zp_stoken__），不要据此要求用户重新登录。"
+                "——已登录也会出现，不代表未登录，不要据此要求用户重新登录，"
+                "让用户手动过滑块即可。"
+                f"浏览器登录态参考：{cookie_note}。"
+                "不要用 `boss status` 判断 CDP 浏览器登录态（它只校验本地 session.enc）。"
             )
 
         return "warn", (
-            "CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签）。"
-            "Doctor 不实际执行搜索、不验证登录态 liveness 或 boss-agent-cli #403-#407 快照 API；"
+            f"CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签，{cookie_note}）。"
+            "Doctor 不实际执行搜索、不验证 cookie 服务端有效性或 boss-agent-cli #403-#407 快照 API；"
             "先运行 `boss --cdp-url http://localhost:9222 login --cdp` 同步现有登录态；"
             "搜索时使用 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`，"
             "确保 CDP 不可用时立即停止而不是降级 headless。"
+            "若搜索报 AUTH_EXPIRED，按登录 runbook 处理（用户在专用窗口登录 + login --cdp），"
+            "不要往安全校验方向解释。"
         )

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -8,10 +8,20 @@
 调用姿势见 skill/references/career.md；check() 只负责「装没装 + CDP 链路就绪 +
 浏览器内有无登录 cookie」的体检，不搜索。
 
-双登录态存储（体检必须区分，历史教训）：
-- `boss status` / `status --live` 只校验本地 `~/.boss-agent/auth/session.enc`；
-- CDP 模式搜索走的是专用 Chrome profile 内的浏览器 cookie——两个存储互不代表。
-  所以第 4 层直接问 CDP 浏览器本体（Storage.getCookies），以浏览器为准。
+双登录态存储（体检必须区分，历史教训）。两者都是必需的，但认证的是不同通道：
+
+- `~/.boss-agent/auth/session.enc`（`boss status` / `status --live` 只校验它）
+  1. 是硬性门槛：`_get_browser()` 无条件 `get_token()`，读不到就 `AuthRequired`，
+     所以别删它——CDP 搜索会在连上浏览器之前就失败；
+  2. 但**不是搜索的认证凭据**：CDP 连上真 Chrome 后复用 `contexts[0]`，其 cookies
+     只在「没有任何 context」的分支才注入，实际从未生效；
+  3. httpx 通道（低危 op：status/detail/cities/`job_card_httpx`）真用它的
+     cookies + stoken；code 37 的 `force_refresh()` 也回写它。
+- 专用 Chrome profile 内的浏览器 cookie：CDP 模式下 search/greet 等高危 op
+  实际携带的凭据。
+
+所以 session.enc 有效 + 浏览器未登录 = `boss status` 报已登录但搜索报
+`AUTH_EXPIRED`。第 4 层直接问 CDP 浏览器本体（Storage.getCookies），以浏览器为准。
 """
 
 import base64

--- a/agent_reach/channels/boss.py
+++ b/agent_reach/channels/boss.py
@@ -145,7 +145,7 @@ class BossChannel(Channel):
 
         return "warn", (
             "CDP 链路就绪（9222 端口通 + 有可复用 zhipin 页签）。"
-            "Doctor 不实际执行搜索、不验证登录态 liveness 或 PR #382 API；"
+            "Doctor 不实际执行搜索、不验证登录态 liveness 或 boss-agent-cli #403-#407 快照 API；"
             "先运行 `boss --cdp-url http://localhost:9222 login --cdp` 同步现有登录态；"
             "搜索时使用 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`，"
             "确保 CDP 不可用时立即停止而不是降级 headless。"

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -19,6 +19,14 @@ from agent_reach import __version__
 
 # Pinned to the 0.4.2 state — PyPI still only has 0.4.1 (upstream issue #10).
 _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66"
+# Temporary, reproducible source while upstream boss-agent-cli PR #382 is pending.
+# Replace this one constant with the first released version containing strict CDP,
+# JobItem.lid, and job_card_browser(). Never point the installer at a moving branch.
+_BOSS_AGENT_CLI_PR_COMMIT = "affcf8485d59812324ff0e076c87f21d4df411ca"
+_BOSS_AGENT_CLI_SOURCE = (
+    "git+https://github.com/iqjiy/boss-agent-cli.git@"
+    + _BOSS_AGENT_CLI_PR_COMMIT
+)
 _MAX_CONFIGURE_VALUE_CHARS = 1024 * 1024
 _SENSITIVE_CONFIG_KEYS = {
     "proxy",
@@ -93,7 +101,7 @@ def main():
     p_install.add_argument("--channels", default="",
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
-                                "reddit,facebook,instagram,bilibili,linkedin,all)")
+                                "reddit,facebook,instagram,bilibili,linkedin,boss,all)")
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -270,6 +278,7 @@ def _cmd_install(args):
         "facebook":    _install_opencli_deps,
         "instagram":   _install_opencli_deps,
         "bilibili":    _install_bili_deps,
+        "boss":        _install_boss_deps,
         "opencli":     _install_opencli_deps,  # cross-channel backend, desktop only
         # xueqiu: cookie-only, no install step
         # linkedin: manual setup, no auto-install
@@ -313,7 +322,7 @@ def _cmd_install(args):
         tools_dir = os.path.expanduser("~/.agent-reach/tools")
         os.makedirs(tools_dir, exist_ok=True)
 
-    OPENCLI_ONLY_CHANNELS = {"opencli", "facebook", "instagram"}
+    DESKTOP_ONLY_CHANNELS = {"opencli", "facebook", "instagram", "boss"}
     COOKIE_CHANNELS = {"twitter", "xueqiu", "bilibili", "xiaohongshu"}
 
     # Auto-detect environment
@@ -326,11 +335,11 @@ def _cmd_install(args):
     else:
         print("Environment: Local computer (auto-detected)")
 
-    server_skipped_opencli_channels = set()
+    server_skipped_desktop_channels = set()
     if env == "server" and requested_channels:
-        # OpenCLI rides a real desktop Chrome session — useless headless
-        server_skipped_opencli_channels = requested_channels & OPENCLI_ONLY_CHANNELS
-        requested_channels -= server_skipped_opencli_channels
+        # Browser-session channels require a real desktop Chrome.
+        server_skipped_desktop_channels = requested_channels & DESKTOP_ONLY_CHANNELS
+        requested_channels -= server_skipped_desktop_channels
 
     # Apply explicit flags
     if args.proxy:
@@ -361,10 +370,10 @@ def _cmd_install(args):
     else:
         core_install_ok = (_install_mcporter() is not False) and core_install_ok
 
-    if server_skipped_opencli_channels:
+    if server_skipped_desktop_channels:
         print()
-        print("  -- OpenCLI 需要桌面环境 + Chrome，服务器环境跳过："
-              f"{', '.join(sorted(server_skipped_opencli_channels))}")
+        print("  -- 以下渠道需要桌面环境 + Chrome，服务器环境跳过："
+              f"{', '.join(sorted(server_skipped_desktop_channels))}")
 
     # ── Install optional channels (only if --channels specified) ──
     if requested_channels and not dry_run and not safe_mode:
@@ -978,6 +987,44 @@ def _install_twitter_deps():
             except (OSError, subprocess.TimeoutExpired):
                 pass
     print("  [!]  twitter-cli install failed. Run: pipx install twitter-cli")
+    return False
+
+
+def _install_boss_deps():
+    """Install the strict-CDP boss-agent-cli build required by the Boss channel.
+
+    PR #382 is not released yet, so the source is pinned to an immutable fork
+    commit. Force-installing is intentional: PyPI 1.18.0 exposes the ``boss``
+    executable but lacks the public strict-CDP APIs required by this channel.
+    """
+    import shutil
+    import subprocess
+
+    print("Setting up Boss直聘 (boss-agent-cli strict CDP, PR #382)...")
+    for tool, args in [
+        ("pipx", ["install", "--force", _BOSS_AGENT_CLI_SOURCE]),
+        ("uv", ["tool", "install", "--force", _BOSS_AGENT_CLI_SOURCE]),
+    ]:
+        tool_cmd = shutil.which(tool)
+        if not tool_cmd:
+            continue
+        try:
+            result = subprocess.run(
+                [tool_cmd, *args],
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=300,
+            )
+            if result.returncode == 0 and shutil.which("boss"):
+                print("  ✅ boss-agent-cli installed from pinned PR #382 commit")
+                print("  下一步：启动专用 Chrome，由用户手动登录 zhipin.com，再运行 agent-reach doctor")
+                return True
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    print("  [!]  boss-agent-cli install failed. Install pipx or uv, then retry:")
+    print(f"       pipx install --force '{_BOSS_AGENT_CLI_SOURCE}'")
     return False
 
 

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -22,7 +22,7 @@ _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c17
 # Temporary, reproducible source while upstream boss-agent-cli PR #382 is pending.
 # Replace this one constant with the first released version containing strict CDP,
 # JobItem.lid, and job_card_browser(). Never point the installer at a moving branch.
-_BOSS_AGENT_CLI_PR_COMMIT = "affcf8485d59812324ff0e076c87f21d4df411ca"
+_BOSS_AGENT_CLI_PR_COMMIT = "ba0f12541079ad794eae4c3bf3fc348befd228c9"
 _BOSS_AGENT_CLI_SOURCE = (
     "git+https://github.com/iqjiy/boss-agent-cli.git@"
     + _BOSS_AGENT_CLI_PR_COMMIT

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -19,10 +19,12 @@ from agent_reach import __version__
 
 # Pinned to the 0.4.2 state — PyPI still only has 0.4.1 (upstream issue #10).
 _RDT_GIT_SOURCE = "git+https://github.com/public-clis/rdt-cli.git@5e4fb3720d5c174e976cd425ccc3b879d52cac66"
-# Temporary, reproducible source while upstream boss-agent-cli PR #382 is pending.
-# Replace this one constant with the first released version containing strict CDP,
-# JobItem.lid, and job_card_browser(). Never point the installer at a moving branch.
-_BOSS_AGENT_CLI_PR_COMMIT = "ba0f12541079ad794eae4c3bf3fc348befd228c9"
+# Temporary, reproducible snapshot while upstream boss-agent-cli PRs #403-#407
+# (the five independent successor PRs of the closed #382) are pending. Points at an
+# immutable merge commit on the fork. Replace this one constant with the first
+# released version containing strict CDP, JobItem.lid, job_card_browser(), and the
+# throttle progress feedback. Never point the installer at a moving branch.
+_BOSS_AGENT_CLI_PR_COMMIT = "8ff6bd3eac5dfc1215500043da9647cd6ea4c73f"
 _BOSS_AGENT_CLI_SOURCE = (
     "git+https://github.com/iqjiy/boss-agent-cli.git@"
     + _BOSS_AGENT_CLI_PR_COMMIT
@@ -993,14 +995,15 @@ def _install_twitter_deps():
 def _install_boss_deps():
     """Install the strict-CDP boss-agent-cli build required by the Boss channel.
 
-    PR #382 is not released yet, so the source is pinned to an immutable fork
-    commit. Force-installing is intentional: PyPI 1.18.0 exposes the ``boss``
-    executable but lacks the public strict-CDP APIs required by this channel.
+    Upstream boss-agent-cli PRs #403-#407 are not released yet, so the source is
+    pinned to an immutable merge snapshot of those five PRs. Force-installing is
+    intentional: PyPI 1.18.0 exposes the ``boss`` executable but lacks the public
+    strict-CDP APIs required by this channel.
     """
     import shutil
     import subprocess
 
-    print("Setting up Boss直聘 (boss-agent-cli strict CDP, PR #382)...")
+    print("Setting up Boss直聘 (boss-agent-cli #403-#407 snapshot)...")
     for tool, args in [
         ("pipx", ["install", "--force", _BOSS_AGENT_CLI_SOURCE]),
         ("uv", ["tool", "install", "--force", _BOSS_AGENT_CLI_SOURCE]),
@@ -1017,7 +1020,7 @@ def _install_boss_deps():
                 timeout=300,
             )
             if result.returncode == 0 and shutil.which("boss"):
-                print("  ✅ boss-agent-cli installed from pinned PR #382 commit")
+                print("  ✅ boss-agent-cli installed from pinned #403-#407 snapshot commit")
                 print("  下一步：启动专用 Chrome，由用户手动登录 zhipin.com，再运行 agent-reach doctor")
                 return True
         except (OSError, subprocess.TimeoutExpired):

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -94,6 +94,10 @@ Boss直聘配置触发：当用户说“帮我配 Boss直聘”时，先读取 `
 只绑定 `127.0.0.1:9222` 的专用 Chrome；必须暂停让用户手动登录、扫码或处理
 滑块，用户确认后再运行 `boss --cdp-url http://localhost:9222 login --cdp`、
 `boss status` 和 `agent-reach doctor` 验收。不要让用户自己研究端口参数。
+专用 Chrome profile 必须长期复用，不要每次创建，也不要默认改用日常主 Chrome。
+执行搜索时必须使用
+`boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`；
+遇到 `ENVIRONMENT_RISK` 立即停止，不刷新、不重新登录、不自动重试。
 
 ```bash
 # Twitter 搜索（twitter-cli 首选；失败重试链见 social.md）

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -7,10 +7,10 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/链接:
   小红书/xiaohongshu/xhs, Twitter/推特/X, B站/bilibili, Reddit, Facebook,
-  Instagram, V2EX, LinkedIn/领英/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
+  Instagram, V2EX, LinkedIn/领英/Boss直聘/招聘/求职/jobs, YouTube, GitHub code search, 小宇宙播客,
   雪球/股票行情, RSS feeds, or any web URL.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -18,21 +18,22 @@ description: >
   发帖/评论/点赞等写操作；已有专门 skill 的平台（先用专门 skill）。
 
   【路由方式】SKILL.md 包含路由表和常用命令，复杂场景需按需阅读对应分类的 references/*.md。
-  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
+  分类：search / social (小红书/推特/B站/V2EX/Reddit/Facebook/Instagram) / career(LinkedIn/Boss直聘) / dev(github) / web(网页/文章/RSS) / video(YouTube/B站/播客) / finance(雪球/股票)。
 metadata:
   homepage: https://github.com/Panniantong/Agent-Reach
 ---
 
 # Agent Reach — 互联网能力路由器
 
-15 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
+16 平台、多后端。**本 skill 存在时必须用它访问这些平台，不要自己发明方案。**
 
 ## 常驻规则（全程适用）
 
-1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram）先跑
+1. **动手前先体检**：多后端/登录态平台（小红书/Reddit/B站/Twitter/Facebook/Instagram/Boss直聘）先跑
    `agent-reach doctor --json`。`active_backend` 有值时按它选命令组；`active_backend: null`
    表示 Doctor 为避免触发浏览器 Cookie 读取或远端写入而没有做实时验证，不代表后端不存在。
-   只有用户任务明确需要该平台时，才按对应 reference 的只读命令手动验证。
+   Doctor 结果是「某一时刻的快照」，通道/登录态可能已变化；执行只读命令前若怀疑失效，
+   按对应 reference 的「体检与恢复」runbook 重新确认（如 career.md 的 Boss直聘 CDP 排查）。
 2. **声明你在用什么**：开始干活前说一句「使用 agent-reach 的 X 平台 / Y 后端」。
 3. **失败按 references 里的重试链处理**，不要瞎猜命令。
 4. **全网调研类任务**：组合多平台（Exa 搜索 + Twitter/Reddit 看讨论 + 小红书/B站看中文场景），并行收集再汇总。
@@ -48,7 +49,7 @@ metadata:
 |---------|------|---------|
 | 网页搜索/代码搜索 | search | [references/search.md](references/search.md) |
 | 小红书/推特/B站/V2EX/Reddit/Facebook/Instagram | social | [references/social.md](references/social.md) |
-| 招聘/职位/LinkedIn | career | [references/career.md](references/career.md) |
+| 招聘/职位/LinkedIn/Boss直聘 | career | [references/career.md](references/career.md) |
 | GitHub/代码 | dev | [references/dev.md](references/dev.md) |
 | 网页/文章/RSS | web | [references/web.md](references/web.md) |
 | YouTube/B站/播客字幕 | video | [references/video.md](references/video.md) |
@@ -107,9 +108,12 @@ opencli instagram user USERNAME -f yaml        # 读指定用户最近帖子
 
 ## 环境检查
 
+> 本机 Python 环境默认是 conda `dl`；若 `agent-reach` 不在 PATH，用
+> `conda run -n dl agent-reach ...` 前缀。
+
 ```bash
 # 检查可用 channel 与每个平台当前激活的后端
-agent-reach doctor --json
+conda run -n dl agent-reach doctor --json
 ```
 
 ## OpenCLI 适配器发现
@@ -128,7 +132,7 @@ agent-reach doctor --json
 
 - [搜索工具](references/search.md) — Exa AI 搜索
 - [社交媒体](references/social.md) — 小红书, Twitter, B站, V2EX, Reddit, Facebook, Instagram（多后端/登录态命令组）
-- [职场招聘](references/career.md) — LinkedIn
+- [职场招聘](references/career.md) — LinkedIn, Boss直聘
 - [开发工具](references/dev.md) — GitHub CLI
 - [网页阅读](references/web.md) — Jina Reader, RSS
 - [视频播客](references/video.md) — YouTube, B站, 小宇宙

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -91,10 +91,16 @@ Cookie-Editor 手工导出后配置 xiaohongshu-mcp / 存量工具。
 Boss直聘配置触发：当用户说“帮我配 Boss直聘”时，先读取 `references/career.md`
 的 Boss 章节，然后在获得安装授权后运行
 `agent-reach install --env=local --system --channels=boss`。Agent 负责按系统启动
-只绑定 `127.0.0.1:9222` 的专用 Chrome；必须暂停让用户手动登录、扫码或处理
-滑块，用户确认后再运行 `boss --cdp-url http://localhost:9222 login --cdp`、
+只绑定 `127.0.0.1:9222` 的专用 Chrome；若 `boss status` 判定未登录，暂停让用户
+登录/扫码，用户确认后再运行 `boss --cdp-url http://localhost:9222 login --cdp`、
 `boss status` 和 `agent-reach doctor` 验收。不要让用户自己研究端口参数。
 专用 Chrome profile 必须长期复用，不要每次创建，也不要默认改用日常主 Chrome。
+
+判断登录态只信 `boss status`（wt2/__zp_stoken__），绝不用当前页 URL：
+`security-check` / `zhipin-security` / `_security_check` 安全校验页是 Boss 反爬挑战，
+与登录无关——已登录也会出现（带 CDP 调试端口的 Chrome 几乎必现）。看到它不要
+当成“未登录”，先跑 `boss status` 验证，再决定是否需要用户登录。
+
 执行搜索时必须使用
 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`；
 遇到 `ENVIRONMENT_RISK` 立即停止，不刷新、不重新登录、不自动重试。

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -88,6 +88,13 @@ Shell。直接运行 `twitter` 前，必须在子进程环境中显式提供
 用户已有且明确控制的 Chrome 会话；没有现成会话时不要自动登录，改用
 Cookie-Editor 手工导出后配置 xiaohongshu-mcp / 存量工具。
 
+Boss直聘配置触发：当用户说“帮我配 Boss直聘”时，先读取 `references/career.md`
+的 Boss 章节，然后在获得安装授权后运行
+`agent-reach install --env=local --system --channels=boss`。Agent 负责按系统启动
+只绑定 `127.0.0.1:9222` 的专用 Chrome；必须暂停让用户手动登录、扫码或处理
+滑块，用户确认后再运行 `boss --cdp-url http://localhost:9222 login --cdp`、
+`boss status` 和 `agent-reach doctor` 验收。不要让用户自己研究端口参数。
+
 ```bash
 # Twitter 搜索（twitter-cli 首选；失败重试链见 social.md）
 twitter search "query" -n 10

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -91,15 +91,20 @@ Cookie-Editor 手工导出后配置 xiaohongshu-mcp / 存量工具。
 Boss直聘配置触发：当用户说“帮我配 Boss直聘”时，先读取 `references/career.md`
 的 Boss 章节，然后在获得安装授权后运行
 `agent-reach install --env=local --system --channels=boss`。Agent 负责按系统启动
-只绑定 `127.0.0.1:9222` 的专用 Chrome；若 `boss status` 判定未登录，暂停让用户
-登录/扫码，用户确认后再运行 `boss --cdp-url http://localhost:9222 login --cdp`、
-`boss status` 和 `agent-reach doctor` 验收。不要让用户自己研究端口参数。
+只绑定 `127.0.0.1:9222` 的专用 Chrome；**拉起后第一步是暂停并让用户肉眼确认**
+窗口内是已登录状态（右上角有头像），未登录则让用户登录/扫码，用户确认后再运行
+`boss --cdp-url http://localhost:9222 login --cdp` 和 `agent-reach doctor` 验收。
+不要让用户自己研究端口参数。
 专用 Chrome profile 必须长期复用，不要每次创建，也不要默认改用日常主 Chrome。
 
-判断登录态只信 `boss status`（wt2/__zp_stoken__），绝不用当前页 URL：
+判断 CDP 浏览器登录态**不要信 `boss status`**（它只校验本地 session.enc，与
+浏览器登录态互不代表），以 `agent-reach doctor` 的浏览器 cookie 探测（wt2）
+为准，并配合用户肉眼确认。绝不用当前页 URL 判断登录态：
 `security-check` / `zhipin-security` / `_security_check` 安全校验页是 Boss 反爬挑战，
 与登录无关——已登录也会出现（带 CDP 调试端口的 Chrome 几乎必现）。看到它不要
-当成“未登录”，先跑 `boss status` 验证，再决定是否需要用户登录。
+当成“未登录”，先跑 `agent-reach doctor` 看浏览器 cookie，再决定是否需要用户登录。
+搜索报 `AUTH_EXPIRED` 即浏览器未登录的 ground truth：直接走登录流程 + `login --cdp`，
+不要往安全校验方向解释。
 
 执行搜索时必须使用
 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`；

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -118,6 +118,13 @@ opencli instagram user USERNAME -f yaml        # recent posts from one user
 agent-reach doctor --json
 ```
 
+When the user asks “help me configure Boss Zhipin” / “帮我配 Boss直聘”, read the
+Boss section in `references/career.md`. After explicit install approval, run
+`agent-reach install --env=local --system --channels=boss`, launch the dedicated
+loopback-only Chrome profile for their OS, and pause for the user to log in
+manually. Then verify with `boss --cdp-url http://localhost:9222 login --cdp`,
+`boss status`, and `agent-reach doctor`. Do not make the user assemble CDP flags.
+
 ## Discovering OpenCLI adapters
 
 When the routing table lacks a needed platform or command, run `opencli list`,

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -124,6 +124,10 @@ Boss section in `references/career.md`. After explicit install approval, run
 loopback-only Chrome profile for their OS, and pause for the user to log in
 manually. Then verify with `boss --cdp-url http://localhost:9222 login --cdp`,
 `boss status`, and `agent-reach doctor`. Do not make the user assemble CDP flags.
+Keep reusing the dedicated Chrome profile; do not recreate it for every run or
+switch to the user's daily profile by default. Search with
+`boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`.
+On `ENVIRONMENT_RISK`, stop without refreshing, relogging, or retrying.
 
 ## Discovering OpenCLI adapters
 

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -7,9 +7,9 @@ description: >
 
   Also MUST USE when user mentions any platform or shares any URL/link:
   Twitter/X, Reddit, Facebook, Instagram, YouTube, GitHub, Bilibili, XiaoHongShu,
-  Xiaoyuzhou Podcast, LinkedIn/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
+  Xiaoyuzhou Podcast, LinkedIn/Boss直聘/jobs/recruiting, V2EX, Xueqiu (stocks), RSS.
 
-  15 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
+  16 platforms, multi-backend routing (OpenCLI / per-platform CLIs / APIs).
   Zero config for 6 channels. Run `agent-reach doctor --json` to see which
   backend serves each platform right now.
 
@@ -22,7 +22,7 @@ metadata:
 
 # Agent Reach — internet capability router
 
-15 platforms, multiple backends each. **When this skill exists, use it for
+16 platforms, multiple backends each. **When this skill exists, use it for
 these platforms — do not invent your own approach.**
 
 ## Standing rules (apply for the whole session)

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -121,13 +121,24 @@ agent-reach doctor --json
 When the user asks “help me configure Boss Zhipin” / “帮我配 Boss直聘”, read the
 Boss section in `references/career.md`. After explicit install approval, run
 `agent-reach install --env=local --system --channels=boss`, launch the dedicated
-loopback-only Chrome profile for their OS, and pause for the user to log in
-manually. Then verify with `boss --cdp-url http://localhost:9222 login --cdp`,
-`boss status`, and `agent-reach doctor`. Do not make the user assemble CDP flags.
+loopback-only Chrome profile for their OS, then **pause and have the user visually
+confirm** the window is logged in (avatar in the top-right); if not, have them log
+in manually. Then verify with `boss --cdp-url http://localhost:9222 login --cdp`
+and `agent-reach doctor`. Do not make the user assemble CDP flags.
 Keep reusing the dedicated Chrome profile; do not recreate it for every run or
 switch to the user's daily profile by default. Search with
 `boss --browser-mode cdp-required --cdp-url http://localhost:9222 search ...`.
 On `ENVIRONMENT_RISK`, stop without refreshing, relogging, or retrying.
+
+**Do not trust `boss status` for CDP browser login state** — it only validates the
+local `~/.boss-agent/auth/session.enc` store, which does not represent the
+dedicated Chrome profile's cookies that `cdp-required` searches actually use. Use
+the browser `wt2` cookie probe in `agent-reach doctor` plus the user's visual
+confirmation. Never judge login state from the page URL: `security-check` /
+`zhipin-security` / `_security_check` pages are anti-bot challenges that appear
+even when logged in. `AUTH_EXPIRED` from a search is the ground truth for a
+logged-out browser — go straight to the login flow + `login --cdp` instead of
+interpreting it as a security check.
 
 ## Discovering OpenCLI adapters
 

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -34,6 +34,13 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 登录和最终验证。不要把 9222 端口等实现细节先甩给用户，也不要替用户输入账号、
 扫码或处理滑块。
 
+> **关键区分：登录门槛 ≠ 反爬安全校验。** zhipin.com 落地后可能停在三种页面：
+> 已登录的 `web/geek/job`、未登录的 `web/user/`（扫码登录/手机号登录）、以及
+> 反爬的**安全校验页**（URL 含 `security-check` / `zhipin-security` /
+> `_security_check`）。安全校验页与登录无关：**已登录也会出现**（带 CDP 调试
+> 端口的 Chrome 几乎必现）。判断登录态只信 `boss status`（wt2/__zp_stoken__），
+> 绝不用当前页 URL。
+
 > **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli PR #382 中，尚未发布。
 > Agent Reach 的临时安装器锁定 fork 提交
 > `ba0f12541079ad794eae4c3bf3fc348befd228c9`，而不是会移动的 branch；上游发布后
@@ -115,11 +122,15 @@ PY
    这个专用 profile 要长期复用，以保留稳定登录态；不要每次运行时删除或新建，
    也不要默认切换到日常主 Chrome。不使用时关闭这个专用窗口。
 
-3. **用户手动登录**：暂停并让用户在这个专用窗口登录、扫码或处理滑块。用户确认
-   完成后，保存 CDP 登录态：
+3. **用户手动登录（仅在 `boss status` 确认未登录时）**：暂停并让用户在这个专用
+   窗口登录或扫码。用户确认完成后，保存 CDP 登录态：
    ```bash
    boss --cdp-url http://localhost:9222 login --cdp
    ```
+
+   若窗口停在安全校验页（`security-check` / `zhipin-security`），这是反爬挑战、
+   不是登录页：等它自动放行或让用户手动过一下滑块即可，不要当成“未登录”去
+   重新扫码登录。
 
 4. **登录态是否有效**（stoken 是否过期）：
    ```bash

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -36,7 +36,7 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 
 > **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli PR #382 中，尚未发布。
 > Agent Reach 的临时安装器锁定 fork 提交
-> `affcf8485d59812324ff0e076c87f21d4df411ca`，而不是会移动的 branch；上游发布后
+> `ba0f12541079ad794eae4c3bf3fc348befd228c9`，而不是会移动的 branch；上游发布后
 > 应把安装器切回正式版本约束。
 
 体检（无副作用，不搜索）：
@@ -51,12 +51,13 @@ agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链
 
 ```bash
 uv run --isolated --no-project \
-  --with 'git+https://github.com/iqjiy/boss-agent-cli.git@affcf8485d59812324ff0e076c87f21d4df411ca' \
+  --with 'git+https://github.com/iqjiy/boss-agent-cli.git@ba0f12541079ad794eae4c3bf3fc348befd228c9' \
   python - <<'PY'
 from pathlib import Path
 
-from boss_agent_cli.api.client import AccountRiskError, BossClient
+from boss_agent_cli.api.client import AccountRiskError, BossClient, EnvironmentRiskError
 from boss_agent_cli.auth.manager import AuthManager
+from boss_agent_cli.platforms.zhipin import BossPlatform
 
 auth = AuthManager(Path.home() / ".boss-agent")
 
@@ -67,6 +68,9 @@ with BossClient(
     browser_mode="cdp_required",
 ) as boss:
     raw = boss.search_jobs("大模型", city="深圳", page=1)
+    if raw.get("code") != 0:
+        code, message = BossPlatform(boss).parse_error(raw)
+        raise RuntimeError(f"{code}: {message}")
     items = raw.get("zpData", {}).get("jobList", [])
     for item in items:
         card = boss.job_card_browser(item["securityId"], item["lid"])
@@ -75,8 +79,8 @@ with BossClient(
         )
         print(item.get("jobName"), post_desc)
 
-# code 36（AccountRiskError）→ 立即停不可重试；code 9（RATE_LIMITED）→ 冷却重试；
-# code 37（TOKEN_REFRESH_FAILED）→ 重新登录
+# AccountRiskError / EnvironmentRiskError → 立即停止，不自动重试；
+# 明确 token/stoken 过期的 code 37 由 BossClient 最多刷新并重试一次。
 PY
 ```
 
@@ -107,8 +111,9 @@ PY
    Start-Process chrome.exe -ArgumentList '--remote-debugging-address=127.0.0.1','--remote-debugging-port=9222',"--user-data-dir=$env:USERPROFILE\.boss-chrome-profile",'https://www.zhipin.com/web/geek/job'
    ```
 
-   只绑定回环地址。任何能访问 9222 的进程都能完全控制该 Chrome；不要监听公网，
-   不使用时关闭这个专用窗口。
+   只绑定回环地址。任何能访问 9222 的进程都能完全控制该 Chrome；不要监听公网。
+   这个专用 profile 要长期复用，以保留稳定登录态；不要每次运行时删除或新建，
+   也不要默认切换到日常主 Chrome。不使用时关闭这个专用窗口。
 
 3. **用户手动登录**：暂停并让用户在这个专用窗口登录、扫码或处理滑块。用户确认
    完成后，保存 CDP 登录态：
@@ -125,4 +130,14 @@ PY
 5. **错误码处置**（搜索/取 JD 时）：
    - code 36（ACCOUNT_RISK）→ 立即停，手动到 BOSS 页面处理，不可自动重试；
    - code 9（RATE_LIMITED）→ 冷却后重试；
-   - code 37（TOKEN_REFRESH_FAILED）→ 重新登录 / 刷新 zhipin 页。
+   - code 37 + `环境存在异常` → `ENVIRONMENT_RISK`，立即停止，不刷新 Token、不重新登录、不自动重试；
+   - 只有文案明确表示 token/stoken 过期的 code 37 才是 `TOKEN_REFRESH_FAILED`；客户端最多自动刷新并重试一次，仍失败再重新登录。
+
+用户要求开始搜索时，Agent 必须指定严格 CDP 模式：
+
+```bash
+boss --browser-mode cdp-required --cdp-url http://localhost:9222 search "大模型" --city 广州 --page 1
+```
+
+不要无提示连续翻页。boss-agent-cli PR #383 为跨 CLI 进程的普通搜索增加持久
+5–10 秒列表预算；该 PR 合并发布前，Agent 仍应主动串行、降频调用。

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -1,6 +1,6 @@
 # 职场招聘
 
-LinkedIn。
+LinkedIn、Boss直聘。
 
 ## LinkedIn
 
@@ -27,3 +27,68 @@ mcporter call linkedin.search_jobs keywords="software engineer" location="Remote
 ```bash
 curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 ```
+
+## Boss直聘
+
+> **状态**：channel 已注册，`agent-reach doctor` 会体检 CDP 链路（boss-agent-cli
+> 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
+
+体检（无副作用，不搜索）：
+
+```bash
+agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链路就绪
+```
+
+搜索 + JD（公开 API，`browser_mode` / `job_card_browser` / `JobItem.lid`）：
+
+```python
+from boss_agent_cli.api.client import AccountRiskError, BossClient
+from boss_agent_cli.auth.manager import AuthManager
+
+# 严格 CDP 模式：跳过 Bridge、CDP 失败立即抛错、永不 headless
+client = BossClient(auth, cdp_url="http://localhost:9222", browser_mode="cdp_required")
+
+# 搜索（公开方法，返回原始 jobList 含 lid/securityId/encryptJobId）
+raw = client.search_jobs("大模型", city="深圳", job_type="实习", page=1)
+items = raw.get("zpData", {}).get("jobList", [])
+
+# 取 JD（公开 job_card_browser，强制 CDP 浏览器通道，绕过 httpx 优先）
+for item in items:
+    card = client.job_card_browser(item["securityId"], item["lid"])
+    post_desc = card.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
+
+# code 36（AccountRiskError）→ 立即停不可重试；code 9（RATE_LIMITED）→ 冷却重试；
+# code 37（TOKEN_REFRESH_FAILED）→ 重新登录
+```
+
+> 上述接口尚未合入上游 boss-agent-cli（见 PR #382），本地开发用 fork 分支即可。
+
+### 环境体检与恢复（抓取前必查）
+
+搜索前若 `agent-reach doctor` 报 boss 为 `off` 或 `warn`，按下面 runbook 排查，不要读源码瞎猜：
+
+1. **CDP 端口通不通**：
+   ```bash
+   curl -s http://localhost:9222/json/version   # 有 Browser 字段 = 端口通
+   ```
+
+2. **调试 Chrome 没开 / 已关**：重启专用 Chrome（登录态独立，不污染日常浏览器）：
+   ```bash
+   Google Chrome --remote-debugging-port=9222 \
+     --user-data-dir=~/.boss-chrome-profile &
+   ```
+
+3. **必须有一个已打开的 zhipin 页签**（否则首次搜索会因导航竞态失败）：
+   ```bash
+   curl -s -X PUT "http://localhost:9222/json/new?https://www.zhipin.com/web/geek/job"
+   ```
+
+4. **登录态是否有效**（stoken 是否过期）：
+   ```bash
+   boss status          # 看 auth 状态与 stoken 新鲜度；过期则 boss login
+   ```
+
+5. **错误码处置**（搜索/取 JD 时）：
+   - code 36（ACCOUNT_RISK）→ 立即停，手动到 BOSS 页面处理，不可自动重试；
+   - code 9（RATE_LIMITED）→ 冷却后重试；
+   - code 37（TOKEN_REFRESH_FAILED）→ 重新登录 / 刷新 zhipin 页。

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -30,8 +30,14 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 
 ## Boss直聘
 
-> **状态**：channel 已注册，`agent-reach doctor` 会体检 CDP 链路（boss-agent-cli
-> 装没装 → 9222 端口通不通 → 有无 zhipin 页签）。
+当用户说“帮我配 Boss直聘”时，按本节完成安装、启动专用 Chrome、等待用户手动
+登录和最终验证。不要把 9222 端口等实现细节先甩给用户，也不要替用户输入账号、
+扫码或处理滑块。
+
+> **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli PR #382 中，尚未发布。
+> Agent Reach 的临时安装器锁定 fork 提交
+> `affcf8485d59812324ff0e076c87f21d4df411ca`，而不是会移动的 branch；上游发布后
+> 应把安装器切回正式版本约束。
 
 体检（无副作用，不搜索）：
 
@@ -39,29 +45,40 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链路就绪
 ```
 
-搜索 + JD（公开 API，`browser_mode` / `job_card_browser` / `JobItem.lid`）：
+搜索 + JD 使用公开 API（`browser_mode` / `job_card_browser` / `JobItem.lid`）。
+因为 pipx/uv tool 是隔离环境，普通 `python` 不一定能 import 已安装工具；临时阶段
+用 `uv run --with` 保证脚本和锁定依赖处于同一解释器环境：
 
-```python
+```bash
+uv run --isolated --no-project \
+  --with 'git+https://github.com/iqjiy/boss-agent-cli.git@affcf8485d59812324ff0e076c87f21d4df411ca' \
+  python - <<'PY'
+from pathlib import Path
+
 from boss_agent_cli.api.client import AccountRiskError, BossClient
 from boss_agent_cli.auth.manager import AuthManager
 
+auth = AuthManager(Path.home() / ".boss-agent")
+
 # 严格 CDP 模式：跳过 Bridge、CDP 失败立即抛错、永不 headless
-client = BossClient(auth, cdp_url="http://localhost:9222", browser_mode="cdp_required")
-
-# 搜索（公开方法，返回原始 jobList 含 lid/securityId/encryptJobId）
-raw = client.search_jobs("大模型", city="深圳", job_type="实习", page=1)
-items = raw.get("zpData", {}).get("jobList", [])
-
-# 取 JD（公开 job_card_browser，强制 CDP 浏览器通道，绕过 httpx 优先）
-for item in items:
-    card = client.job_card_browser(item["securityId"], item["lid"])
-    post_desc = card.get("zpData", {}).get("jobCard", {}).get("postDescription", "")
+with BossClient(
+    auth,
+    cdp_url="http://localhost:9222",
+    browser_mode="cdp_required",
+) as boss:
+    raw = boss.search_jobs("大模型", city="深圳", page=1)
+    items = raw.get("zpData", {}).get("jobList", [])
+    for item in items:
+        card = boss.job_card_browser(item["securityId"], item["lid"])
+        post_desc = card.get("zpData", {}).get("jobCard", {}).get(
+            "postDescription", ""
+        )
+        print(item.get("jobName"), post_desc)
 
 # code 36（AccountRiskError）→ 立即停不可重试；code 9（RATE_LIMITED）→ 冷却重试；
 # code 37（TOKEN_REFRESH_FAILED）→ 重新登录
+PY
 ```
-
-> 上述接口尚未合入上游 boss-agent-cli（见 PR #382），本地开发用 fork 分支即可。
 
 ### 环境体检与恢复（抓取前必查）
 
@@ -72,20 +89,37 @@ for item in items:
    curl -s http://localhost:9222/json/version   # 有 Browser 字段 = 端口通
    ```
 
-2. **调试 Chrome 没开 / 已关**：重启专用 Chrome（登录态独立，不污染日常浏览器）：
+2. **调试 Chrome 没开 / 已关**：按系统启动专用 Chrome（登录态独立，不污染日常浏览器）：
    ```bash
-   Google Chrome --remote-debugging-port=9222 \
-     --user-data-dir=~/.boss-chrome-profile &
+   # macOS
+   open -na "Google Chrome" --args --remote-debugging-address=127.0.0.1 \
+     --remote-debugging-port=9222 --user-data-dir="$HOME/.boss-chrome-profile" \
+     "https://www.zhipin.com/web/geek/job"
+
+   # Linux
+   google-chrome --remote-debugging-address=127.0.0.1 \
+     --remote-debugging-port=9222 --user-data-dir="$HOME/.boss-chrome-profile" \
+     "https://www.zhipin.com/web/geek/job"
    ```
 
-3. **必须有一个已打开的 zhipin 页签**（否则首次搜索会因导航竞态失败）：
+   Windows PowerShell：
+   ```powershell
+   Start-Process chrome.exe -ArgumentList '--remote-debugging-address=127.0.0.1','--remote-debugging-port=9222',"--user-data-dir=$env:USERPROFILE\.boss-chrome-profile",'https://www.zhipin.com/web/geek/job'
+   ```
+
+   只绑定回环地址。任何能访问 9222 的进程都能完全控制该 Chrome；不要监听公网，
+   不使用时关闭这个专用窗口。
+
+3. **用户手动登录**：暂停并让用户在这个专用窗口登录、扫码或处理滑块。用户确认
+   完成后，保存 CDP 登录态：
    ```bash
-   curl -s -X PUT "http://localhost:9222/json/new?https://www.zhipin.com/web/geek/job"
+   boss --cdp-url http://localhost:9222 login --cdp
    ```
 
 4. **登录态是否有效**（stoken 是否过期）：
    ```bash
-   boss status          # 看 auth 状态与 stoken 新鲜度；过期则 boss login
+   boss status
+   agent-reach doctor
    ```
 
 5. **错误码处置**（搜索/取 JD 时）：

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -41,9 +41,10 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 > 端口的 Chrome 几乎必现）。判断登录态只信 `boss status`（wt2/__zp_stoken__），
 > 绝不用当前页 URL。
 
-> **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli PR #382 中，尚未发布。
-> Agent Reach 的临时安装器锁定 fork 提交
-> `ba0f12541079ad794eae4c3bf3fc348befd228c9`，而不是会移动的 branch；上游发布后
+> **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli 后继拆分 PR #403–#407 中
+> （#402/#382 已按维护者意见拆分），尚未发布。Agent Reach 的临时安装器锁定五个 PR
+> 的不可变 merge 快照提交
+> `8ff6bd3eac5dfc1215500043da9647cd6ea4c73f`，而不是会移动的 branch；上游发布后
 > 应把安装器切回正式版本约束。
 
 体检（无副作用，不搜索）：
@@ -58,7 +59,7 @@ agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链
 
 ```bash
 uv run --isolated --no-project \
-  --with 'git+https://github.com/iqjiy/boss-agent-cli.git@ba0f12541079ad794eae4c3bf3fc348befd228c9' \
+  --with 'git+https://github.com/iqjiy/boss-agent-cli.git@8ff6bd3eac5dfc1215500043da9647cd6ea4c73f' \
   python - <<'PY'
 from pathlib import Path
 
@@ -152,3 +153,7 @@ boss --browser-mode cdp-required --cdp-url http://localhost:9222 search "大模�
 
 不要无提示连续翻页。boss-agent-cli PR #383 为跨 CLI 进程的普通搜索增加持久
 5–10 秒列表预算；该 PR 合并发布前，Agent 仍应主动串行、降频调用。
+
+> **等待属预期，不是卡死**：连续搜索命中节流时，boss-agent-cli 会静默等待 5–10 秒
+> （TTY 下会显示「节流等待 Ns…」提示；Agent Reach 以 `--json` 调用，看不到该提示）。
+> 等待窗口内不要重试、不要拉起新浏览器、不要切换 profile。

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -38,8 +38,19 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 > 已登录的 `web/geek/job`、未登录的 `web/user/`（扫码登录/手机号登录）、以及
 > 反爬的**安全校验页**（URL 含 `security-check` / `zhipin-security` /
 > `_security_check`）。安全校验页与登录无关：**已登录也会出现**（带 CDP 调试
-> 端口的 Chrome 几乎必现）。判断登录态只信 `boss status`（wt2/__zp_stoken__），
-> 绝不用当前页 URL。
+> 端口的 Chrome 几乎必现）。绝不用当前页 URL 判断登录态。
+
+> **双登录态存储（cdp-required 模式下以浏览器为准）。** 存在两个互不代表的
+> 凭据存储：本地 `~/.boss-agent/auth/session.enc` 和专用 Chrome profile 内的
+> 浏览器 cookie。**`boss status` / `status --live` 只校验前者**——即使它报
+> `logged_in: true`，也不代表 CDP 浏览器已登录（session.enc 是 Bridge/httpx
+> 时代遗留的凭据库）。CDP 模式搜索走的是浏览器 cookie，所以：
+> 1. 拉起专用 Chrome 后，第一步必须**暂停并让用户肉眼确认**窗口内是已登录
+>    状态（右上角有头像），确认后才允许执行搜索；
+> 2. doctor 的 boss 行会直接探测浏览器内有无 wt2 cookie，以它为准；
+> 3. **`AUTH_EXPIRED` 是 ground truth**：搜索报它就直接走登录 runbook
+>    （用户在专用窗口登录 → `login --cdp`），禁止再往「安全校验」方向解释；
+>    `_security_check` 页面只在 `AUTH_EXPIRED` 不存在时才按滑块处理。
 
 > **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli 后继拆分 PR #403–#407 中
 > （#402/#382 已按维护者意见拆分），尚未发布。Agent Reach 的临时安装器锁定五个 PR
@@ -50,7 +61,8 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 体检（无副作用，不搜索）：
 
 ```bash
-agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链路就绪
+agent-reach doctor          # boss 行：off = 未装或 CDP 不通；warn = 链路就绪，
+                            # message 会注明浏览器内有无 wt2 登录 cookie（以浏览器为准）
 ```
 
 搜索 + JD 使用公开 API（`browser_mode` / `job_card_browser` / `JobItem.lid`）。
@@ -123,8 +135,12 @@ PY
    这个专用 profile 要长期复用，以保留稳定登录态；不要每次运行时删除或新建，
    也不要默认切换到日常主 Chrome。不使用时关闭这个专用窗口。
 
-3. **用户手动登录（仅在 `boss status` 确认未登录时）**：暂停并让用户在这个专用
-   窗口登录或扫码。用户确认完成后，保存 CDP 登录态：
+   **拉起后第一步：暂停并让用户肉眼确认窗口内是已登录状态（右上角有头像）。**
+   不要用 `boss status` 代替这一步——它只校验本地 session.enc，不代表浏览器。
+
+3. **用户手动登录（浏览器未登录时）**：判定以 doctor 的浏览器 cookie 探测为准
+   （无 wt2 = 浏览器未登录），其次才是用户肉眼确认；`boss status` 只作参考。
+   让用户在这个专用窗口登录或扫码。用户确认完成后，保存 CDP 登录态：
    ```bash
    boss --cdp-url http://localhost:9222 login --cdp
    ```
@@ -133,13 +149,16 @@ PY
    不是登录页：等它自动放行或让用户手动过一下滑块即可，不要当成“未登录”去
    重新扫码登录。
 
-4. **登录态是否有效**（stoken 是否过期）：
+4. **登录态是否有效**（浏览器 cookie 探测 + stoken 是否过期）：
    ```bash
-   boss status
-   agent-reach doctor
+   agent-reach doctor     # 看 boss 行 message 里的浏览器 wt2 cookie 探测结果
+   boss status            # 只反映本地 session.enc，仅作参考
    ```
 
 5. **错误码处置**（搜索/取 JD 时）：
+   - `AUTH_EXPIRED`（用户未登录）→ **ground truth**：CDP 浏览器未登录（不管
+     `boss status` 说什么），直接走第 3 步登录流程 + `login --cdp`，禁止往
+     「安全校验」方向解释；
    - code 36（ACCOUNT_RISK）→ 立即停，手动到 BOSS 页面处理，不可自动重试；
    - code 9（RATE_LIMITED）→ 冷却后重试；
    - code 37 + `环境存在异常` → `ENVIRONMENT_RISK`，立即停止，不刷新 Token、不重新登录、不自动重试；

--- a/agent_reach/skill/references/career.md
+++ b/agent_reach/skill/references/career.md
@@ -40,17 +40,23 @@ curl -s "https://r.jina.ai/https://linkedin.com/in/username"
 > `_security_check`）。安全校验页与登录无关：**已登录也会出现**（带 CDP 调试
 > 端口的 Chrome 几乎必现）。绝不用当前页 URL 判断登录态。
 
-> **双登录态存储（cdp-required 模式下以浏览器为准）。** 存在两个互不代表的
-> 凭据存储：本地 `~/.boss-agent/auth/session.enc` 和专用 Chrome profile 内的
-> 浏览器 cookie。**`boss status` / `status --live` 只校验前者**——即使它报
-> `logged_in: true`，也不代表 CDP 浏览器已登录（session.enc 是 Bridge/httpx
-> 时代遗留的凭据库）。CDP 模式搜索走的是浏览器 cookie，所以：
+> **双登录态存储（cdp-required 模式下以浏览器为准）。** 存在两个凭据存储，
+> **都不能删**，但认证的是不同通道：
+>
+> | 存储 | 角色 |
+> |---|---|
+> | `~/.boss-agent/auth/session.enc` | ① 硬性门槛：`_get_browser()` 无条件 `get_token()`，读不到直接 `AuthRequired`，CDP 搜索会在连浏览器前就失败；② **不是**搜索的认证凭据：CDP 复用真 Chrome 的 `contexts[0]` 时，它的 cookies 只在「无 context」分支注入，实际从未生效；③ httpx 通道（低危 op：`status`/`detail`/`cities`/`job_card_httpx`）真用它的 cookies + stoken，code 37 的 `force_refresh()` 也回写它 |
+> | 专用 Chrome profile 内的浏览器 cookie | CDP 模式下 search/greet 等高危 op 实际携带的凭据 |
+>
+> **`boss status` / `status --live` 只校验 session.enc**——即使报
+> `logged_in: true`，也不代表 CDP 浏览器已登录。所以：
 > 1. 拉起专用 Chrome 后，第一步必须**暂停并让用户肉眼确认**窗口内是已登录
 >    状态（右上角有头像），确认后才允许执行搜索；
 > 2. doctor 的 boss 行会直接探测浏览器内有无 wt2 cookie，以它为准；
 > 3. **`AUTH_EXPIRED` 是 ground truth**：搜索报它就直接走登录 runbook
 >    （用户在专用窗口登录 → `login --cdp`），禁止再往「安全校验」方向解释；
 >    `_security_check` 页面只在 `AUTH_EXPIRED` 不存在时才按滑块处理。
+> 4. 不要为了「清理旧凭据」删除 session.enc；要刷新它就跑 `login --cdp`。
 
 > **依赖状态**：所需公开 strict-CDP API 在 boss-agent-cli 后继拆分 PR #403–#407 中
 > （#402/#382 已按维护者意见拆分），尚未发布。Agent Reach 的临时安装器锁定五个 PR

--- a/docs/install.md
+++ b/docs/install.md
@@ -112,6 +112,7 @@ After installing the basics, **ask the user** which additional channels they nee
 > - 📷 **Instagram** — 用户搜索、Profile、用户最近帖子、Explore（桌面走 OpenCLI，复用 Chrome 登录态）
 > - 📺 **B站完整版** — 热门、排行、搜索、视频详情（bili-cli，无需登录）
 > - 💼 **LinkedIn** — Profile、职位搜索
+> - 🎯 **Boss直聘** — 搜索岗位 + JD 全文（本地专用 Chrome；用户手动登录）
 >
 > 告诉我你要哪些，比如"帮我装小红书和 Twitter"、"帮我装 Facebook 和 Instagram"。或者说"全部装"。
 
@@ -120,10 +121,11 @@ Based on the user's choice, run:
 ```bash
 agent-reach install --env=auto --system --channels=opencli,xiaohongshu   # Desktop user chose XHS
 agent-reach install --env=auto --system --channels=facebook,instagram    # Desktop Meta channels
+agent-reach install --env=local --system --channels=boss                # Desktop Boss直聘
 agent-reach install --env=auto --system --channels=all                   # User approved everything
 ```
 
-Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `bilibili`, `linkedin`, `all`
+Supported channel names: `opencli`, `twitter`, `xiaoyuzhou`, `xueqiu`, `xiaohongshu`, `reddit`, `facebook`, `instagram`, `bilibili`, `linkedin`, `boss`, `all`
 
 ### Step 3: Fix what's broken
 
@@ -137,7 +139,7 @@ Only ask the user when you genuinely need their input (credentials, permissions,
 
 Some channels need credentials only the user can provide. Based on the doctor output, ask for what's missing:
 
-> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
+> 🔒 **Security tip:** For platforms that need cookies or browser sessions (Twitter, XiaoHongShu, Reddit, Facebook, Instagram, Boss直聘), we recommend using a **dedicated/secondary account** rather than your main account. Cookie/browser-session auth carries two risks:
 > 1. **Account ban** — platforms may detect non-browser API calls and restrict or ban the account
 > 2. **Credential exposure** — cookies grant full account access; using a secondary account limits the blast radius if credentials are ever compromised
 
@@ -314,6 +316,48 @@ agent-reach configure groq-key
 >
 > 详见 https://github.com/stickerdaniel/linkedin-mcp-server
 
+**Boss直聘（桌面专用 — boss-agent-cli + CDP）:**
+
+当用户说“帮我配 Boss直聘”时，Agent 完成可自动完成的部分，只把网站登录留给用户：
+
+1. 先说明将安装一个上游 CLI、启动独立 Chrome 配置目录，并请求系统安装授权。
+2. 用户同意后运行：
+   ```bash
+   agent-reach install --env=local --system --channels=boss
+   ```
+3. 按操作系统启动只绑定本机回环地址的专用 Chrome：
+   ```bash
+   # macOS
+   open -na "Google Chrome" --args --remote-debugging-address=127.0.0.1 \
+     --remote-debugging-port=9222 --user-data-dir="$HOME/.boss-chrome-profile" \
+     "https://www.zhipin.com/web/geek/job"
+
+   # Linux
+   google-chrome --remote-debugging-address=127.0.0.1 \
+     --remote-debugging-port=9222 --user-data-dir="$HOME/.boss-chrome-profile" \
+     "https://www.zhipin.com/web/geek/job"
+   ```
+   Windows PowerShell：
+   ```powershell
+   Start-Process chrome.exe -ArgumentList '--remote-debugging-address=127.0.0.1','--remote-debugging-port=9222',"--user-data-dir=$env:USERPROFILE\.boss-chrome-profile",'https://www.zhipin.com/web/geek/job'
+   ```
+4. 暂停，让**用户手动登录**、扫码或处理滑块；Agent 不索取账号密码、不代替登录。
+5. 用户确认登录完成后运行：
+   ```bash
+   boss --cdp-url http://localhost:9222 login --cdp
+   boss status
+   agent-reach doctor
+   ```
+
+> 安全边界：任何能访问调试端口 9222 的本机进程都能完全控制这个 Chrome。
+> 必须使用 `--remote-debugging-address=127.0.0.1`，不得暴露到局域网或公网；使用
+> 独立 profile，不使用时关闭专用 Chrome。Boss 不支持服务器/无桌面环境。
+>
+> 临时依赖：boss-agent-cli PR #382 尚未发布，安装器锁定 fork 的不可变提交
+> `affcf8485d59812324ff0e076c87f21d4df411ca`，不跟随会移动的 branch。上游发布后，
+> Agent Reach 应改用包含 `browser_mode="cdp_required"`、`JobItem.lid` 和
+> `job_card_browser()` 的正式版本。
+
 ### Step 4: Final check
 
 Run `agent-reach doctor` one final time and report the results to your user.
@@ -344,6 +388,7 @@ If the user wants a different agent to handle it, let them choose.
 | `agent-reach install --env=auto` | Read-only dependency and channel check (default) |
 | `agent-reach install --env=auto --system` | Explicitly install/configure core external tools |
 | `agent-reach install --env=auto --system --channels=twitter,xiaohongshu` | Install approved optional channels |
+| `agent-reach install --env=local --system --channels=boss` | Install the desktop Boss直聘 strict-CDP backend |
 | `agent-reach install --env=auto --system --channels=all` | Install everything after explicit approval |
 | `agent-reach install --env=auto --safe` | Compatibility alias for the safe default |
 | `agent-reach install --env=auto --dry-run` | Preview what would be done |
@@ -370,6 +415,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | 小红书 | `opencli`（服务器 `mcporter`） | `opencli xiaohongshu search "query" -f yaml` |
 | 小宇宙播客 | `transcribe.sh` | `bash ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh <URL>` |
 | LinkedIn | `mcporter` | `mcporter call linkedin.get_person_profile linkedin_username="..."` |
+| Boss直聘 | `boss` / Python public API | `boss status`；搜索和 JD 见 `references/career.md` |
 | RSS | `feedparser` | `python3 -c "import feedparser; ..."` |
 
 > 多后端平台以 `agent-reach doctor --json` 的 `active_backend` 为准。

--- a/docs/install.md
+++ b/docs/install.md
@@ -351,10 +351,12 @@ agent-reach configure groq-key
 
 > 安全边界：任何能访问调试端口 9222 的本机进程都能完全控制这个 Chrome。
 > 必须使用 `--remote-debugging-address=127.0.0.1`，不得暴露到局域网或公网；使用
-> 独立 profile，不使用时关闭专用 Chrome。Boss 不支持服务器/无桌面环境。
+> 独立 profile 并长期复用，不要每次删除或新建，也不要默认切换到日常主 Chrome；
+> 不使用时关闭专用 Chrome。Boss 不支持服务器/无桌面环境。搜索命令必须带
+> `--browser-mode cdp-required --cdp-url http://localhost:9222`。
 >
 > 临时依赖：boss-agent-cli PR #382 尚未发布，安装器锁定 fork 的不可变提交
-> `affcf8485d59812324ff0e076c87f21d4df411ca`，不跟随会移动的 branch。上游发布后，
+> `ba0f12541079ad794eae4c3bf3fc348befd228c9`，不跟随会移动的 branch。上游发布后，
 > Agent Reach 应改用包含 `browser_mode="cdp_required"`、`JobItem.lid` 和
 > `job_card_browser()` 的正式版本。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -341,12 +341,13 @@ agent-reach configure groq-key
    ```powershell
    Start-Process chrome.exe -ArgumentList '--remote-debugging-address=127.0.0.1','--remote-debugging-port=9222',"--user-data-dir=$env:USERPROFILE\.boss-chrome-profile",'https://www.zhipin.com/web/geek/job'
    ```
-4. 暂停，让**用户手动登录**、扫码或处理滑块；Agent 不索取账号密码、不代替登录。
+4. 暂停，让**用户肉眼确认**窗口内的登录状态（右上角有头像）；未登录则让**用户手动
+   登录**、扫码或处理滑块。Agent 不索取账号密码、不代替登录，也不要用 `boss status`
+   代替这一步——它只校验本地 `session.enc`，不代表这个 Chrome 已登录。
 5. 用户确认登录完成后运行：
    ```bash
    boss --cdp-url http://localhost:9222 login --cdp
-   boss status
-   agent-reach doctor
+   agent-reach doctor    # 看 boss 行 message 里的浏览器 wt2 cookie 探测结果
    ```
 
 > 安全边界：任何能访问调试端口 9222 的本机进程都能完全控制这个 Chrome。
@@ -418,7 +419,7 @@ After installation, use upstream tools directly. See SKILL.md for the full comma
 | 小红书 | `opencli`（服务器 `mcporter`） | `opencli xiaohongshu search "query" -f yaml` |
 | 小宇宙播客 | `transcribe.sh` | `bash ~/.agent-reach/tools/xiaoyuzhou/transcribe.sh <URL>` |
 | LinkedIn | `mcporter` | `mcporter call linkedin.get_person_profile linkedin_username="..."` |
-| Boss直聘 | `boss` / Python public API | `boss status`；搜索和 JD 见 `references/career.md` |
+| Boss直聘 | `boss` / Python public API | `agent-reach doctor`（浏览器 wt2 探测；`boss status` 只反映本地 session.enc）；搜索和 JD 见 `references/career.md` |
 | RSS | `feedparser` | `python3 -c "import feedparser; ..."` |
 
 > 多后端平台以 `agent-reach doctor --json` 的 `active_backend` 为准。

--- a/docs/install.md
+++ b/docs/install.md
@@ -355,8 +355,9 @@ agent-reach configure groq-key
 > 不使用时关闭专用 Chrome。Boss 不支持服务器/无桌面环境。搜索命令必须带
 > `--browser-mode cdp-required --cdp-url http://localhost:9222`。
 >
-> 临时依赖：boss-agent-cli PR #382 尚未发布，安装器锁定 fork 的不可变提交
-> `ba0f12541079ad794eae4c3bf3fc348befd228c9`，不跟随会移动的 branch。上游发布后，
+> 临时依赖：boss-agent-cli 后继拆分 PR #403–#407 尚未发布，安装器锁定五个 PR 的
+> 不可变 merge 快照提交
+> `8ff6bd3eac5dfc1215500043da9647cd6ea4c73f`，不跟随会移动的 branch。上游发布后，
 > Agent Reach 应改用包含 `browser_mode="cdp_required"`、`JobItem.lid` 和
 > `job_card_browser()` 的正式版本。
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,17 +22,20 @@ agent-reach configure --from-browser chrome --platform xueqiu
 但 `boss ... search` 立刻报 `{"code": "AUTH_EXPIRED", "message": "用户未登录"}`。
 专用 Chrome 可能同时停在带 `_security_check` 的 URL 上，看起来像反爬滑块。
 
-**原因：** Boss 有两个**互不代表**的登录态存储：
+**原因：** Boss 有两个登录态存储，认证的是不同通道：
 
 | 存储 | 谁在用 |
 |---|---|
-| `~/.boss-agent/auth/session.enc` | `boss status` / `status --live`（Bridge/httpx 时代遗留） |
-| `~/.boss-chrome-profile` 内的浏览器 cookie | `cdp-required` 模式下的实际搜索请求 |
+| `~/.boss-agent/auth/session.enc` | `boss status` / `status --live`；httpx 通道的低危操作（`detail` / `cities` / `job_card_httpx`）。CDP 搜索也会读它（读不到直接报「未登录」），但复用真 Chrome context 时它的 cookie 从未真正生效 |
+| `~/.boss-chrome-profile` 内的浏览器 cookie | `cdp-required` 模式下 search / greet 等高危操作实际携带的凭据 |
 
 `boss status` 只校验本地 session.enc。本地存着几天前的旧凭据、而专用 Chrome
 profile 本身没登录时，它依然报 `logged_in: true`——这不是登录态有效的证明。
 同时 `_security_check` 页面是反爬挑战，**已登录也会出现**，不能用它判断登录态；
 两者叠加很容易把「浏览器未登录」误判成「卡在滑块」。
+
+> 两个存储都不要删。session.enc 缺失会让 CDP 搜索在连上浏览器之前就失败；
+> 需要刷新它时跑 `login --cdp`，不要手工删文件。
 
 **判定顺序：**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,41 @@ agent-reach configure --from-browser chrome --platform xueqiu
 
 ---
 
+## Boss直聘: `boss status` 说已登录，但搜索报 `AUTH_EXPIRED`
+
+**症状：** `boss status` / `status --live` 返回 `logged_in: true`（甚至带用户名），
+但 `boss ... search` 立刻报 `{"code": "AUTH_EXPIRED", "message": "用户未登录"}`。
+专用 Chrome 可能同时停在带 `_security_check` 的 URL 上，看起来像反爬滑块。
+
+**原因：** Boss 有两个**互不代表**的登录态存储：
+
+| 存储 | 谁在用 |
+|---|---|
+| `~/.boss-agent/auth/session.enc` | `boss status` / `status --live`（Bridge/httpx 时代遗留） |
+| `~/.boss-chrome-profile` 内的浏览器 cookie | `cdp-required` 模式下的实际搜索请求 |
+
+`boss status` 只校验本地 session.enc。本地存着几天前的旧凭据、而专用 Chrome
+profile 本身没登录时，它依然报 `logged_in: true`——这不是登录态有效的证明。
+同时 `_security_check` 页面是反爬挑战，**已登录也会出现**，不能用它判断登录态；
+两者叠加很容易把「浏览器未登录」误判成「卡在滑块」。
+
+**判定顺序：**
+
+1. `AUTH_EXPIRED` 是 ground truth——出现即浏览器未登录，不管 `boss status` 说什么；
+2. `agent-reach doctor` 的 boss 行会直接探测浏览器内有无 `wt2` cookie，以它为准；
+3. `boss status` 仅作参考；页面 URL 完全不作为判据。
+
+**解决方案：** 在专用 Chrome 窗口里肉眼确认并手动登录 zhipin.com，然后同步登录态：
+
+```bash
+boss --cdp-url http://localhost:9222 login --cdp
+agent-reach doctor    # boss 行 message 应显示「浏览器内有登录 cookie（wt2）」
+```
+
+> 拉起专用 Chrome 后的第一步永远是让用户肉眼确认登录状态，不要用 `boss status` 代替。
+
+---
+
 ## Twitter/X: twitter-cli 连接失败
 
 **症状：** `twitter search` 或其他命令返回错误

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Dedicated tests for the ``boss`` channel.
+
+Boss直聘 走 CDP 调试端口复用已登录的真 Chrome（headless 是禁区，code 36 风控）。
+check() 只做三层只读探测：boss-agent-cli 装没装 → CDP 端口通不通 → 有无可复用
+zhipin 页签。四分支各自返回 (status, message)，且永不触发浏览器启动（无副作用）。
+"""
+
+from unittest.mock import patch
+
+from agent_reach.channels import boss as boss_mod
+from agent_reach.channels.boss import BossChannel
+from agent_reach.probe import ProbeResult
+
+
+def _ok_probe():
+    return ProbeResult("ok", output="1.18.0")
+
+
+# --- can_handle ---
+
+def test_can_handle_matches_zhipin_hosts():
+    ch = BossChannel()
+    for url in [
+        "https://www.zhipin.com/job_detail/abc.html",
+        "https://zhipin.com/web/geek/job?query=大模型",
+    ]:
+        assert ch.can_handle(url) is True, url
+    for url in [
+        "https://example.com",
+        "https://zhipin.com.evil.test/job",
+        "",
+        "https://user@zhipin.com/job",
+    ]:
+        assert ch.can_handle(url) is False, url
+
+
+# --- check() 四分支 ---
+
+def test_check_off_when_cli_missing():
+    ch = BossChannel()
+    with patch.object(boss_mod, "probe_command", return_value=ProbeResult("missing")):
+        status, message = ch.check()
+    assert status == "off"
+    assert "boss-agent-cli" in message
+    assert ch.active_backend is None
+
+
+def test_check_error_when_cli_broken():
+    ch = BossChannel()
+    with patch.object(boss_mod, "probe_command", return_value=ProbeResult("broken")):
+        status, message = ch.check()
+    assert status == "error"
+    assert ch.active_backend is None
+
+
+def test_check_off_when_cdp_unreachable():
+    ch = BossChannel()
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", return_value=None
+    ):
+        status, message = ch.check()
+    assert status == "off"
+    assert "9222" in message
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_no_zhipin_page():
+    ch = BossChannel()
+
+    def fake_cdp(path):
+        if path == "/json/version":
+            return {"Browser": "Chrome"}
+        return [{"type": "page", "url": "https://example.com"}]
+
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", side_effect=fake_cdp
+    ):
+        status, message = ch.check()
+    assert status == "warn"
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_ready():
+    ch = BossChannel()
+
+    def fake_cdp(path):
+        if path == "/json/version":
+            return {"Browser": "Chrome"}
+        return [{"type": "page", "url": "https://www.zhipin.com/web/geek/job"}]
+
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", side_effect=fake_cdp
+    ):
+        status, message = ch.check()
+    assert status == "warn"
+    assert ch.active_backend is None
+
+
+def test_check_clears_stale_active_backend():
+    ch = BossChannel()
+    ch.active_backend = "stale"
+    with patch.object(boss_mod, "probe_command", return_value=ProbeResult("missing")):
+        ch.check()
+    assert ch.active_backend is None

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -43,6 +43,7 @@ def test_check_off_when_cli_missing():
         status, message = ch.check()
     assert status == "off"
     assert "boss-agent-cli" in message
+    assert "agent-reach install --system --channels=boss" in message
     assert ch.active_backend is None
 
 
@@ -63,6 +64,21 @@ def test_check_off_when_cdp_unreachable():
     assert status == "off"
     assert "9222" in message
     assert ch.active_backend is None
+
+
+def test_chrome_launch_command_is_portable_and_loopback_only():
+    mac = boss_mod._chrome_launch_command("Darwin")
+    linux = boss_mod._chrome_launch_command("Linux")
+    windows = boss_mod._chrome_launch_command("Windows")
+
+    assert mac.startswith('open -na "Google Chrome" --args ')
+    assert linux.startswith("google-chrome ")
+    assert windows.startswith("Start-Process chrome.exe -ArgumentList ")
+    for command in (mac, linux, windows):
+        assert "--remote-debugging-address=127.0.0.1" in command
+        assert "--remote-debugging-port=9222" in command
+        assert "boss-chrome-profile" in command
+        assert "https://www.zhipin.com/web/geek/job" in command
 
 
 def test_check_warn_when_no_zhipin_page():
@@ -94,6 +110,7 @@ def test_check_warn_when_ready():
     ):
         status, message = ch.check()
     assert status == "warn"
+    assert "PR #382" in message
     assert ch.active_backend is None
 
 

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -2,8 +2,9 @@
 """Dedicated tests for the ``boss`` channel.
 
 Boss直聘 走 CDP 调试端口复用已登录的真 Chrome（headless 是禁区，code 36 风控）。
-check() 只做三层只读探测：boss-agent-cli 装没装 → CDP 端口通不通 → 有无可复用
-zhipin 页签。四分支各自返回 (status, message)，且永不触发浏览器启动（无副作用）。
+check() 只做只读探测：boss-agent-cli 装没装 → CDP 端口通不通 → 有无可复用
+zhipin 页签 → 页签是否都停在反爬安全校验页。各分支各自返回 (status, message)，
+且永不触发浏览器启动（无副作用）。
 """
 
 from unittest.mock import patch
@@ -114,6 +115,30 @@ def test_check_warn_when_ready():
     assert "boss --cdp-url http://localhost:9222 login --cdp" in message
     assert "--browser-mode cdp-required" in message
     assert "code 37 = TOKEN_REFRESH_FAILED" not in message
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_stuck_on_security_check():
+    ch = BossChannel()
+
+    def fake_cdp(path):
+        if path == "/json/version":
+            return {"Browser": "Chrome"}
+        return [
+            {
+                "type": "page",
+                "url": "https://www.zhipin.com/web/common/security-check.html?seed=abc",
+            }
+        ]
+
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", side_effect=fake_cdp
+    ):
+        status, message = ch.check()
+    assert status == "warn"
+    assert "安全校验" in message
+    assert "不代表未登录" in message
+    assert "boss status" in message
     assert ch.active_backend is None
 
 

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -111,6 +111,9 @@ def test_check_warn_when_ready():
         status, message = ch.check()
     assert status == "warn"
     assert "PR #382" in message
+    assert "boss --cdp-url http://localhost:9222 login --cdp" in message
+    assert "--browser-mode cdp-required" in message
+    assert "code 37 = TOKEN_REFRESH_FAILED" not in message
     assert ch.active_backend is None
 
 

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -3,8 +3,11 @@
 
 Boss直聘 走 CDP 调试端口复用已登录的真 Chrome（headless 是禁区，code 36 风控）。
 check() 只做只读探测：boss-agent-cli 装没装 → CDP 端口通不通 → 有无可复用
-zhipin 页签 → 页签是否都停在反爬安全校验页。各分支各自返回 (status, message)，
-且永不触发浏览器启动（无副作用）。
+zhipin 页签 → 浏览器内有无登录 cookie（wt2）→ 页签是否都停在反爬安全校验页。
+各分支各自返回 (status, message)，且永不触发浏览器启动（无副作用）。
+
+注意 `boss status` 只校验本地 session.enc，不代表 CDP 浏览器已登录——第 4 层
+以浏览器本体（Storage.getCookies）为准。
 """
 
 from unittest.mock import patch
@@ -92,7 +95,7 @@ def test_check_warn_when_no_zhipin_page():
 
     with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
         boss_mod, "_cdp_json", side_effect=fake_cdp
-    ):
+    ), patch.object(boss_mod, "_cdp_zhipin_login_cookie", return_value=None):
         status, message = ch.check()
     assert status == "warn"
     assert ch.active_backend is None
@@ -108,13 +111,51 @@ def test_check_warn_when_ready():
 
     with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
         boss_mod, "_cdp_json", side_effect=fake_cdp
-    ):
+    ), patch.object(boss_mod, "_cdp_zhipin_login_cookie", return_value=True):
         status, message = ch.check()
     assert status == "warn"
     assert "boss-agent-cli #403-#407" in message
     assert "boss --cdp-url http://localhost:9222 login --cdp" in message
     assert "--browser-mode cdp-required" in message
     assert "code 37 = TOKEN_REFRESH_FAILED" not in message
+    assert "wt2" in message
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_cookie_probe_fails():
+    ch = BossChannel()
+
+    def fake_cdp(path):
+        if path == "/json/version":
+            return {"Browser": "Chrome"}
+        return [{"type": "page", "url": "https://www.zhipin.com/web/geek/job"}]
+
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", side_effect=fake_cdp
+    ), patch.object(boss_mod, "_cdp_zhipin_login_cookie", return_value=None):
+        status, message = ch.check()
+    assert status == "warn"
+    assert "登录态未知" in message
+    assert ch.active_backend is None
+
+
+def test_check_warn_when_browser_not_logged_in():
+    """浏览器内无 wt2 → 明确提示未登录，且指出 boss status 只代表 session.enc。"""
+    ch = BossChannel()
+
+    def fake_cdp(path):
+        if path == "/json/version":
+            return {"Browser": "Chrome"}
+        return [{"type": "page", "url": "https://www.zhipin.com/web/geek/job"}]
+
+    with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
+        boss_mod, "_cdp_json", side_effect=fake_cdp
+    ), patch.object(boss_mod, "_cdp_zhipin_login_cookie", return_value=False):
+        status, message = ch.check()
+    assert status == "warn"
+    assert "AUTH_EXPIRED" in message
+    assert "session.enc" in message
+    assert "boss --cdp-url http://localhost:9222 login --cdp" in message
     assert ch.active_backend is None
 
 
@@ -133,13 +174,19 @@ def test_check_warn_when_stuck_on_security_check():
 
     with patch.object(boss_mod, "probe_command", return_value=_ok_probe()), patch.object(
         boss_mod, "_cdp_json", side_effect=fake_cdp
-    ):
+    ), patch.object(boss_mod, "_cdp_zhipin_login_cookie", return_value=True):
         status, message = ch.check()
     assert status == "warn"
     assert "安全校验" in message
     assert "不代表未登录" in message
     assert "boss status" in message
+    assert "wt2" in message
     assert ch.active_backend is None
+
+
+def test_cdp_cookie_probe_returns_none_without_ws_url():
+    with patch.object(boss_mod, "_cdp_json", return_value={"Browser": "Chrome"}):
+        assert boss_mod._cdp_zhipin_login_cookie() is None
 
 
 def test_check_clears_stale_active_backend():

--- a/tests/test_boss_channel.py
+++ b/tests/test_boss_channel.py
@@ -111,7 +111,7 @@ def test_check_warn_when_ready():
     ):
         status, message = ch.check()
     assert status == "warn"
-    assert "PR #382" in message
+    assert "boss-agent-cli #403-#407" in message
     assert "boss --cdp-url http://localhost:9222 login --cdp" in message
     assert "--browser-mode cdp-required" in message
     assert "code 37 = TOKEN_REFRESH_FAILED" not in message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,68 @@ class TestCLI:
         assert commands == [["/usr/local/bin/pipx", "install", cli._RDT_GIT_SOURCE]]
         assert "✅ rdt-cli installed" in out
 
+    def test_install_boss_deps_pins_pr_commit_with_pipx(self, monkeypatch, capsys):
+        state = {"boss_installed": False}
+        commands = []
+
+        def fake_which(name):
+            if name == "boss":
+                return "/usr/local/bin/boss" if state["boss_installed"] else None
+            if name == "pipx":
+                return "/usr/local/bin/pipx"
+            return None
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            state["boss_installed"] = True
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert cli._install_boss_deps() is True
+
+        assert commands == [
+            [
+                "/usr/local/bin/pipx",
+                "install",
+                "--force",
+                cli._BOSS_AGENT_CLI_SOURCE,
+            ]
+        ]
+        assert cli._BOSS_AGENT_CLI_PR_COMMIT in cli._BOSS_AGENT_CLI_SOURCE
+        assert "PR #382" in capsys.readouterr().out
+
+    def test_install_boss_deps_falls_back_to_uv(self, monkeypatch):
+        state = {"boss_installed": False}
+        commands = []
+
+        def fake_which(name):
+            if name == "boss":
+                return "/usr/local/bin/boss" if state["boss_installed"] else None
+            if name == "uv":
+                return "/usr/local/bin/uv"
+            return None
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            state["boss_installed"] = True
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(shutil, "which", fake_which)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert cli._install_boss_deps() is True
+        assert commands == [
+            [
+                "/usr/local/bin/uv",
+                "tool",
+                "install",
+                "--force",
+                cli._BOSS_AGENT_CLI_SOURCE,
+            ]
+        ]
+
     def test_install_reddit_deps_routes_by_environment(self, monkeypatch):
         """桌面 → OpenCLI;服务器 → rdt-cli(钉 git 源)。"""
         calls = []
@@ -303,14 +365,14 @@ class TestCLI:
                 system=True,
                 safe=False,
                 dry_run=True,
-                channels="facebook,instagram,opencli,bilibili",
+                channels="facebook,instagram,opencli,boss,bilibili",
             )
         )
 
         out = capsys.readouterr().out
-        assert "服务器环境跳过：facebook, instagram, opencli" in out
+        assert "服务器环境跳过：boss, facebook, instagram, opencli" in out
         assert "[dry-run] Would install optional channels: bilibili" in out
-        assert "facebook, instagram, opencli, bilibili" not in out
+        assert "boss, facebook, instagram, opencli, bilibili" not in out
 
 
 class TestCheckUpdateRetry:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,6 +241,7 @@ class TestCLI:
             ]
         ]
         assert cli._BOSS_AGENT_CLI_PR_COMMIT in cli._BOSS_AGENT_CLI_SOURCE
+        assert cli._BOSS_AGENT_CLI_PR_COMMIT == "ba0f12541079ad794eae4c3bf3fc348befd228c9"
         assert "PR #382" in capsys.readouterr().out
 
     def test_install_boss_deps_falls_back_to_uv(self, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,8 +241,8 @@ class TestCLI:
             ]
         ]
         assert cli._BOSS_AGENT_CLI_PR_COMMIT in cli._BOSS_AGENT_CLI_SOURCE
-        assert cli._BOSS_AGENT_CLI_PR_COMMIT == "ba0f12541079ad794eae4c3bf3fc348befd228c9"
-        assert "PR #382" in capsys.readouterr().out
+        assert cli._BOSS_AGENT_CLI_PR_COMMIT == "8ff6bd3eac5dfc1215500043da9647cd6ea4c73f"
+        assert "boss-agent-cli #403-#407" in capsys.readouterr().out
 
     def test_install_boss_deps_falls_back_to_uv(self, monkeypatch):
         state = {"boss_installed": False}

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -411,6 +411,45 @@ def test_install_rejects_unknown_channel_before_side_effects(
     assert "twiter" in capsys.readouterr().err
 
 
+def test_install_accepts_boss_channel_in_dry_run(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_install_system_deps_dryrun", lambda: None)
+
+    cli._cmd_install(
+        Namespace(
+            env="local",
+            proxy="",
+            system=True,
+            safe=False,
+            dry_run=True,
+            channels="boss",
+        )
+    )
+
+    assert "Would install optional channels: boss" in capsys.readouterr().out
+
+
+def test_install_all_includes_boss_on_desktop(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_install_system_deps_dryrun", lambda: None)
+
+    cli._cmd_install(
+        Namespace(
+            env="local",
+            proxy="",
+            system=True,
+            safe=False,
+            dry_run=True,
+            channels="all",
+        )
+    )
+
+    install_line = next(
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "Would install optional channels:" in line
+    )
+    assert "boss" in install_line
+
+
 @pytest.mark.parametrize("sync_legacy", [False, True])
 def test_manual_twitter_cookie_legacy_copies_are_opt_in(
     monkeypatch, capsys, sync_legacy

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -132,7 +132,11 @@ class TestSkillCommand(unittest.TestCase):
         )
         self.assertIn('browser_mode="cdp_required"', career)
         self.assertIn("job_card_browser", career)
-        self.assertIn("affcf8485d59812324ff0e076c87f21d4df411ca", career)
+        self.assertIn("ba0f12541079ad794eae4c3bf3fc348befd228c9", career)
+        self.assertIn("ENVIRONMENT_RISK", career)
+        self.assertIn("--browser-mode cdp-required", career)
+        self.assertIn("长期复用", career)
+        self.assertNotIn("code 37（TOKEN_REFRESH_FAILED）→ 重新登录", career)
         self.assertNotIn("client = BossClient(auth", career)
 
     def test_localized_readmes_use_current_linkedin_server_name(self):

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -109,6 +109,32 @@ class TestSkillCommand(unittest.TestCase):
         self.assertNotIn("linkedin-scraper.", linkedin_section)
         self.assertNotIn("--transport streamable-http", linkedin_section)
 
+    def test_boss_setup_is_agent_driven_and_reproducible(self):
+        root = Path(__file__).resolve().parents[1]
+        install_doc = (root / "docs" / "install.md").read_text(encoding="utf-8")
+        skill = (root / "agent_reach" / "skill" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        career = (
+            root / "agent_reach" / "skill" / "references" / "career.md"
+        ).read_text(encoding="utf-8")
+        readme = (root / "README.md").read_text(encoding="utf-8")
+
+        for content in (install_doc, skill, readme):
+            self.assertIn("帮我配 Boss直聘", content)
+        self.assertIn("agent-reach install --env=local --system --channels=boss", install_doc)
+        self.assertIn("--remote-debugging-address=127.0.0.1", install_doc)
+        self.assertIn("用户手动登录", install_doc)
+        self.assertIn("完全控制", install_doc)
+
+        self.assertIn(
+            'auth = AuthManager(Path.home() / ".boss-agent")', career
+        )
+        self.assertIn('browser_mode="cdp_required"', career)
+        self.assertIn("job_card_browser", career)
+        self.assertIn("affcf8485d59812324ff0e076c87f21d4df411ca", career)
+        self.assertNotIn("client = BossClient(auth", career)
+
     def test_localized_readmes_use_current_linkedin_server_name(self):
         root = Path(__file__).resolve().parents[1]
         for name in ("README_ja.md", "README_ko.md"):

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -132,7 +132,7 @@ class TestSkillCommand(unittest.TestCase):
         )
         self.assertIn('browser_mode="cdp_required"', career)
         self.assertIn("job_card_browser", career)
-        self.assertIn("ba0f12541079ad794eae4c3bf3fc348befd228c9", career)
+        self.assertIn("8ff6bd3eac5dfc1215500043da9647cd6ea4c73f", career)
         self.assertIn("ENVIRONMENT_RISK", career)
         self.assertIn("--browser-mode cdp-required", career)
         self.assertIn("长期复用", career)


### PR DESCRIPTION
> **Maintainer correction (2026-09-16, post-merge)**: two statements in this description date from the dependency-transition period and no longer match the final code:
> 1. Upstream boss-agent-cli PRs #403–#407 were all merged between 2026-08-31 and 09-11. The installer ultimately pins an immutable commit on the **upstream official repo**, `can4hou6joeng4/boss-agent-cli@4c991b7` — not the fork snapshot `8ff6bd3` described below; the fork-snapshot plan was dropped.
> 2. The strict-CDP flag in the released upstream CLI is `--browser-source existing-browser` (not `--browser-mode cdp-required`); the merged code and docs use the correct form.
>
> The original description below is archived as-is for historical record.

---

## 动机

新增 Boss直聘（zhipin.com）的岗位搜索 + JD 全文能力，并让用户像配置其他平台一样直接告诉 Agent「帮我配 Boss直聘」，无需自己研究 9222/CDP 参数。

## 改动

1. **`boss` channel**
   - `check()` 只读探测 boss-agent-cli、CDP 端口和 zhipin 页签，不搜索、不拉起浏览器。
   - Doctor 提供 macOS / Linux / Windows 的专用 Chrome 恢复命令。
   - 调试端口强制绑定 `127.0.0.1`，并提示 9222 可完全控制浏览器的安全边界。

2. **Agent 驱动的配置流程**
   - 注册 `agent-reach install --env=local --system --channels=boss`，并纳入 `--channels=all`。
   - Boss 为桌面专用 channel，服务器环境自动跳过。
   - Agent 负责安装、启动专用 Chrome、在用户确认登录后运行 `boss --cdp-url http://localhost:9222 login --cdp`，再以 `boss status` 和 `agent-reach doctor` 验收；用户只负责手动登录、扫码或处理滑块。
   - 专用 profile 长期复用，不反复创建，也不默认切换到用户日常主 Chrome。

3. **严格 CDP 抓取**
   - 使用公开 `BossClient(..., browser_mode="cdp_required")`、`search_jobs()`、`job_card_browser()` 和 `JobItem.lid`，不依赖私有接口。
   - 上游 CLI 等价命令：`boss --browser-source existing-browser --cdp-url http://localhost:9222 search ...`。CDP 不可用时立即失败，禁止静默降级 headless。
   - 使用 `uv run --isolated --no-project --with ...` 运行 Python API 示例，避免 tool 隔离环境导致普通 Python 无法 import，也避免在用户工作区创建 `.venv`。

4. **正确处理 code 37**
   - code 37 + `环境存在异常` → `ENVIRONMENT_RISK`，立即停止，不刷新 Token、不重新登录、不自动重试。
   - 只有明确 token/stoken 过期语义才是 `TOKEN_REFRESH_FAILED`；上游最多刷新并重试一次。
   - 文档要求串行、降频翻页。跨 CLI 进程的 5–10 秒持久搜索预算另见 [boss-agent-cli PR #383](https://github.com/can4hou6joeng4/boss-agent-cli/pull/383)，不混入本 PR 的固定依赖。

## 依赖策略（终态）

#382 已按维护者意见关闭，拆分为五个互相独立的 PR：[#403](https://github.com/can4hou6joeng4/boss-agent-cli/pull/403)（code 37 语境分类，Breaking Change）、[#404](https://github.com/can4hou6joeng4/boss-agent-cli/pull/404)（strict-CDP 模式）、[#405](https://github.com/can4hou6joeng4/boss-agent-cli/pull/405)（`JobItem.lid` + `job_card_browser`）、[#406](https://github.com/can4hou6joeng4/boss-agent-cli/pull/406)（复用已登录 CDP 会话 + 首次导航竞态，与 #390 对齐）、[#407](https://github.com/can4hou6joeng4/boss-agent-cli/pull/407)（TTY 节流等待提示）。**五个 PR 已全部合入上游 master。**

因此安装器固定到上游官方仓库的不可变提交（包含全部五个 PR，上游维护者签名提交）：

`can4hou6joeng4/boss-agent-cli@4c991b77086a203173bf08a4cb64a23af6514fe6`

上游发布包含 #403/#404/#406 的正式版本后，把 `_BOSS_AGENT_CLI_SOURCE` 换成版本约束即可。

## 验证

- `599 passed, 16 subtests passed`（合并前维护者本地复测：607 passed）
- `ruff check agent_reach tests`：通过
- `mypy agent_reach`：36 个源文件通过
- `git diff --check`：通过
- 维护者本地端到端实测：专用 Chrome + CDP 真实搜索返回岗位数据；四层体检（未装 CLI / CDP 不可达 / 无登录 cookie / 反爬安全校验页）行为与提示均正确

