### PR TITLE
feat(skill): add explicit project scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements / 改进
 
-- Add an explicit `--scope=project` option for project-local Claude Code skill registration while preserving user scope as the default.
+- Add an explicit `--scope=project` option for project-local Claude Code skill registration and removal, while preserving user scope as the default.
 
 ## [1.3.1] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Improvements / 改进
+
+- Add an explicit `--scope=project` option for project-local Claude Code skill registration while preserving user scope as the default.
+
 ## [1.3.1] - 2026-03-27
 
 ### 🐛 Bug Fixes / 修复

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -234,6 +234,7 @@ def main():
         and args.provider != "auto"
     ):
         p_tr.error("--allow-provider-fallback requires --provider auto")
+
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
 
@@ -490,8 +491,8 @@ def _cmd_install(args):
 def _project_skill_paths() -> "tuple[Path, Path] | None":
     """Resolve the project skill directory and target under the current directory.
 
-    Returns ``None`` when a component of the path is a symlink, so neither
-    install nor uninstall can reach outside the project through one.
+    Returns ``None`` when ``.claude`` or ``.claude/skills`` is a symlink, so a
+    linked directory is never written to or removed on the user's behalf.
     """
     project_skill_dir = Path.cwd()
     for component in _PROJECT_SKILL_COMPONENTS:

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -104,7 +104,7 @@ def main():
         "--scope",
         choices=_SKILL_SCOPES,
         default=_SKILL_SCOPE_USER,
-        help="Skill installation scope: user (default) or current project",
+        help="Skill scope: user (default) or current project",
     )
 
     # ── configure ──
@@ -164,7 +164,7 @@ def main():
         "--scope",
         choices=_SKILL_SCOPES,
         default=_SKILL_SCOPE_USER,
-        help="Skill installation scope: user (default) or current project",
+        help="Skill scope: user (default) or current project",
     )
 
     # ── format ──
@@ -234,13 +234,6 @@ def main():
         and args.provider != "auto"
     ):
         p_tr.error("--allow-provider-fallback requires --provider auto")
-    if (
-        args.command == "skill"
-        and args.uninstall
-        and args.scope != _SKILL_SCOPE_USER
-    ):
-        p_skill.error("--scope is only supported with --install")
-
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
 
