### PR TITLE
fix(web): explain reader-side refusals instead of surfacing a bare HTTPError

### DIFF
--- a/agent_reach/channels/web.py
+++ b/agent_reach/channels/web.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Web — any URL via Jina Reader. Always available."""
 
+import urllib.error
 import urllib.request
 
 from agent_reach.utils.url import normalize_public_http_url
@@ -10,6 +11,8 @@ from .base import Channel
 _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 _MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 _ANTIBOT_SCAN_BYTES = 4096
+# Reader-side refusals: the request never reached the target page.
+_READER_REFUSED_CODES = frozenset({401, 403, 429})
 
 
 def _is_antibot_page(body: bytes) -> bool:
@@ -53,8 +56,20 @@ class WebChannel(Channel):
             jina_url,
             headers={"User-Agent": _UA, "Accept": "text/plain"},
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            body = resp.read(_MAX_RESPONSE_BYTES + 1)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read(_MAX_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as e:
+            if e.code not in _READER_REFUSED_CODES:
+                raise
+            # check() 恒报可用（零开销兜底，不探测网络），所以 doctor 的绿灯
+            # 并不保证 r.jina.ai 会受理本机的请求。这里说清楚是「读取器拒绝」
+            # 而不是「目标网页不存在」，否则调用方只能看到一行裸 HTTPError。
+            raise RuntimeError(
+                f"Jina Reader 拒绝了本次请求（HTTP {e.code}），与目标网页无关："
+                "通常是出口 IP 被限流或封禁。doctor 不探测网络，因此 web 渠道"
+                "仍显示为可用。请改用站点专用渠道、其他网页抓取工具或换网络环境。"
+            ) from e
         if len(body) > _MAX_RESPONSE_BYTES:
             raise ValueError(
                 f"Jina Reader response exceeds {_MAX_RESPONSE_BYTES} byte limit"

--- a/tests/test_web_channel.py
+++ b/tests/test_web_channel.py
@@ -8,6 +8,7 @@ URL before handing it to Jina Reader. Follow-up to #331 / #360 / #361,
 completing dedicated coverage for the channels that still lacked it.
 """
 
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -210,6 +211,44 @@ def test_read_does_not_reject_single_generic_antibot_terms(body):
 
     with patch("urllib.request.urlopen", return_value=_resp(body.encode("utf-8"))):
         assert channel.read("https://example.com/article") == body
+
+
+def _http_error(code):
+    return urllib.error.HTTPError(
+        "https://r.jina.ai/https://example.com", code, "refused", {}, None
+    )
+
+
+@pytest.mark.parametrize("code", [401, 403, 429])
+def test_read_explains_a_reader_side_refusal(code):
+    """A 401 from r.jina.ai means the reader refused *us*, not that the page 404'd.
+
+    check() is deliberately zero-overhead and always reports ok, so doctor's
+    green light cannot warn about this. The read path is the only place the
+    caller can learn why nothing came back.
+    """
+    channel = WebChannel()
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(code)):
+        with pytest.raises(RuntimeError, match="Jina Reader") as excinfo:
+            channel.read("https://example.com/article")
+
+    assert str(code) in str(excinfo.value)
+    # The original status must stay reachable for anything logging the chain.
+    assert isinstance(excinfo.value.__cause__, urllib.error.HTTPError)
+    assert excinfo.value.__cause__.code == code
+
+
+@pytest.mark.parametrize("code", [404, 500, 502])
+def test_read_leaves_other_http_errors_untouched(code):
+    """Only reader refusals are reinterpreted; a real 404 stays a 404."""
+    channel = WebChannel()
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(code)):
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            channel.read("https://example.com/missing")
+
+    assert excinfo.value.code == code
 
 
 def test_antibot_detection_has_a_fixed_scan_window():


### PR DESCRIPTION
## Problem

On some networks `r.jina.ai` answers **401** — it declines to serve the caller's egress IP. The request never reaches the target page, but `WebChannel.read()` let the raw `urllib.error.HTTPError` escape, so the caller saw only:

```
HTTP Error 401: Unauthorized
```

That is indistinguishable from a genuinely missing page, and it points the reader at the wrong suspect (the target site) instead of the reader.

`check()` cannot help here: it is deliberately the zero-overhead tier-0 fallback and never probes the network, so `doctor` reports the web channel as available regardless. `read()` is therefore the only place a caller can find out what actually happened.

## Change

- `read()` reinterprets **401 / 403 / 429** as a `RuntimeError` naming the cause (reader-side refusal, usually egress-IP rate limiting or a block), noting that `doctor` still shows the channel as green, and pointing at the alternatives.
- The original `HTTPError` is chained with `raise ... from e`, so the status code stays reachable for anything logging the chain.
- Every other status propagates untouched — a real 404 is still a 404.

No behaviour change on the success path, no new dependency, `check()` still touches no network.

## Tests

`tests/test_web_channel.py` gains two parametrized cases:

- `test_read_explains_a_reader_side_refusal` — 401/403/429 raise `RuntimeError`, the message carries the status code, and `__cause__` is the original `HTTPError`.
- `test_read_leaves_other_http_errors_untouched` — 404/500/502 propagate as `HTTPError`.

```
pytest tests/test_web_channel.py -q  →  47 passed
pytest tests/ -q                     →  560 passed, 28 skipped, 4 failed
```

The 4 failures are pre-existing on `main` in this environment: they are symlink-creation tests that need `SeCreateSymbolicLinkPrivilege` on Windows (`WinError 1314`), and are unrelated to this change.