@@ -494,6 +487,24 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
+def _project_skill_paths() -> "tuple[Path, Path] | None":
+    """Resolve the project skill directory and target under the current directory.
+
+    Returns ``None`` when a component of the path is a symlink, so neither
+    install nor uninstall can reach outside the project through one.
+    """
+    project_skill_dir = Path.cwd()
+    for component in _PROJECT_SKILL_COMPONENTS:
+        project_skill_dir /= component
+        if project_skill_dir.is_symlink():
+            print(
+                "  Warning: Refusing project skill operation through "
+                f"symlinked directory: {project_skill_dir}"
+            )
+            return None
+    return project_skill_dir, project_skill_dir / _SKILL_DIRECTORY_NAME
+
+
 def _install_skill(
     force: bool = True,
     *,
@@ -574,22 +585,18 @@ def _install_skill(
         raise ValueError(f"unsupported skill scope: {scope}")
 
     if scope == _SKILL_SCOPE_PROJECT:
-        project_root = Path.cwd()
-        project_skill_dir = project_root
-        for component in _PROJECT_SKILL_COMPONENTS:
-            project_skill_dir /= component
-            if project_skill_dir.is_symlink():
-                print(
-                    "  Warning: Refusing project skill installation through "
-                    f"symlinked directory: {project_skill_dir}"
-                )
-                return False
+        resolved = _project_skill_paths()
+        if resolved is None:
+            return False
+        project_skill_dir, project_target = resolved
+        # Announce the absolute destination before the first write, so a
+        # project-scoped install is never silent about where it lands.
+        print(f"Installing skill for current project: {project_target}")
         try:
             project_skill_dir.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             print(f"  Warning: Could not prepare project skill directory: {exc}")
             return False
-        project_target = project_skill_dir / _SKILL_DIRECTORY_NAME
         status = _copy_skill_dir(os.fspath(project_target))
         if status == "preserved":
             print(
@@ -650,9 +657,30 @@ def _install_skill(
     return installed
 
 
-def _uninstall_skill():
-    """Remove SKILL.md from all known agent skill directories."""
+def _uninstall_skill(scope: str = _SKILL_SCOPE_USER):
+    """Remove SKILL.md from the agent skill directories of the given scope."""
     import shutil
+
+    if scope not in _SKILL_SCOPES:
+        raise ValueError(f"unsupported skill scope: {scope}")
+
+    if scope == _SKILL_SCOPE_PROJECT:
+        resolved = _project_skill_paths()
+        if resolved is None:
+            return
+        _, project_target = resolved
+        if not project_target.is_symlink() and not project_target.is_dir():
+            print("  No project skill installation found.")
+            return
+        try:
+            if project_target.is_symlink():
+                project_target.unlink()
+            else:
+                shutil.rmtree(project_target)
+            print(f"  Removed project skill: {project_target}")
+        except OSError as exc:
+            print(f"  Could not remove {project_target}: {exc}")
+        return
 
     skill_dirs = [
         ("~/.config/opencode/skills/agent-reach", "OpenCode"),
@@ -693,7 +721,7 @@ def _cmd_skill(args):
         if not _install_skill(scope=getattr(args, "scope", _SKILL_SCOPE_USER)):
             raise SystemExit(1)
     elif args.uninstall:
-        _uninstall_skill()
+        _uninstall_skill(scope=getattr(args, "scope", _SKILL_SCOPE_USER))
 
 
 def _cmd_format(args):

--- a/agent_reach/cli.py
+++ b/agent_reach/cli.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 
 from agent_reach import __version__
 
@@ -28,6 +29,11 @@ _SENSITIVE_CONFIG_KEYS = {
     "twitter-cookies",
     "xhs-cookies",
 }
+_SKILL_SCOPE_USER = "user"
+_SKILL_SCOPE_PROJECT = "project"
+_SKILL_SCOPES = (_SKILL_SCOPE_USER, _SKILL_SCOPE_PROJECT)
+_PROJECT_SKILL_COMPONENTS = (".claude", "skills")
+_SKILL_DIRECTORY_NAME = "agent-reach"
 
 
 def _ensure_utf8_console():
@@ -94,6 +100,12 @@ def main():
                            help="Comma-separated optional channels to install "
                                 "(twitter,xiaoyuzhou,xueqiu,xiaohongshu,"
                                 "reddit,facebook,instagram,bilibili,linkedin,all)")
+    p_install.add_argument(
+        "--scope",
+        choices=_SKILL_SCOPES,
+        default=_SKILL_SCOPE_USER,
+        help="Skill installation scope: user (default) or current project",
+    )
 
     # ── configure ──
     p_conf = sub.add_parser("configure", help="Set a config value or auto-extract from browser")
@@ -133,7 +145,9 @@ def main():
                           help="Output machine-readable JSON instead of the text report")
 
     # ── uninstall ──
-    p_uninstall = sub.add_parser("uninstall", help="Remove all Agent Reach config, tokens, and skill files")
+    p_uninstall = sub.add_parser(
+        "uninstall", help="Remove user config, tokens, and user-scoped skill files"
+    )
     p_uninstall.add_argument("--dry-run", action="store_true",
                              help="Show what would be removed without making any changes")
     p_uninstall.add_argument("--keep-config", action="store_true",
@@ -146,6 +160,12 @@ def main():
                                help="Install SKILL.md to agent skill directories")
     p_skill_group.add_argument("--uninstall", action="store_true",
                                help="Remove SKILL.md from agent skill directories")
+    p_skill.add_argument(
+        "--scope",
+        choices=_SKILL_SCOPES,
+        default=_SKILL_SCOPE_USER,
+        help="Skill installation scope: user (default) or current project",
+    )
 
     # ── format ──
     p_format = sub.add_parser("format", help="Clean and format platform API output")
@@ -214,6 +234,12 @@ def main():
         and args.provider != "auto"
     ):
         p_tr.error("--allow-provider-fallback requires --provider auto")
+    if (
+        args.command == "skill"
+        and args.uninstall
+        and args.scope != _SKILL_SCOPE_USER
+    ):
+        p_skill.error("--scope is only supported with --install")
 
     # Suppress loguru noise unless --verbose
     _configure_logging(getattr(args, "verbose", False))
@@ -434,7 +460,9 @@ def _cmd_install(args):
             )
         else:
             # ── Install agent skill ──
-            skill_install_ok = _install_skill() is not False
+            skill_install_ok = _install_skill(
+                scope=getattr(args, "scope", _SKILL_SCOPE_USER)
+            ) is not False
             install_ok = (
                 core_install_ok and optional_install_ok and skill_install_ok
             )
@@ -466,7 +494,11 @@ def _cmd_install(args):
         print("Dry run complete. No changes were made.")
 
 
-def _install_skill(force: bool = True):
+def _install_skill(
+    force: bool = True,
+    *,
+    scope: str = _SKILL_SCOPE_USER,
+):
     """Install Agent Reach as an agent skill for supported agent clients."""
     import importlib.resources
     import os
@@ -538,7 +570,40 @@ def _install_skill(force: bool = True):
             print(f"  Warning: Could not install skill: {e}")
             return None
 
-    # Install into every known skill root that already exists.
+    if scope not in _SKILL_SCOPES:
+        raise ValueError(f"unsupported skill scope: {scope}")
+
+    if scope == _SKILL_SCOPE_PROJECT:
+        project_root = Path.cwd()
+        project_skill_dir = project_root
+        for component in _PROJECT_SKILL_COMPONENTS:
+            project_skill_dir /= component
+            if project_skill_dir.is_symlink():
+                print(
+                    "  Warning: Refusing project skill installation through "
+                    f"symlinked directory: {project_skill_dir}"
+                )
+                return False
+        try:
+            project_skill_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            print(f"  Warning: Could not prepare project skill directory: {exc}")
+            return False
+        project_target = project_skill_dir / _SKILL_DIRECTORY_NAME
+        status = _copy_skill_dir(os.fspath(project_target))
+        if status == "preserved":
+            print(
+                "Skill already installed, preserving existing files: "
+                f"{project_target}"
+            )
+            return True
+        if status == "installed":
+            print(f"Skill installed for current project: {project_target}")
+            return True
+        print("  -- Could not install agent skill for current project")
+        return False
+
+    # Install into every known user skill root that already exists.
     skill_dirs = [
         (os.path.expanduser("~/.agents/skills"), "Agent"),
         (os.path.expanduser("~/.config/opencode/skills"), "OpenCode"),
@@ -625,7 +690,7 @@ def _uninstall_skill():
 def _cmd_skill(args):
     """Manage agent skill registration."""
     if args.install:
-        if not _install_skill():
+        if not _install_skill(scope=getattr(args, "scope", _SKILL_SCOPE_USER)):
             raise SystemExit(1)
     elif args.uninstall:
         _uninstall_skill()

--- a/agent_reach/skill/SKILL.md
+++ b/agent_reach/skill/SKILL.md
@@ -122,6 +122,8 @@ agent-reach doctor --json
 
 **不要在 agent workspace 创建文件。** 使用 `/tmp/` 存放临时输出，`~/.agent-reach/` 存放持久数据。
 
+唯一例外：用户显式传入 `--scope=project` 时，skill 注册可写入 `<项目>/.claude/skills/agent-reach/`。
+
 ## 详细文档
 
 根据用户需求，阅读对应的详细文档：

--- a/agent_reach/skill/SKILL_en.md
+++ b/agent_reach/skill/SKILL_en.md
@@ -130,6 +130,9 @@ only when the user's task requires that platform, and require non-empty content.
 **Never create files in the agent workspace.** Use `/tmp/` for temporary
 output and `~/.agent-reach/` for persistent data.
 
+The one exception is skill registration under `<project>/.claude/skills/agent-reach/`,
+and only when the user explicitly passes `--scope=project`.
+
 ## Detailed references
 
 Read the matching file when you need specifics (commands above cover the

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,21 +30,28 @@ When fixing issues, stay within these limits:
 - **DO NOT** modify system files outside `~/.agent-reach/`
 - **DO NOT** install packages not listed in this guide
 - **DO NOT** disable firewalls, security settings, or system protections
-- **DO NOT** clone repos, create files, or run commands inside the agent workspace / working directory
+- **DO NOT** clone repos or create unrelated files inside the agent workspace /
+  working directory. The only supported workspace write is project-local skill
+  registration when the user explicitly selects `--scope=project`.
 - If something requires elevated permissions, **tell the user** what's needed and let them decide
 
 ### 📁 Directory Rules
 
-All Agent Reach files go in dedicated directories — **never in the agent workspace**:
+Agent Reach files go in dedicated directories. Project-local skill registration
+is the only workspace exception and must be selected explicitly:
 
 | Purpose | Directory | Example |
 |---------|-----------|---------|
 | Config & tokens | `~/.agent-reach/` | `~/.agent-reach/config.json` |
 | Upstream tool repos | `~/.agent-reach/tools/` | `~/.agent-reach/tools/xiaoyuzhou/` |
 | Temporary files | `/tmp/` | `/tmp/yt-dlp-output/` |
-| Skills | `~/.openclaw/skills/agent-reach/` | SKILL.md |
+| User-scoped skills | `~/.openclaw/skills/agent-reach/` | SKILL.md |
+| Project-scoped Claude Code skill | `<project>/.claude/skills/agent-reach/` | SKILL.md |
 
-**Why?** If you clone repos or create files in the workspace, it pollutes the user's project directory and can break their agent over time. Keep the workspace clean.
+**Why?** Unrelated workspace files pollute the user's project and can break the
+agent over time. The explicit project scope is limited to Claude Code's
+standard `.claude/skills/` directory and is rejected when `.claude` or its
+`skills` directory is a symlink.
 
 ### Step 1: Install the basics
 
@@ -92,6 +99,15 @@ agent-reach install --env=auto             # Check only; safe default
 agent-reach install --env=auto --safe      # Same check-only behavior (compatibility)
 agent-reach install --env=auto --system    # Explicitly allow external/system installs
 agent-reach install --env=auto --dry-run   # Preview what --system would do
+```
+
+Skill registration remains user-scoped by default. To limit the Claude Code
+skill to the current project, choose the scope explicitly:
+
+```bash
+agent-reach install --env=auto --system --scope=project
+# Or register only the project-local skill:
+agent-reach skill --install --scope=project
 ```
 
 ### Step 2: Ask the user which optional channels they want

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,28 +30,25 @@ When fixing issues, stay within these limits:
 - **DO NOT** modify system files outside `~/.agent-reach/`
 - **DO NOT** install packages not listed in this guide
 - **DO NOT** disable firewalls, security settings, or system protections
-- **DO NOT** clone repos or create unrelated files inside the agent workspace /
-  working directory. The only supported workspace write is project-local skill
-  registration when the user explicitly selects `--scope=project`.
+- **DO NOT** clone repos, create files, or run commands inside the agent workspace / working directory
+  - Sole exception: project-local skill registration, and only when the user explicitly passes `--scope=project`
 - If something requires elevated permissions, **tell the user** what's needed and let them decide
 
 ### 📁 Directory Rules
 
-Agent Reach files go in dedicated directories. Project-local skill registration
-is the only workspace exception and must be selected explicitly:
+All Agent Reach files go in dedicated directories — **never in the agent workspace**:
 
 | Purpose | Directory | Example |
 |---------|-----------|---------|
 | Config & tokens | `~/.agent-reach/` | `~/.agent-reach/config.json` |
 | Upstream tool repos | `~/.agent-reach/tools/` | `~/.agent-reach/tools/xiaoyuzhou/` |
 | Temporary files | `/tmp/` | `/tmp/yt-dlp-output/` |
-| User-scoped skills | `~/.openclaw/skills/agent-reach/` | SKILL.md |
-| Project-scoped Claude Code skill | `<project>/.claude/skills/agent-reach/` | SKILL.md |
+| Skills | `~/.openclaw/skills/agent-reach/` | SKILL.md |
+| Skills, project scope (opt-in) | `<project>/.claude/skills/agent-reach/` | SKILL.md |
 
-**Why?** Unrelated workspace files pollute the user's project and can break the
-agent over time. The explicit project scope is limited to Claude Code's
-standard `.claude/skills/` directory and is rejected when `.claude` or its
-`skills` directory is a symlink.
+**Why?** If you clone repos or create files in the workspace, it pollutes the user's project directory and can break their agent over time. Keep the workspace clean.
+
+`--scope=project` is the one opt-in exception. It writes only Claude Code's standard `.claude/skills/agent-reach/` directory in the current working directory, and refuses to run when `.claude` or `.claude/skills` is a symlink.
 
 ### Step 1: Install the basics
 
@@ -108,7 +105,13 @@ skill to the current project, choose the scope explicitly:
 agent-reach install --env=auto --system --scope=project
 # Or register only the project-local skill:
 agent-reach skill --install --scope=project
+# And to remove it again:
+agent-reach skill --uninstall --scope=project
 ```
+
+`agent-reach uninstall` stays user-scoped: it never touches the working
+directory. Removing a project-scoped skill is always an explicit,
+project-scoped command.
 
 ### Step 2: Ask the user which optional channels they want
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -22,6 +22,8 @@ Update Agent Reach: https://raw.githubusercontent.com/Panniantong/agent-reach/ma
 
 **Never create files, clone repos, or run commands in the agent workspace.** Use `/tmp/` for temporary work and `~/.agent-reach/` for persistent data.
 
+The one exception is skill registration under `<project>/.claude/skills/agent-reach/`, and only when the user explicitly passes `--scope=project`.
+
 ### Goal
 
 Update Agent Reach to the latest version, refresh upstream tools, migrate from retired backends, and verify everything works. The user should not need to do anything manually (except things only a human can do, like clicking a browser-extension install button).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,7 +263,7 @@ class TestCLI:
         monkeypatch.setattr(cli, "_install_system_deps", lambda: None)
         monkeypatch.setattr(cli, "_install_mcporter", lambda: None)
         monkeypatch.setattr(cli, "_install_opencli_deps", lambda: calls.append("opencli"))
-        monkeypatch.setattr(cli, "_install_skill", lambda: None)
+        monkeypatch.setattr(cli, "_install_skill", lambda **_kwargs: None)
         monkeypatch.setattr(
             "agent_reach.doctor.check_all",
             lambda config: {

--- a/tests/test_p0_cli.py
+++ b/tests/test_p0_cli.py
@@ -315,7 +315,7 @@ def test_install_does_not_implicitly_read_browser_cookies(monkeypatch, tmp_path,
     monkeypatch.setattr(cli, "_install_system_deps", lambda: None)
     monkeypatch.setattr(cli, "_install_mcporter", lambda: None)
     monkeypatch.setattr(cli, "_install_twitter_deps", lambda: None)
-    monkeypatch.setattr(cli, "_install_skill", lambda: None)
+    monkeypatch.setattr(cli, "_install_skill", lambda **_kwargs: None)
     monkeypatch.setattr(
         "agent_reach.doctor.check_all",
         lambda _config: {},

--- a/tests/test_private_file_writes.py
+++ b/tests/test_private_file_writes.py
@@ -534,7 +534,7 @@ def test_install_system_flag_explicitly_enables_writes(
     monkeypatch.setattr(
         cli,
         "_install_skill",
-        lambda: calls.append("skill"),
+        lambda **_kwargs: calls.append("skill"),
     )
     monkeypatch.setattr("agent_reach.doctor.check_all", lambda _config: {})
     monkeypatch.setattr(
@@ -561,7 +561,7 @@ def test_install_system_exits_nonzero_when_core_steps_fail(
     monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
     monkeypatch.setattr(cli, "_install_system_deps", lambda: False)
     monkeypatch.setattr(cli, "_install_mcporter", lambda: False)
-    monkeypatch.setattr(cli, "_install_skill", lambda: None)
+    monkeypatch.setattr(cli, "_install_skill", lambda **_kwargs: None)
     monkeypatch.setattr("agent_reach.doctor.check_all", lambda _config: {})
     monkeypatch.setattr(
         "agent_reach.doctor.format_report",
@@ -589,7 +589,7 @@ def test_install_system_exits_nonzero_when_requested_channel_fails(
     monkeypatch.setattr(cli, "_install_system_deps", lambda: True)
     monkeypatch.setattr(cli, "_install_mcporter", lambda: True)
     monkeypatch.setattr(cli, "_install_opencli_deps", lambda: False)
-    monkeypatch.setattr(cli, "_install_skill", lambda: True)
+    monkeypatch.setattr(cli, "_install_skill", lambda **_kwargs: True)
     monkeypatch.setattr("agent_reach.doctor.check_all", lambda _config: {})
     monkeypatch.setattr(
         "agent_reach.doctor.format_report",
@@ -621,7 +621,7 @@ def test_install_system_exits_nonzero_when_skill_install_fails(
     monkeypatch.setattr(cli, "_configure_logging", lambda _verbose=False: None)
     monkeypatch.setattr(cli, "_install_system_deps", lambda: True)
     monkeypatch.setattr(cli, "_install_mcporter", lambda: True)
-    monkeypatch.setattr(cli, "_install_skill", lambda: False)
+    monkeypatch.setattr(cli, "_install_skill", lambda **_kwargs: False)
     monkeypatch.setattr("agent_reach.doctor.check_all", lambda _config: {})
     monkeypatch.setattr(
         "agent_reach.doctor.format_report",

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -169,6 +169,112 @@ class TestSkillCommand(unittest.TestCase):
             self.assertFalse(installed)
             self.assertFalse((external / "skills").exists())
 
+    def test_project_scope_announces_target_before_writing(self):
+        """The resolved absolute target is printed before anything is created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+            target = project / ".claude" / "skills" / "agent-reach"
+            printed_before_mkdir = []
+            original_mkdir = Path.mkdir
+
+            def record_then_mkdir(path, *args, **kwargs):
+                printed_before_mkdir.append(list(printed))
+                return original_mkdir(path, *args, **kwargs)
+
+            printed = []
+            with patch("pathlib.Path.cwd", return_value=project), patch.object(
+                Path, "mkdir", autospec=True, side_effect=record_then_mkdir
+            ), patch("builtins.print", side_effect=lambda *a, **k: printed.append(" ".join(str(x) for x in a))):
+                installed = _install_skill(scope="project")
+
+            self.assertTrue(installed)
+            self.assertTrue(printed_before_mkdir, "mkdir was never called")
+            self.assertTrue(
+                any(str(target) in line for line in printed_before_mkdir[0]),
+                f"target not announced before first write: {printed_before_mkdir[0]}",
+            )
+
+    def test_project_scope_uninstall_removes_only_project_skill(self):
+        """Project uninstall removes what project install created, nothing else."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+            target = project / ".claude" / "skills" / "agent-reach"
+            user_skill = Path(tmpdir) / ".claude" / "skills" / "agent-reach"
+            user_skill.mkdir(parents=True)
+            (user_skill / "SKILL.md").write_text("user", encoding="utf-8")
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                self.assertTrue(_install_skill(scope="project"))
+                self.assertTrue((target / "SKILL.md").is_file())
+
+                with patch(
+                    "agent_reach.cli.os.path.expanduser",
+                    side_effect=lambda path: path.replace("~", tmpdir),
+                ), patch.dict(os.environ, {}, clear=True):
+                    _uninstall_skill(scope="project")
+
+            self.assertFalse(target.exists())
+            self.assertTrue((user_skill / "SKILL.md").is_file())
+
+    def test_project_scope_uninstall_reports_when_nothing_installed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                _uninstall_skill(scope="project")
+
+            self.assertFalse((project / ".claude").exists())
+
+    def test_project_scope_uninstall_rejects_symlinked_skill_parent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            external = Path(tmpdir) / "external"
+            project.mkdir()
+            (external / "skills" / "agent-reach").mkdir(parents=True)
+            (external / "skills" / "agent-reach" / "SKILL.md").write_text(
+                "outside", encoding="utf-8"
+            )
+            (project / ".claude").symlink_to(external, target_is_directory=True)
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                _uninstall_skill(scope="project")
+
+            self.assertTrue((external / "skills" / "agent-reach" / "SKILL.md").is_file())
+
+    def test_skill_cli_accepts_project_scope_uninstall(self):
+        """`skill --uninstall --scope=project` is a supported combination."""
+        with patch.object(
+            sys, "argv", ["agent-reach", "skill", "--uninstall", "--scope=project"]
+        ), patch("agent_reach.cli._uninstall_skill") as uninstall:
+            cli.main()
+
+        uninstall.assert_called_once_with(scope="project")
+
+    def test_skill_command_forwards_uninstall_scope(self):
+        with patch("agent_reach.cli._uninstall_skill") as uninstall:
+            _cmd_skill(Namespace(install=False, uninstall=True, scope="project"))
+
+        uninstall.assert_called_once_with(scope="project")
+
+    def test_top_level_uninstall_stays_user_scoped(self):
+        """`agent-reach uninstall` must never touch the working directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            target = project / ".claude" / "skills" / "agent-reach"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("project", encoding="utf-8")
+
+            with patch("pathlib.Path.cwd", return_value=project), patch(
+                "agent_reach.cli.os.path.expanduser",
+                side_effect=lambda path: path.replace("~", tmpdir),
+            ), patch.dict(os.environ, {}, clear=True):
+                _uninstall_skill()
+
+            self.assertTrue((target / "SKILL.md").is_file())
+
     def test_project_scope_reports_expected_directory_creation_failure(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             project = Path(tmpdir) / "project"
@@ -236,19 +342,6 @@ class TestSkillCommand(unittest.TestCase):
             cli.main()
 
         self.assertEqual(command.call_args.args[0].scope, "project")
-
-    def test_skill_cli_rejects_project_scope_for_uninstall(self):
-        with patch.object(
-            sys,
-            "argv",
-            ["agent-reach", "skill", "--uninstall", "--scope", "project"],
-        ), patch("agent_reach.cli._cmd_skill") as command, self.assertRaises(
-            SystemExit
-        ) as raised:
-            cli.main()
-
-        self.assertEqual(raised.exception.code, 2)
-        command.assert_not_called()
 
     def test_system_install_forwards_project_scope(self):
         args = Namespace(

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -4,12 +4,14 @@
 import importlib.resources
 import os
 import re
+import sys
 import tempfile
 import unittest
 from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
+import agent_reach.cli as cli
 from agent_reach.cli import _cmd_skill, _install_skill, _uninstall_skill
 
 
@@ -122,6 +124,173 @@ class TestSkillCommand(unittest.TestCase):
                 _cmd_skill(Namespace(install=True, uninstall=False))
 
         self.assertEqual(raised.exception.code, 1)
+
+    def test_project_scope_installs_only_in_current_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+
+            with patch("pathlib.Path.cwd", return_value=project), patch(
+                "agent_reach.cli.os.path.expanduser",
+                side_effect=lambda path: path.replace("~", tmpdir),
+            ), patch.dict(os.environ, {}, clear=True):
+                installed = _install_skill(scope="project")
+
+            self.assertTrue(installed)
+            self.assertTrue(
+                (project / ".claude" / "skills" / "agent-reach" / "SKILL.md").is_file()
+            )
+            self.assertFalse((Path(tmpdir) / ".agents" / "skills" / "agent-reach").exists())
+
+    def test_project_scope_preserves_existing_skill_when_not_forced(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            skill = project / ".claude" / "skills" / "agent-reach" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("custom", encoding="utf-8")
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                installed = _install_skill(force=False, scope="project")
+
+            self.assertTrue(installed)
+            self.assertEqual(skill.read_text(encoding="utf-8"), "custom")
+
+    def test_project_scope_rejects_symlinked_skill_parent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            external = Path(tmpdir) / "external"
+            project.mkdir()
+            external.mkdir()
+            (project / ".claude").symlink_to(external, target_is_directory=True)
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                installed = _install_skill(scope="project")
+
+            self.assertFalse(installed)
+            self.assertFalse((external / "skills").exists())
+
+    def test_project_scope_reports_expected_directory_creation_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+            skill_root = project / ".claude" / "skills"
+            original_mkdir = Path.mkdir
+            attempted_paths = []
+
+            def fail_for_skill_root(path, *args, **kwargs):
+                attempted_paths.append(path)
+                if path == skill_root:
+                    raise OSError("read only")
+                return original_mkdir(path, *args, **kwargs)
+
+            with patch("pathlib.Path.cwd", return_value=project), patch.object(
+                Path, "mkdir", autospec=True, side_effect=fail_for_skill_root
+            ):
+                installed = _install_skill(scope="project")
+
+            self.assertFalse(installed)
+            self.assertIn(skill_root, attempted_paths)
+            self.assertFalse(skill_root.exists())
+
+    def test_project_scope_reports_expected_destination_copy_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            project.mkdir()
+            target = project / ".claude" / "skills" / "agent-reach"
+            original_makedirs = os.makedirs
+            attempted_paths = []
+
+            def fail_for_target(path, *args, **kwargs):
+                attempted_paths.append(Path(path))
+                if Path(path) == target:
+                    raise OSError("read only")
+                return original_makedirs(path, *args, **kwargs)
+
+            with patch("pathlib.Path.cwd", return_value=project), patch(
+                "agent_reach.cli.os.makedirs", side_effect=fail_for_target
+            ):
+                installed = _install_skill(scope="project")
+
+            self.assertFalse(installed)
+            self.assertIn(target, attempted_paths)
+            self.assertFalse(target.exists())
+
+    def test_install_skill_rejects_unknown_scope(self):
+        with self.assertRaisesRegex(ValueError, "unsupported skill scope"):
+            _install_skill(scope="automatic")
+
+    def test_skill_command_forwards_explicit_scope(self):
+        with patch("agent_reach.cli._install_skill", return_value=True) as install:
+            _cmd_skill(Namespace(install=True, uninstall=False, scope="project"))
+
+        install.assert_called_once_with(scope="project")
+
+    def test_skill_cli_accepts_project_scope(self):
+        with patch.object(
+            sys,
+            "argv",
+            ["agent-reach", "skill", "--install", "--scope", "project"],
+        ), patch("agent_reach.cli._configure_logging"), patch(
+            "agent_reach.cli._cmd_skill"
+        ) as command:
+            cli.main()
+
+        self.assertEqual(command.call_args.args[0].scope, "project")
+
+    def test_skill_cli_rejects_project_scope_for_uninstall(self):
+        with patch.object(
+            sys,
+            "argv",
+            ["agent-reach", "skill", "--uninstall", "--scope", "project"],
+        ), patch("agent_reach.cli._cmd_skill") as command, self.assertRaises(
+            SystemExit
+        ) as raised:
+            cli.main()
+
+        self.assertEqual(raised.exception.code, 2)
+        command.assert_not_called()
+
+    def test_system_install_forwards_project_scope(self):
+        args = Namespace(
+            env="local",
+            proxy="",
+            system=True,
+            safe=False,
+            dry_run=False,
+            channels="",
+            scope="project",
+        )
+        with patch("agent_reach.config.Config"), patch(
+            "agent_reach.doctor.check_all", return_value={}
+        ), patch("agent_reach.doctor.format_report", return_value="report"), patch(
+            "agent_reach.cli._install_system_deps", return_value=True
+        ), patch("agent_reach.cli._install_mcporter", return_value=True), patch(
+            "agent_reach.cli._install_skill", return_value=True
+        ) as install:
+            cli._cmd_install(args)
+
+        install.assert_called_once_with(scope="project")
+
+    def test_system_install_keeps_default_user_scope_call_compatible(self):
+        args = Namespace(
+            env="local",
+            proxy="",
+            system=True,
+            safe=False,
+            dry_run=False,
+            channels="",
+            scope="user",
+        )
+        with patch("agent_reach.config.Config"), patch(
+            "agent_reach.doctor.check_all", return_value={}
+        ), patch("agent_reach.doctor.format_report", return_value="report"), patch(
+            "agent_reach.cli._install_system_deps", return_value=True
+        ), patch("agent_reach.cli._install_mcporter", return_value=True), patch(
+            "agent_reach.cli._install_skill", return_value=True
+        ) as install:
+            cli._cmd_install(args)
+
+        install.assert_called_once_with(scope="user")
 
     def test_install_skill_creates_skill_md(self):
         """_install_skill should create SKILL.md in the first available skill dir."""

--- a/tests/test_skill_command.py
+++ b/tests/test_skill_command.py
@@ -223,10 +223,60 @@ class TestSkillCommand(unittest.TestCase):
             project = Path(tmpdir) / "project"
             project.mkdir()
 
-            with patch("pathlib.Path.cwd", return_value=project):
+            printed = []
+            with patch("pathlib.Path.cwd", return_value=project), patch(
+                "builtins.print",
+                side_effect=lambda *a, **k: printed.append(" ".join(str(x) for x in a)),
+            ):
                 _uninstall_skill(scope="project")
 
             self.assertFalse((project / ".claude").exists())
+            self.assertTrue(
+                any("No project skill installation found." in x for x in printed), printed
+            )
+
+    def test_uninstall_skill_rejects_unknown_scope(self):
+        with self.assertRaises(ValueError):
+            _uninstall_skill(scope="workspace")
+
+    def test_project_scope_uninstall_unlinks_symlinked_target(self):
+        """A symlinked skill dir is unlinked, never followed into its victim."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            victim = Path(tmpdir) / "victim"
+            victim.mkdir()
+            (victim / "SKILL.md").write_text("outside", encoding="utf-8")
+            target = project / ".claude" / "skills" / "agent-reach"
+            target.parent.mkdir(parents=True)
+            target.symlink_to(victim, target_is_directory=True)
+
+            with patch("pathlib.Path.cwd", return_value=project):
+                _uninstall_skill(scope="project")
+
+            self.assertFalse(target.is_symlink())
+            self.assertTrue((victim / "SKILL.md").is_file())
+
+    def test_project_scope_uninstall_reports_removal_failure(self):
+        """A failing removal is reported, not raised at the caller."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "project"
+            target = project / ".claude" / "skills" / "agent-reach"
+            target.mkdir(parents=True)
+            (target / "SKILL.md").write_text("project", encoding="utf-8")
+            printed = []
+
+            with patch("pathlib.Path.cwd", return_value=project), patch(
+                "shutil.rmtree", side_effect=OSError("read only")
+            ), patch(
+                "builtins.print",
+                side_effect=lambda *a, **k: printed.append(" ".join(str(x) for x in a)),
+            ):
+                _uninstall_skill(scope="project")
+
+            self.assertTrue((target / "SKILL.md").is_file())
+            self.assertTrue(
+                any("read only" in line for line in printed), printed
+            )
 
     def test_project_scope_uninstall_rejects_symlinked_skill_parent(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## 摘要 / Summary

根据维护者关闭 #390 时提出的方向，本 PR 实现了显式的 `scope` 参数：`--scope=user|project`。默认值仍为 `user`，不进行隐式推断。

Adds an explicit `--scope=user|project` parameter for skill registration. `user`
remains the default, and nothing is inferred from the working directory.

Addresses #333.

## Design rationale

Issue #333 asked for project-local skill installation, and listed an explicit
`--scope` flag as one of its two options. #390 (@StevanusPangau) explored the
feature and identified the same target path, but derived the scope from the
working directory; it was closed in favour of designing an explicit scope
parameter. This PR implements that project-local target with an explicit flag
rather than inference, on the current installer.

Keeping `user` as the default is deliberate: an implicit write into the working
directory would contradict the workspace-isolation rules in `docs/install.md`
and the read-only-by-default install introduced in #577.

On `agent-reach install`, project scope is already covered by the `--system`
gate from #577 — `install --scope=project` without `--system` writes nothing.
Only `agent-reach skill --install` / `--uninstall` is ungated, and it is ungated
today for user scope too, so this PR did not add a second authorization flag
there. Instead the resolved absolute destination is printed before the first
write, so a project-scoped install is never silent about where it lands. Happy
to put the `skill` subcommand behind `--system` as well if you prefer.

## Changes

- `--scope=user|project` on `agent-reach install` and
  `agent-reach skill --install` / `--uninstall`, defaulting to `user`
- project scope resolves `<cwd>/.claude/skills/agent-reach` through one helper
  shared by install and uninstall, which refuses to proceed when `.claude` or
  `.claude/skills` is a symlink
- the resolved absolute destination is printed before the first write
- `skill --uninstall --scope=project` removes that directory, so a
  project-scoped install can be undone by the CLI that created it;
  `agent-reach uninstall` stays user-scoped and never touches the working
  directory
- the workspace-policy wording in `docs/install.md` is kept byte-identical and
  the exception added as a separate line; `agent_reach/skill/SKILL.md`,
  `SKILL_en.md` and `docs/update.md` state the same rule and are updated in the
  same PR, so the agent-facing instructions do not tell an agent to refuse a
  supported flag
- `CHANGELOG.md` entry under `## [Unreleased]` — happy to drop or re-target it
  if you keep the changelog on a different cadence

Documentation diffs are additions only: `docs/install.md` +19/-0,
`docs/update.md` +2/-0, `SKILL.md` +2/-0, `SKILL_en.md` +3/-0.

## Test verification (RED → GREEN)

`tests/test_skill_command.py` from this branch applied to `upstream/main` with
no production changes (RED):

```text
FAILED test_install_skill_rejects_unknown_scope
FAILED test_project_scope_announces_target_before_writing
FAILED test_project_scope_installs_only_in_current_project
FAILED test_project_scope_preserves_existing_skill_when_not_forced
FAILED test_project_scope_rejects_symlinked_skill_parent
FAILED test_project_scope_reports_expected_destination_copy_failure
FAILED test_project_scope_reports_expected_directory_creation_failure
FAILED test_project_scope_uninstall_rejects_symlinked_skill_parent
FAILED test_project_scope_uninstall_removes_only_project_skill
FAILED test_project_scope_uninstall_reports_removal_failure
FAILED test_project_scope_uninstall_reports_when_nothing_installed
FAILED test_project_scope_uninstall_unlinks_symlinked_target
FAILED test_skill_cli_accepts_project_scope
FAILED test_skill_cli_accepts_project_scope_uninstall
FAILED test_skill_command_forwards_explicit_scope
FAILED test_skill_command_forwards_uninstall_scope
FAILED test_system_install_forwards_project_scope
FAILED test_system_install_keeps_default_user_scope_call_compatible
FAILED test_uninstall_skill_rejects_unknown_scope
19 failed, 12 passed, 16 subtests passed
```

Patched branch (GREEN):

```text
606 passed, 16 subtests passed
```

`upstream/main` baseline is 586 passed, measured in a clean worktree; this PR
adds 20 tests and removes none.

Each project-uninstall branch was mutation-checked rather than only covered —
breaking the scope guard, the symlinked-target unlink, the removal-failure
report or the not-found message each fails a test:

```text
mutate: drop uninstall scope guard        1 failed, 30 passed
mutate: follow symlinked target           1 failed, 30 passed
mutate: swallow removal error             1 failed, 30 passed
mutate: drop not-found message            1 failed, 30 passed
```

## Verification

- `ruff check agent_reach tests` — All checks passed
- `mypy agent_reach` — Success: no issues found in 35 source files
- `pytest -q` — 606 passed
